### PR TITLE
Adding Sonnet 3.5 v1 vs v2 output token limit comparison notebook

### DIFF
--- a/notebooks/claude_35_output_limit_comparison/claude_35_output_limit_comparison.ipynb
+++ b/notebooks/claude_35_output_limit_comparison/claude_35_output_limit_comparison.ipynb
@@ -1,0 +1,447 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Claude 3.5 Sonnet Output Length Comparison\n",
+    "\n",
+    "This notebook demonstrates the difference in output token limits between:\n",
+    "- Claude 3.5 Sonnet v1 (4k output tokens)\n",
+    "- Claude 3.5 Sonnet v2 (8k output tokens)\n",
+    "\n",
+    "We'll use Amazon Bedrock to test both models with the same prompt designed to generate a long response."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import boto3\n",
+    "import logging\n",
+    "from botocore.config import Config\n",
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd\n",
+    "\n",
+    "# Configure logging\n",
+    "logging.basicConfig(level=logging.INFO)\n",
+    "logger = logging.getLogger()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup Amazon Bedrock Client\n",
+    "\n",
+    "Configure the Bedrock runtime client with a long timeout to handle lengthy responses."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:botocore.credentials:Found credentials in shared credentials file: ~/.aws/credentials\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Set up the Bedrock client with extended timeout\n",
+    "config = Config(read_timeout=1000)\n",
+    "client = boto3.client('bedrock-runtime', config=config)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define Models for Testing\n",
+    "\n",
+    "We'll test both versions of Claude 3.5 Sonnet to compare their output length capabilities."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define model IDs for both versions\n",
+    "models = {\n",
+    "    \"Claude 3.5 Sonnet v1\": \"us.anthropic.claude-3-5-sonnet-20240620-v1:0\",  # 4k output token limit\n",
+    "    \"Claude 3.5 Sonnet v2\": \"us.anthropic.claude-3-5-sonnet-20241022-v2:0\"   # 8k output token limit\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create Test Prompt\n",
+    "\n",
+    "We'll use a prompt that encourages the model to generate a lengthy response that will likely exceed the token limits."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a prompt that will generate a long response\n",
+    "input_text = \"\"\"While writing unit tests in Jest for TypeScript code, I want to check the values of variables in a function while running the test. How to modify the functions? Give 20 detailed examples, each with a different example function and the corresponding test. Ensure all 20 examples are highly detailed. Provide all examples in one response. If you run out of tokens, it's not a problem. Do not be concerned about length limitations; I need all 20 detailed examples in a single response.\"\"\"\n",
+    "\n",
+    "# Setup system prompts and messages\n",
+    "system_prompts = [{\"text\": \"You are an AI assistant helping with writing unit tests in Jest for TypeScript code.\"}]\n",
+    "message = {\n",
+    "    \"role\": \"user\",\n",
+    "    \"content\": [{\"text\": input_text}]\n",
+    "}\n",
+    "messages = [message]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define Function for Making API Calls"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def generate_conversation(bedrock_client, model_id, system_prompts, messages, max_tokens=None):\n",
+    "    \"\"\"Generate a conversation with the specified model and parameters.\"\"\"\n",
+    "    logger.info(f\"Generating message with model {model_id}\")\n",
+    "    \n",
+    "    # Set parameters\n",
+    "    temperature = 0.5\n",
+    "    top_k = 200\n",
+    "    \n",
+    "    # If max_tokens is not specified, use the appropriate limit based on the model\n",
+    "    if max_tokens is None:\n",
+    "        if \"v1\" in model_id:\n",
+    "            max_tokens = 4096  # v1 has 4k output token limit\n",
+    "        else:\n",
+    "            max_tokens = 8192  # v2 has 8k output token limit\n",
+    "    \n",
+    "    # Configure the API call\n",
+    "    inference_config = {\"temperature\": temperature, \"maxTokens\": max_tokens}\n",
+    "    additional_model_fields = {\"top_k\": top_k}\n",
+    "    \n",
+    "    # Make the API call\n",
+    "    response = bedrock_client.converse(\n",
+    "        modelId=model_id,\n",
+    "        messages=messages,\n",
+    "        system=system_prompts,\n",
+    "        inferenceConfig=inference_config,\n",
+    "        additionalModelRequestFields=additional_model_fields\n",
+    "    )\n",
+    "    \n",
+    "    # Log usage information\n",
+    "    token_usage = response['usage']\n",
+    "    logger.info(f\"Input tokens: {token_usage['inputTokens']}\")\n",
+    "    logger.info(f\"Output tokens: {token_usage['outputTokens']}\")\n",
+    "    logger.info(f\"Total tokens: {token_usage['totalTokens']}\")\n",
+    "    logger.info(f\"Stop reason: {response['stopReason']}\")\n",
+    "    \n",
+    "    return response"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Test Models and Compare Results\n",
+    "\n",
+    "Let's run the test on both models and capture the results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:root:Generating message with model us.anthropic.claude-3-5-sonnet-20240620-v1:0\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "Testing Claude 3.5 Sonnet v1...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:root:Input tokens: 128\n",
+      "INFO:root:Output tokens: 4096\n",
+      "INFO:root:Total tokens: 4224\n",
+      "INFO:root:Stop reason: max_tokens\n",
+      "INFO:root:Generating message with model us.anthropic.claude-3-5-sonnet-20241022-v2:0\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Input tokens: 128\n",
+      "Output tokens: 4096\n",
+      "Stop reason: max_tokens\n",
+      "\n",
+      "\n",
+      "Testing Claude 3.5 Sonnet v2...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:root:Input tokens: 128\n",
+      "INFO:root:Output tokens: 6270\n",
+      "INFO:root:Total tokens: 6398\n",
+      "INFO:root:Stop reason: end_turn\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Input tokens: 128\n",
+      "Output tokens: 6270\n",
+      "Stop reason: end_turn\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Dictionary to store results\n",
+    "results = {}\n",
+    "\n",
+    "# Run test for each model\n",
+    "for model_name, model_id in models.items():\n",
+    "    print(f\"\\n\\nTesting {model_name}...\")\n",
+    "    try:\n",
+    "        response = generate_conversation(client, model_id, system_prompts, messages)\n",
+    "        \n",
+    "        # Store results\n",
+    "        results[model_name] = {\n",
+    "            \"output_tokens\": response['usage']['outputTokens'],\n",
+    "            \"input_tokens\": response['usage']['inputTokens'],\n",
+    "            \"stop_reason\": response['stopReason'],\n",
+    "            \"response_text\": response['output']['message']['content'][0]['text'][0:500] + \"...\" # Show just first 500 chars\n",
+    "        }\n",
+    "        \n",
+    "        # Display result summary\n",
+    "        print(f\"Input tokens: {response['usage']['inputTokens']}\")\n",
+    "        print(f\"Output tokens: {response['usage']['outputTokens']}\")\n",
+    "        print(f\"Stop reason: {response['stopReason']}\")\n",
+    "        \n",
+    "    except Exception as e:\n",
+    "        print(f\"Error testing {model_name}: {str(e)}\")\n",
+    "        results[model_name] = {\"error\": str(e)}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualize the Results\n",
+    "\n",
+    "Now let's create a visual comparison of the output token limits."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA90AAAJOCAYAAACqS2TfAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAACL00lEQVR4nO3dB5gTVdfA8bO79N6bVKX3poAgXVAQQRClIyAKAgpIEUUQFFFAET9BLAj6IkpRlCIgUhVQlCICUqVK732B3XzPuTghySbLlsxudvP/PU82m5mbyZ3JZGbO3BbicDgcAgAAAAAA/C7U/4sEAAAAAACKoBsAAAAAAJsQdAMAAAAAYBOCbgAAAAAAbELQDQAAAACATQi6AQAAAACwCUE3AAAAAAA2IegGAAAAAMAmBN0AAAAAANiEoBsIMkuXLpUuXbpI8eLFJVOmTJI6dWrJmzevPPjggzJ+/Hg5efKkW/pp06ZJSEiIPPXUUxLIEjKf27dvl759+0rt2rWlYMGCki5dOkmbNq0ULVpUunXrJn/99Vesl7l//36T/+geL730Upzyu3HjRunatavJn+ZT81uoUCGpWbOmDBgwwOwTiPu+0KdPHylTpoxkzpzZbN/ChQtLu3btZNGiRYmdvYAWk33e2yO2v/HXXnvNvE+fkxrruKb7VExZ2ykhv8PY5C+2HA6HzJkzR9q2bStFihSR9OnTS5o0aaRAgQLyyCOPyMcffywXL1607fOTo5UrV5rvrW7duomdFSBopEjsDABIGKdOnTIXLT/99JN5rRdJ9erVMxcwx44dk7Vr15p5w4YNM8/VqlVL7CwHLN1WEyZMkNy5c0uJEiWkRo0acuXKFRNsf/bZZ/LFF1+Yh27v2NLv4/HHH/c6r0qVKrFe3v/93/+ZGwSRkZFy1113me88a9as5uaKBuO6LnoBpjddgoUGMnrjqXPnzub/uAYCr776qrz11lsSEREh+fLlM9tWb2L9/fff8tVXX5lHkyZNzLPe4PIX/e0eOHBA9u3bZ2uwY3eeMmTIYL4DT3v27JE1a9b4/C3UqlXLL3mGvfyxn/7zzz9mH9i0aZN5XapUKWnUqJH5nf3777/mhuHChQvllVdekT/++MPcTASAQETQDQSB8+fPmwvVnTt3SsmSJU3JwAMPPOCWJjw8XD7//HMZPny4HD16NNHymhQ0bNjQBFa6LV1pYPvuu+/KwIED5emnn5aHHnrIBLixkSNHjjgHgp62bNniDLi1FoOWyIaFhbnl95dffjEPxE7//v3lvffeMyVun3zyiSl9dS1d/PXXX6VDhw7yww8/mCBh9erVkipVqkTNc6Dxta/rNA26/flbCCZ6bEooeiNPPy9lypR+X/bBgwfNDc0TJ06Y58mTJ0v58uXd0mgJ94cffiijRo2Ss2fPEnTH0H333We+N631BCBhUL0cCAIabGnAraUNejHrGXArLTl45plnZPPmzaY0Ab7pdvQMuFVoaKiprn333Xebku/EDmZnz55tAmu9YNXg2zXgtvKrVeRffvnlRMtjUqSlaxpwq6+//tqUmntW561evbqsWLHC3HT57bff5PXXX0+k3CLY6LHJ2/HJDhps62fdc889fl+23rTSgFsDxOXLl0cJuFXGjBll0KBBsmHDBlPzCDGjwbZ+b9o8CkDCIOgGkjmtnjdjxgzzv5bCZsuWLdr0VpXpmPj2229NiW7ZsmVNcKGlftrmTtsPa5DvjbYh0wBFqzTHtv3lzZs3TbBTrlw581k5c+aUVq1axagN9a5du+TZZ581F4f6Xm1/qwHn9OnTxd9SpEjhvJGRmI4fP26ec+XKFaf3Hz582NywKVasmHObaTvwjz76yFSpjq5d/eXLl2XIkCGmHbluhzx58piqxFolNLr2hTdu3JC3337btJHW9tHZs2eXli1bRlt6pyVcWkOjYsWK5iJcLyh1H3njjTfMzQ/PGyYaJCut2eHaVjim7RvffPNN89ysWTNp3ry5z3Ta5lSroKv333/frd1pTNpUerbNtbavVtlV+ltzzb/1m3Jdtq6/3lTR70G/Q60Gr/0O3Ol78Hee/GnHjh3mO9RSTd239JjWoEEDmTVrVqyXpVWStU8LvSH1zjvvxOuY4Xps05uXut9qab3msXTp0mb52izBbr7adOu+r9O1Hbb2N6D51XXSY7e2jXY9juo5Q2/W6e8pS5YsZl327t0bozbd/tgnVq1aJT///LP5X0u4dftHR/dv/R49zxf63vvvv9+spy5Dj2XPP/+81/3fc9vp96wBvzaD0HONNhfS0nel3+MHH3xgjjnaDEK/Zz3u6U2C6I6Lp0+fll69eplgV/cL3Yf79etnjmH+OsdatW70c7du3SpPPvmkcx+3zqvR/db1Boa+J3/+/KZ2jjaN0RvJeq79/vvvvX6m3nzU36D+Fq310jzqb8gb131Rb05qbSBdPz3mV65c2TTPApIdB4BkbcKECXqV58iSJYvj5s2bsX7/1KlTzfs7d+4cZV5YWJgjXbp0jqpVqzpatmzpePTRRx133323SZ8+fXrHmjVrorynTp06Zv6KFSu8ft7w4cPNfH12FRER4WjRooWZlypVKkejRo0cTz75pKNw4cKONGnSOJ577jmf+Zw1a5ZJo/NLlizpeOyxxxz169c3edRpXbp0cfjLRx99ZJaZK1cux/nz52P8vn379pn35ciRwzF69GjHs88+6+jdu7dj/Pjxjh07dsQpL6+//rpZZoYMGRx//fVXrN67fv16R7Zs2cz7CxYsaLb1Qw895NyOjRs3doSHh3vdV/R7Kl++vNnnmjVr5mjevLnZHjqvUKFCjnPnzrm9T/cFnXf//fc7GjZsaPYp/axWrVo5ChQo4Nx/dRt52rZtmzNN3rx5zfv0M3Pnzm2mVaxY0e3zXnzxRUfNmjXNvHvuucfsL9ZDt/udnDlzxhEaGmreP3v27DumP3nypEmrj3nz5kVZZ/09+GK9z/Lzzz+bfFr7rW4f1/z//fffbsuuUaOGo3r16mZ7NmnSxNG6dWuzjXRenjx5HLt27fL6PdiRp9iw9iPdVzwtWLDAuQ+WKFHC0aZNG/Nb1mORTuvatWuMjynff/+92TZp06Z1fPPNN/E+ZljHtpdeeskco0qVKmXyp9Ot/L3wwgt+2xYx/Y4sugwrfyEhIeZ38MQTTziKFy/u/I3t2bPHMXDgQEeKFCnM+j7++OPO31e+fPnM/u/tuOWaP3/sE/369TPvLVeunCMurl27Zo4lugz9Hh9++GFzDLPWRY+zGzZs8LntdBu5bgM9Bup0fb9uA91uulw93ui+YR3f9Ljn67io50c95uh21mOkvi9r1qzOffnEiRN+OcfqNtb53bt3d6ROndqcIzW/elwcN25ctL/1n376yZEyZUozr0KFCmbdNZ/33XefWZYey11FRkY6OnXqZNJb20v3eWuf0rwvWrTI57746quvmn2xSpUq5n16vLK+Az33AckJQTeQzHXs2NGcwPRkGBfRBd1ff/2149KlS1FOwhMnTjTvKVOmjHntj6D7gw8+MNM1mNq+fbtz+o0bNxw9e/Z0nqg987llyxZzsaAXSJ4X1vv37zcXdfq+zz//3BFbly9fdl5I6kVU0aJFnXlcvXp1rJZlXbx6e+hFSYcOHRwXL16M1TIPHjzoyJgxo/OCSAOvt99+27F06dIoga/nBat1UdSjRw/H9evXnfP27t1rLuJ03ssvv+x1X7GCctebDnqhqgGwznvzzTfd3mddAOqjUqVKjqNHjzrnXb161SxL5z3zzDNu77ty5Yq5iNV5Q4cOdbvY1e+mbdu2XgOk6PbpO1m2bJkzrwcOHIjRe4oUKWLSDxs2LF4BrsX6brzdhHBdtj50n3TNp25PDYJ0nl7genufHXnyR6B57NgxR+bMmc28N954w+3Y8vvvvzsDmI8//viOx5T333/f3DzJmTOnY926dX45ZljHNn1Mnjw5yn6jv2MNog4dOhTvbRGdO31Hum4aXFn0ZqzekNF5ZcuWdWTPnt2xefNmt9+S3hCztvudgm5/7BMPPPCAz5soMTF48GDnjTXXz9djWbdu3cw8/V16BsjWtvPcBnqsqVWrlvNGgC5X9wXXm2vW8X/69Ok+j4v6mzt9+rRz3tmzZ53bVoNOf5xjraDbunmgN6w9+fqt16tXz+s6KD1neP5WPvzwQ+dNjE2bNrnl0frd6U0GzxsK1r6hAf78+fO9bi/9ret2B5ILgm4gmdM78b5O6DER1wBFS9n0fVoS6Y+g27qg0ZO8Jw0ktOTOWz61dEOnW3f4vZXo6ny90x5besHkGSBrKYSvdYvOkSNHTMnEkiVLzEW5XmzottPSaqvESEv3PS+w7kQvkrSkzjOfGnDoxZ5e1Hn63//+5yzZ0gDc05w5c8x8Deh123vuK5pfXR9P+lnebgBZF4AalLhe6Fp+/fVX57b1dsH3yCOPeF13vUmhJVB6w8G1hC4+Qbe1Dvrwtm28sUpv9OZQQgfd3333XZT5x48fNyVQOt+1pCzQg26r5oav36r+xnV+sWLFfB5TNADp27evea2lcVqy6ymuxwzr2KYlktEdi7/44gtHYgbdWpLtaePGjc73aUDnSW8+6DwNyhIi6LaOWRo0xpYek7R2j2ftEtebCFZNmC+//NJtXnTb4Ntvv3XOX7hwYZT577zzTrQ3+fThGpi63uTRY58ek2NzQ8bXOdYKunX/9lW7zddvvXTp0ma6Z40GX6ybnnoTy5Oeq7TkX+ePGjXK677Rv3//aL//2N68BgIZbboBxIsO76Nt27SjLm0rqu3J9GG1J/bV7iw2tP2dfo7VuY4nbef2xBNPRJmunYhZYyVrGzVvqlatatrs6ZA0165di1W+tK3jfzcvzbBr2lO1tv3ToaO0B/PY0DZ32qu8tm3TtnTatk3bgQ4dOtR0IqTt8X788Uefbep80Q69tm3bZpahHQ5p3rR9o24bHS6sTZs2UcY9ttpc6jxv7dK1fae2v9M2ytr+z9s29WxfqawO+ny1p9R2jhUqVIjx+3SooOi+W/1eNS/atvP333+XxJIQ7Xh97Z+PPvpolOnaxl971ld2tLm2i5VXb8OMKT3+qN27d8uRI0eizNf27douVfuF0NEc1q1bF6UDMH8cM7Stvzd32v8Tig5j50nbOsdkvrftGmi0nf6lS5dM+2Jv34X2+aDHNqXtib2Jbhtonx16nI7tNtJjm7YB96T9T1SqVMnsezrKgb/OsS1atIjSeeadaBt21b59e9MRqB47o+vzw2rn7+03qW22rf4zfG3nQP+tAP7EkGFAMqdBoPLWwUt8aEdavXv3Np1qRRdUXLhwId6fpSd3pZ3V6MWuN9q5jCfttMb6fO3U6k40vQ6BExfaAd3DDz9sOpPRMc7HjRsnderUMR0UxZdeCOnFyXfffSfz5883F1Oxob2Ua7CtD+u704Bj5MiRpidu7VCsadOm0rp1a7cLHW/b1LqY0nna+Y+3iyJfPeJaY1X7urlxp/fpsHaenQSqjh07mkd0dFxyf9B90KIXvTHp/df67Vm/xYRidVbkjfXdWr+tpOBO+6XeZNBA68yZM2a9tNM4VzpsngYR2inVTz/95PWGkj+OGXHd/xOKt/y5Hle9zdcO1RIy7/pb0Q7z4nLeutN+oqybLdHdAPS1jfSGotVZZmy2UXT50XkbN250+z3G9xwbl7HRR48ebYaa1BtP+rA6NtMO1zQQdx3ZxNp22tmltW/7YzsH0m8F8CeCbiCZq1Klivzvf/8zJ3Q9icf2zrcvEyZMMD3Daq/U2iu69hCrgafVy2y7du3kq6++inUpn97t9xfXZfkqHXPlj97GtbdXvTjR3ovnzp3rl6Bb6cWOBt3+CJJ0H9CSPr2o0oBe9w1dthV0x5cG+QnxPuv71VLbOw0X5K/xe7VESgNZ3a91KLA7Bd0a7O/bt8/5W0yM30F0YvP7TKg82UVvLGnpnfbo/NZbb5ke7+04ZsR1/08od8pfIORffyvae3li1VCJbhvYuX1cf4/xPcdqwBxb+llaU0B7j9cbUzrEqB7n9FlHbdCgfPDgweIvgbCvAQmFoBtI5jTo69+/v5w7d07mzZsnjz32mF+Waw3Po3fhvVVh1SqevoJS5Tp8kitrmBlXVknSqVOnTLVBb6XdOvSIt1JJvfC4evWqKXl2LaW0kw4h4+/aBVqi5lqa4g8afNevX98E3bptPbe3VZLsjRVIxrVmgD9oSaSWhmmVy8cffzxBPlNLUnWce60GqsPa3OlGhd7wsr431+F54vI7iC1vvwnPedqUISHzFB+6r+n37Wu/PH/+vCnlttJ60qq9o0aNkgcffNAMnaTrqceFQDhmwJ0OxafNAHQYM63Grze7Ysr67q1jlDfWPpSQx6/o8uPt9xjXc2x8WUOJWccrLW3W4cd0qDMdflCPtVqCbW07q3aIt9LuxNjOQKDiFhOQzOnJUccXVS+++KLzotQXDRRj0g7bWo63EkRtQ6wlvd5YJ19v4y5rm0tvbb/0QkTHCVXWmOOutNrx7NmzvQaVeoGt4jKGb1wtW7bMPBcvXtwvy9Mxr7VauWubO3+VYlrjzrpe7FkXWzNnzvRavU9L8LVquQaSsSm99Tetzh+X79YKLqNrrxgdvfBUCxYsiLaN/aFDh8xY4UqribpelLre2Lh+/XqU91rt1eOTf73RZu03nqXvixcvNv+73ghIiDzFh5VXbQ7hzWeffeZsW+vrIl/Hf9cSVK16q+Nm9+jRw610O7GOGclRfPYJ/a5r1qxp/u/Zs2eUpiWetG3x0aNH3drc6zlKbzR70hsqOq60sprcJASttq0Pb+dLvfGppb46Dnx8z7H+piXr+jspX768+a1Y66DnDKv6uAbl3s4/1vSE3M5AoCLoBoLA//3f/0nRokXNnXatVqxVLD3pRbZetGqJgreA2JPVtmvixIluF6164dOpUyefF1oNGzZ0vs+1nZcGls8884wJVLzRTmSUllBpaZdFq8wPGDDAZ+c1WoVUL/60YzO9WPdWRVarm3777bcSU1oC4y2fetNAg6xvvvnGtPmzOpGx6PqWLFnSPDzbuGknat6Wqd+ZlvrodtU2q127do1xPl955RXp06eP1ws9/X60BGXOnDnmtdWxkNLSW602rdtUa0m4fpeaH715o3TZVlXHxKD7i16Q6g0XrfLorYRWO7j75JNP3KZZNxi2b98ep89t3LixWXelN7T0wtLzBodWydQLTb05oUGAZ1VmzbcGhxoYv/3221E6DBs2bJjPz7fyrxfed6LflWuTBA1etMRKf296A8cKbBIyT3HVvXt3c+NCAxSt6uq6zbU01LrBcadODDVQ0MC7RIkS5jfgebyy45gRjOK7T0yfPt3UNNDfktbI0VJvT7ofa9VrvflndSymxyTdx63937WGxo0bN+SFF14wxwVtR51QNWSU7q96A0GPCa61M3SaztNO/lz7EYjrOTY+tHaHdSPWlZ5zrZJ115sAeu5Vr7/+uvz5559u66q/R70xoOct/e0CQS+xu08HkDB0mKC6des6hy7RMUqbN29uxjLWIZysIVYyZcrk+O233+44vJIO45QqVSozT4fzeuKJJ8yQOGnTpjVjhz722GNmnr7flY6TWrVqVec4nE2bNnU8/PDDZrzcu+66y4zL6m3IMB3qp1mzZmaefq6O3azDoOl66Hi61ljd3oaBmjVrlnOIpPz585uht9q3b28+V1/rdB0mKKZ0uBMd4kWHV9H11G2o29YaJ1jHwfU2LJDrWNyew+hUqFDBLFPHydUhh3TdqlWrZpZljRu7atUqR2y88MILzs/TbavjdLdr185sO2uINX0MGTLE67BI2bJlcw4HpNtH36/bWqfpMjzHuL3TUFy+hheKz1BVW7dudY4bruPB1q5d26yjjpuu349uUx0eyJXmW4dDs8YF79Spkxm7d8yYMY6Y0uFwdCxgHebH2r76mbqdrGFyrO3ka0x0HYZJ86fpdAxzHStZh6HSaTqmt691tsas19+s7iuad33s2LHDbXvqkEK6D+m+r8Oq6W/UWm8dSs1KnxB5io3ohsnSMX2tfVCHFdLfXoMGDcywcN6Ga4puGEI9JurvTufpd+c6BFxcjhlxHQ4xJttCj3n6Xfp6uA5HF9dh3Xy9L7rfbnRDhvljn9i9e7fb70l/09bxUcfyto6P+ht3HY9ev0vdL3SenpP02KXfV8GCBZ3H0z/++MMv2+BOxzHrO3z00UfNsId6nNLzhq6HdYzVYe50f/THOdYaMsxzekzyqudk67ely9djqZ7brN+XHis9j4MdO3Y08zSNbnP9TZYoUcK57X/44YdY74sxWQcgqSHoBoLMokWLzIlTT+J6MZQyZUoTgD344IOO9957z3H69OkYB1I6vqheSOTNm9dcCOuFw6BBgxwXLlyI9qSp41v37t3bXLzq52vA8swzz5iLjuguTG/cuGHGQtULL73Y0gsnvXGgYzvHJODr16+fCWp1HGnNr5749YLirbfe8jpery86tqt+jl74aB7CwsLMzQoN4AYMGODYu3evzzz4CrqnTJliLqr0YkcvxPQCRi/O7r33XrMtPC/IYuLUqVNmXGkd/7ty5crme9Ll6vrr5+gNjrVr1/p8/8GDBx29evUyF4p68afjcmsgp+Nj63fhKTGCbqX7mwbMmjfdZrpP6brqttMxib2t419//WX2Xb3ZYwXO0X2+Lxr06zbS7am/J90vCxQoYC7wFyxYcMf363i/NWvWNAGefi86pvfMmTOjXWe9ATV69Giz/1kBqGuw57o9L126ZLaB3pzS71CDk6eeesp8twmZp9i409jU27dvN/uYdfzQ71zHj/Y25ryK7piixyJrvGM9BuoYznE9ZtgZdN/p4brvBkrQ7a99Qpej+58eH/VzNJDT35l+/3oz6ZNPPnH73ix6jJo0aZLZf/XYpfu/jivdp08fx+HDh/22DWIadOs+e+LECcezzz5r8q750WPF888/H+W8G59zbHyC7unTp5sbV7rP63lIt7Our95smjt3rgmyvZkxY4b5XVjHX10vPc74usFC0I1gFKJ/Eru0HQAA+IdWBdeq7TpkXVIahxtIjrT5iTY10t7wvbV9BhAcaNMNAAAAAIBNCLoBAAAAALAJQTcAAAAAADahTTcAAAAAADahpBsAAAAAAJsQdAMAAAAAYJMUdi04uYuMjJQjR45IxowZJSQkJLGzAwAAAABIQNpS++LFi5IvXz4JDfVdnk3QHUcacBcoUCCxswEAAAAASESHDh2S/Pnz+5xP0B1HWsJtbeBMmTIldnYAAAAAAAnowoULpiDWig19IeiOI6tKuQbcBN0AAAAAEJxC7tDcmI7UAAAAAACwCUE3AAAAAAA2IegGAAAAAMAmtOkGAAAAENQiIiLkxo0biZ0NBJiUKVNKWFhYvJdD0A0AAAAgaMdZPnbsmJw7dy6xs4IAlSVLFsmTJ88dO0uLDkE3AAAAgKBkBdy5cuWSdOnSxSuwQvK7IXPlyhU5ceKEeZ03b944L4ugGwAAAEBQVim3Au7s2bMndnYQgNKmTWueNfDW/SSuVc3pSA0AAABA0LHacGsJN+CLtX/Ep80/QTcAAACAoEWVcti9fxB0AwAAAABgE4JuAAAAAIBPr732mlSsWDFey9i/f78pNd68eXOc3t+xY0d58803/fZ5169fl8KFC8sff/whdiPoBgAAAIBk4ujRo9KuXTspXry4hIaGSt++feMdoA4YMECWLVsWr3wVKFDA5K1s2bLm9cqVK81nxmS4tj///FN++OEHef75573O79Gjh1nWe++9F+P8pEqVyqzX4MGDxW4E3QAAAACQTISHh0vOnDll6NChUqFCBb8sM0OGDPHu4T0sLMyMd50iRewH0Pq///s/ad26tcmHp7lz58qvv/4q+fLli/Vy27dvL7/88ots27ZN7ETQDQAAAABJwMcff2yCy8jISLfpzZs3l65du5r/tcr0hAkTpFOnTpI5c2Zbqpc/9dRT0qJFC1PdO3fu3JIlSxYZOXKk3Lx5UwYOHCjZsmWT/Pnzy9SpU72Wpuv/9erVM9OzZs1qpusyfQ3tNmfOHGnWrFmUef/++6/06dNHvvzyS0mZMmW066DL0W1UsmRJOXjwoPOza9asKV9//bXYiaAbAAAAACzXrvl+XL/u/7SxoKW9p0+flhUrVjinnTlzRhYvXmxKbRPS8uXL5ciRI7J69Wp59913Zfjw4fLII4+YQPa3334zVb6fffZZOXz4sNeq5t988435f+fOnabaud4o8GbLli1y/vx5qVq1qtt0vfGg7bw1yC9TpswdS/9122nA//PPP0vBggWd8+677z4zzU6xL9sHAAAAgOSqdWvf8zTwGz789usOHTSi855W2y6PHn37dbduIhcuRE03f36Ms6YB7cMPPywzZsyQBg0amGlaCpwjRw5nyXFC0dLs999/37QbL1GihIwZM0auXLkiL7/8spk/ZMgQeeutt0z17TZt2kSpaq7vV7ly5TIl5b4cOHDApNd0rt5++21TVd1XO2/LpUuXpGnTpibw1psVnqX/WnNAP8NOlHQDAAAAQBKhJdpaSqxBpNKq1RrUavCbkLR02fUztZp5uXLlnK81UNZ24CdOnIjX51y9elVSp07tNl72hg0bTMn4tGnT7jiOdtu2beXy5cvy448/eq1unzZtWnOzwE6UdAMAAACAZfZs3/M8A9vp02OedsoU8Qdt2+xwOGThwoVy7733mqrR48ePl4Tm2YZag19v0yI92p/Hlpbia1CsQ3xpj+NK11mDeddq4tpm+8UXXzQ9mGubcUuTJk1k+vTpsm7dOqlfv36U5Wv1fO14zk4E3QAAAABgSZMm8dNGu5g00rJlS1PCvWfPHlO1u3LlypLUpPovgNZgOTpWB27bt293/q9tuRs2bOiWrnHjxmZ6ly5d3Kb37NnTDFP26KOPmhsVderUcZu/detWqVSpktiJoDuert28Jqlu3tphXIWGhEqqsFRu6XyJT9rwm+HiEIfXtCESIqlTpI5T2usR1yXS4fuuVJoUaRI9beqw29VMbkTckAhHhN/T3oy8aR7+SKvfm35//k6bMjSlhIWGxTptRGSE3Ii84TNtitAU5hHbtPqd6Xfn77R6Rzc8ItwvacNCwiRlWEq/p02o3z3HiJil5RhxC8eI2KflGHELx4j4p+UYEdjHCLNPOxxmOfpsfRf6v6993WJtX7vSWuvnS9t2beXRZo+aoa46dOgQJa013ra2Zz5x8oR5rUFu6dKlvS7Xmvb3jr+jTNdq5Jp313S31iTquljb807TIh2RUqBgAbPN582fZ0qjtZq3NSSY63bIniO7uamgpdvlK5Q307Jmy2oermm1lF2ruBcrXsws3/pMfe7Vu5fpWV07elu0aJHUqlXLOV+XO2LkiCh51OOa6z6h+4t4/DyiO966IuiOp05zO0nKdFG7p6+at6oMr3u7k4UO33bweSIum7OsjG54u5OFbvO6yYVwL50siEixbMXk3cbvOl8/t/A5OXHFezuJApkKyKSmk5yv+y3pJ4cuHPKaNle6XDKl+e0qLy/99JLsPrPba9pMqTPJly2/dL4evmK4bD251efJZM4Tc5yvR/88Wv44+of4Mr/t7Y4k3l33rqw5tMZn2tmtZztPrhN/nyjL9i3zmXb6Y9Mlc5pbbTg+3fip/LDnB59ppzw6RXKlv9VRwxd/fiFzd8z1mXZik4lSMPOtai2zts2Sr7Z+5TPtu43elWLZi5n/5+2cJ1M33x5CwdOb9d+UcrlvtYlZsmeJTN4w2WfaYbWHyb133Wv+X7V/lbz323s+0w6uOVhqFaxl/l93eJ28veZtn2n7VusrDe6+1UHHxqMbZeTqkT7T9qjSQ5oWb2r+33Zim7y8/FYHGt50qdhFWpZqaf7fe2av9P+xv8+0bcu2lXbl2pn/dd/t9UMvn2kfK/mYdK10a6iMk1dOmt+RL02KNpGe9/Y0/+tvrcPcDj7TNijSQPpW72v+199w69m+O1epWaCmvFTrJefr6NJyjLiFY8RtHCNu4RhxC8eIWzhG3MYxwv/HiBwpc8hThZ+S0HOhkiNzDsmRLoeZrjce9p+7XT3Zk+4L1nesN2D2nd3nM63u77kz5Db/a5CqefYlQ6oMkjdjXufr6NKWvq+06YhMe/5u166dyYNr0FilchXn/9r++asZX0mhQoVMtWtdN70R4urwuVs9jLdre2t7uVq9ZbWcuXrGHIOsPF0MvyhXb1yNEoCeDz/vlm/dlqeunJKD528N0WX598K/ci3tNXl+8PMyePBg6da1m7R4soW8/cHb5sbO3VnvdqY9cvGIPNrmUfnsi8/koXYPuS1HA+57st3jfK3HPuvzrXU6dP6QZDyTUR7p9IgJnjXA197ei5QrIj+v+VnOnjsrletXjrK9dbkaeJv1vX5R+i7uK6dunHJLc+OK75tJrgi6AQAAACAJ0Q7MdLgui2fAuOvULuf/aVOmlfyZ8ke7vPwF85v36I2oApkLOKdrgK61OzQ41odFg2PXWjNq5oKZUWoerNh0e2gzHT/cKjHXQFj1GtDLPO6kZduW8tGEj2TT75uk0r3eq4LrDQUN0C9fv+y2Tq769+9vHuroxaMybfI06da7m6RJ65+q/76EOKw1R6xcuHDB9H53/PRxyZQpU5T5VAuzPy3Vwm4J5mphcU1L1dFbOEbEPy3HCI4RHCO8p+UYwTEiKRwjwq+Fy78H/5XCRQpL2jRpk1T18mBMu3LlSrl48aLpSM4fy70Wfk3Gjhkr/V/sb6q2e7Kql1+7dk3++ecfuavgXZI6ze3jnBUT5s6e24wj7i0mdC6LoDt+QfedNjAAAACAwKPB1L59+6RIkSKmczIgtvtJTGNCxukGAAAAAMAmBN0AAAAAANiEoBsAAAAAAJsQdAMAAAAAECxBd0REhLz66qumobr2InfPPffI66+/7uxeXun/w4YNk7x585o0DRs2lN273ceCPHPmjLRv3940aM+SJYt069bNDA7vasuWLfLAAw+YBvEFChSQMWPGJNh6AgAAAACSv4ALut9++2358MMP5YMPPpC///7bvNZg+P/+7/+cafT1+++/L5MnT5bffvtN0qdPL40bNzY9y1k04N62bZssXbpUFixYIKtXr5ZnnnnGrae5Ro0amUHidcD4sWPHymuvvSYff/xxgq8zAAAAACB5Crghwx555BHJnTu3TJkyxTmtVatWpkR7+vTpppQ7X7588uKLL8qAAQPMfO2iXd8zbdo0adOmjQnWS5cuLb///rtUrVrVpFm8eLE0adJEDh8+bN6vgf0rr7wix44dk1Spbo1X+dJLL8l3330nO3bsuGM+GTIMAAAASLoYMgwJNWTYrdHiA8j9999vSpt37dolxYsXlz///FN++eUXeffdd818XWENlLVKuUVXtFq1arJu3ToTdOuzVim3Am6l6UNDQ03J+GOPPWbS1K5d2xlwKy0t15L1s2fPStasWd3yFR4ebh6uG1hFRkaaBwAAAICkQ6/htUDPesC3Ll26yLlz52Tu3LlxXsbKlSulfv36phmwxmqxVadOHXn22WelXbt2MUq/f/9+ufvuu2Xjxo1SsWLFKPOvX78uJUqUkNmzZ7vFjZ6s/cNb3BfTODDggm4tbdaAtmTJkhIWFmbaeI8aNcpUF1cacCst2Xalr615+pwrVy63+SlSpJBs2bK5pdG7FZ7LsOZ5Bt2jR4+WESNGRMnvyZMn3aq1AwAAAAh8N27cMEHTzZs3zSO50MBYCzG18FILDbUGsPaZpU1rfVm1apU8+OCDcuLECa8B8bhx40zgGZ/tdN9998nBgwdN02BdzhdffGFqL2s8dSfz5883Mdrjjz/uzIO+1thx2bJlcvHiRVNgq69btmxp5lvpfH2/WiDbr18/GTx4sCxZssTnZ+t7dT85ffq0pEyZ0m2efm6SDLpnzZolX375pcyYMUPKlCkjmzdvlr59+5oq4Z07d060fA0ZMkT69+/vfK03BrTztZw5c1K9HAAAAEhitOBMgyYtnNNHcrFmzRoTQL/55psmgJ46daqp6fvrr79KpUqVvL5HCzuVr22RPXv2eOcrRYoUki5dOreg15p+J5MmTTKl7a61lLWjbC19//777yVHjhwmftRScG1irOtpLTe677djx44yaNAg2blzp4k9feVb86rbwLN6eUybJQTc3jVw4EBzh0Kriaty5crJgQMHTEmzBt158uQx048fP256L7foa6vagKbRuzSedyi0KoP1fn3W97iyXltpXKVOndo8POkXYO0wAAAAAJIGvYYPCQlxPpICLcHWzp+1nyrXGKR58+YmKPzss89kwoQJbu/ROGrevHmmc+nKlSt7Xa61/r62xVNPPWUCXO3/StWtW9fEaRqsf/755yYYfuONN0zQ27t3b5kzZ46pRaydYT/88MPO6uX16tUzTXm1YLVr165murUew4cPN+vmSUvCly9fbtbLNW9r1641/XRpM2OlpfnvvfeeqU6u6+m5TlqDunv37uZ9P/74oxQsWNDUhK5Zs6bMnDnTjJjla9vow1vcF9M4MOCixStXrkTJvH6ZVn15rRKuQbFWI3Atdda22jVq1DCv9Vl3Cu2V3KJflC7D+lI0jfZortVKLNrTudbr96xaDgAAACA4XLt5zefjesR1v6eNjdatW5tqzitWrHBO04JF7TTaao7rSWMgLdHXANOfNNjWEub169dLnz59pGfPniZ/2keXBr5anV1Lkq9cuRLlvZpGA2StMXz06FHzsDrJ9qT9e2kJealSpaIsQ4NlXX9dx6+//trUXtAbAp60mr3mTYP9n3/+2QTcrtXedZqdAq6ku1mzZqYNt24ILeLftGmT6UTNuhOidxm0urneSSlWrJgJwvWuhlY/b9GihUmjX8hDDz1k7mTosGIaWOsdFy0913RK78JoG22tlqD1+Ldu3WrunowfPz5R1x8AAABA4mk9u7XPeVXzVpXhdYc7X3f4toOER9zubNlV2ZxlZXTD0c7X3eZ1kwvhtzpjdjW/7fwY500LB7XkWKtSN2jQwEzTUmUNfrUU2Rttj33p0iV54oknxJ8qVKggQ4cOdTbFfeutt0w+NAZTw4YNMyXRW7ZskerVq7u9V0vGtTNsje281TJ2pbWetdTcs2BWmyU/+eSTpoTfqrqu7dmLFi3qlk7XvWnTpibw1psV+rmuND7UzwiqoFurIGgQ/dxzz5kq4roRtJc6/dIsWu/+8uXLZtxtLdGuVauWubvjWqde24VroK07o35BOuyYju1t0Y2t1Qp69eolVapUMTuIfobrWN4AAAAAEEi0RFsDW23nrM1fNe7RwkVvVZ01ONeCRm337NnRdHyVL1/erWayBr9a5dyzk+oTHs1+Y+vq1ate205rzKix4E8//WRiOa36rjcWtNTaNR9t27aV/Pnzm5rPOgy1J53mrTQ+WQfdGTNmNFUN9OGL3hEZOXKkefii1Sd0J7vTjmJ3VQIAAAAAScfs1rN9zgsNcQ9sp7ecHuO0Ux6d4reawdqT+MKFC+Xee+818Yy32rpa3frpp582Q2K5DrfsL549eWuM5jrNalMdGc/hlTWg1nbgrvbu3SsffPCBqa1sdYCmJe+6LSZOnGhqO1uaNGki06dPN0NG65BlnrR6unaOHVRBNwAAAAAkljQp0iR62miXkyaNGRZLS7j37Nlj+qTy7CDtq6++Ms1zNfDWqtWBKFWqVKZzszvRnsh1eDANvK2+t6yS6ej6ArNoW/OyZcvKo48+am5U6HjfrjRw99Wru78QdAMAAABAEqti/sgjj8i2bdukQ4cObvO0tq+O+qT9VWkn0hqwWtWoPdsze/rrr79MzWPX0motQbZD4cKFTXtr7SBbP0PbZLsOKWbRgFhLu3UoNF1nVbJkSdN2W5sha5t1rdqu1cu1Y2ztpd2TdvSmAb6+f9GiRaZ5skVLx331XO4vAdd7OQAAAADAN60mrc1pdXxp7SDac1gxHS5Z+67SIZatxwsvvHDH5dauXdsEudZD+76yy/333y89evQwnaFp9e4xY8Z4Tael1zpGt5bsW7Qa+w8//GDep9XttdnwF198YXpU1+rk3mhn3Nq+XefrsGFKq5yfP39eHn/8cbFTiEMbBCDWdJgyvVOkX5J2dQ8AAAAg6dDhpfbt22dGQ/LWURcCx7Fjx0zbbR2KrFChQn5brgb8Wsr+8ssvx2k/iWlMSEk3AAAAACBg5cmTR6ZMmSIHDx702zKvX79uejnv16+f2I023QAAAACAgNaiRQu/d+RmjTNuN0q6AQAAAACwCUE3AAAAAAA2IegGAAAAAMAmBN0AAAAAglZkZGRiZwHJfP+gIzUAAAAAQUc70goNDZUjR46Y8Z71dUhISGJnCwFCR9bWHs5Pnjxp9hPdP+KKoBsAAABA0NFASsdePnr0qAm8AW/SpUsnBQsWNPtLXBF0AwAAAAhKWnqpAdXNmzclIiIisbODABMWFiYpUqSIdw0Igm4AAAAAQUsDqpQpU5oHYAc6UgMAAAAAwCYE3QAAAAAA2ISgGwAAAAAAmxB0AwAAAABgE4JuAAAAAABsQtANAAAAAIBNCLoBAAAAALAJQTcAAAAAADYh6AYAAAAAwCYE3QAAAAAA2ISgGwAAAAAAmxB0AwAAAABgE4JuAAAAAABsQtANAAAAAIBNCLoBAAAAALAJQTcAAAAAADYh6AYAAAAAwCYE3QAAAAAA2ISgGwAAAAAAmxB0AwAAAABgE4JuAAAAAABsQtANAAAAAIBNCLoBAAAAALAJQTcAAAAAADYh6AYAAAAAwCYE3QAAAAAA2ISgGwAAAAAAmxB0AwAAAABgE4JuAAAAAABsQtANAAAAAIBNCLoBAAAAALAJQTcAAAAAAMESdBcuXFhCQkKiPHr16mXmX7t2zfyfPXt2yZAhg7Rq1UqOHz/utoyDBw9K06ZNJV26dJIrVy4ZOHCg3Lx50y3NypUrpXLlypI6dWopWrSoTJs2LUHXEwAAAACQ/AVc0P3777/L0aNHnY+lS5ea6a1btzbP/fr1k/nz58vs2bNl1apVcuTIEWnZsqXz/RERESbgvn79uqxdu1Y+//xzE1APGzbMmWbfvn0mTb169WTz5s3St29fefrpp2XJkiWJsMYAAAAAgOQqxOFwOCSAaUC8YMEC2b17t1y4cEFy5swpM2bMkMcff9zM37Fjh5QqVUrWrVsn1atXl0WLFskjjzxigvHcuXObNJMnT5bBgwfLyZMnJVWqVOb/hQsXytatW52f06ZNGzl37pwsXrw4RvnSvGTOnFnOnz8vmTJlsmntAQAAAACBKKYxYcCVdLvS0urp06dL165dTRXzDRs2yI0bN6Rhw4bONCVLlpSCBQuaoFvpc7ly5ZwBt2rcuLHZINu2bXOmcV2GlcZaBgAAAAAA/pBCAth3331nSp+feuop8/rYsWOmpDpLlixu6TTA1nlWGteA25pvzYsujQbmV69elbRp00bJS3h4uHlYNK2KjIw0DwAAAABA8IiMYRwY0EH3lClT5OGHH5Z8+fIldlZk9OjRMmLEiCjTtcq6du4GAAAAAAgeFy9eTNpB94EDB+Snn36Sb7/91jktT548psq5ln67lnZr7+U6z0qzfv16t2VZvZu7pvHs8Vxfaz18b6XcasiQIdK/f3+3ku4CBQqYNua06QYAAACA4JImTZqkHXRPnTrVDPelvYxbqlSpIilTppRly5aZocLUzp07zRBhNWrUMK/1edSoUXLixAnzfqU9oGtgXLp0aWeaH374we3zNI21DG90aDF9eAoNDTUPAAAAAEDwCI1hHBgaqHXjNeju3LmzpEhx+76A9gzXrVs3U+K8YsUK07Faly5dTLCsPZerRo0ameC6Y8eO8ueff5phwIYOHWrG9raC5h49esg///wjgwYNMr2fT5o0SWbNmmWGIwMAAAAAwF8CsqRbq5Vr6bX2Wu5p/Pjx5o6ClnRrx2ba67gGzZawsDAzxFjPnj1NMJ4+fXoTvI8cOdKZpkiRImbIMA2yJ0yYIPnz55dPP/3ULAsAAAAAgKAZpztQMU43AAAAAASvC8lhnG4AAAAAAJIygm4AAAAAAGxC0A0AAAAAgE0IugEAAAAAsAlBNwAAAAAANiHoBgAAAADAJgTdAAAAAADYhKAbAAAAAACbEHQDAAAAAGATgm4AAAAAAGxC0A0AAAAAgE0IugEAAAAAsAlBNwAAAAAANiHoBgAAABLJxo0b5dFHH5Vs2bJJunTppGzZsvL++++beVeuXJGJEydKo0aNJG/evJIxY0apVKmSfPjhhxIREeG2nNdee01CQkJ8PtasWeOW/u+//5aHHnpIMmTIYD67Y8eOcvLkyQRddyBYhDgcDkdiZyIpunDhgmTOnFnOnz8vmTJlSuzsAAAAIIn58ccfpVmzZiaQfvLJJ00AvHfvXomMjJQxY8bI1q1bpXz58tKgQQMTeOs155IlS2Tu3LnSqVMn+fzzz53L2rJli3l4evnll+XSpUty7NgxSZUqlZl2+PBh85l6Lfv888+b+ePGjZOCBQvK+vXrnekA+CcmJOiOI4JuAAAAxOdasnjx4nL//ffLnDlzJDQ0agXUU6dOyfHjx6VMmTJu07t27SpTp06V3bt3S9GiRX1+xqFDh6RQoULy9NNPy8cff+yc/txzz8m0adNkx44dJtBWP/30kzz44IPy0UcfyTPPPOPXdQWCPSakejkAAACQwGbMmGEC6lGjRpmA+/Lly6aE21WOHDmiBNzqsccec1YRj85XX30lWr7Wvn17t+nffPONPPLII86AWzVs2NDcBJg1a1Y81wyAJ4JuAAAAIIFpybKWjP37779SokQJU7VcX/fs2VOuXbsW7Xu1qrgVlEfnyy+/lAIFCkjt2rWd0/TzTpw4IVWrVo2S/r777pNNmzbFeZ0AeEfQDQAAACQwrRp+8+ZNad68uTRu3NiUPmu18cmTJ0uXLl18vu/69evy3nvvSZEiReTee+/1mW7btm2mjXfbtm1NR2qWo0ePmmftmM2TTjtz5oyEh4fHe/0A3JbC5X8AAAAACUA7L9PeyXv06OHsrbxly5YmqNZ21SNHjpRixYpFeV/v3r1l+/btsnDhQkmRIkW0pdzKs2r51atXzXPq1KmjvCdNmjTONN7mA4gbSroBAACABJY2bVrzrCXRrtq1a2ee161bF+U9Y8eOlU8++URef/11adKkic9laztubTOuw49p7+fePtdbabZVrd1KA8A/CLoBAACABJYvXz7znDt3brfpuXLlMs9nz551m669jQ8ePNiUjA8dOjTaZeuY3AcOHIhSyu1ardyqZu5Kp+mY3ZRyA/5F0A0AAAAksCpVqjg7NnN15MgR85wzZ07ntO+//94M+6XVzydOnHjHZWvVcm3HbZWau7rrrrvMsv/4448o83SM7ooVK8ZpfQD4RtANAAAAJLAnnnjCPE+ZMsVt+qeffmraatetW9e8Xr16tbRp08b0QK7BtLfxvF3duHFDZs+eLbVq1XIbEsxVq1atZMGCBWYcb8uyZctk165d0rp1az+sHQBXdKQGAAAAJLBKlSqZ3so/++wz04t5nTp1ZOXKlSZgHjJkiKl+rlXEH330UVNq/fjjj5t5rrS9tmeb7SVLlsjp06e9Vi23vPzyy2ZZ9erVkxdeeMF06qbtxcuVKxdtz+kA4oagGwAAAEgEOjyYlkZPnTpV5s6dK4UKFZLx48dL3759zfx9+/bJ+fPnzf+9evWK8v7hw4dHCbq1NDxlypTRlljr2N2rVq2S/v37y0svvSSpUqWSpk2byjvvvEN7bsAGIQ7t3hCxduHCBcmcObM5EGbKlCmxswMAAAAACMCYkDbdAAAAAADYhKAbAAAAAACbEHQDAAAAAGATgm4AAAAAAGxC0A0AAAAAgE0IugEAAAAAsAlBNwAAAAAANiHoBgAAAADAJgTdAAAAAADYJIVdCwYAAAhEISHjEjsLAIAYcDgGSHJASTcAAAAAADYh6AYAAAAAwCYE3QAAAAAA2ISgGwAAAAAAmxB0AwAAAABgE4JuAAAAAABsQtANAAAAAIBNCLoBAAAAALAJQTcAAAAAADYh6AYAAAAAIJiC7n///Vc6dOgg2bNnl7Rp00q5cuXkjz/+cM53OBwybNgwyZs3r5nfsGFD2b17t9syzpw5I+3bt5dMmTJJlixZpFu3bnLp0iW3NFu2bJEHHnhA0qRJIwUKFJAxY8Yk2DoCAAAAAJK/gAu6z549KzVr1pSUKVPKokWLZPv27fLOO+9I1qxZnWk0OH7//fdl8uTJ8ttvv0n69OmlcePGcu3aNWcaDbi3bdsmS5culQULFsjq1avlmWeecc6/cOGCNGrUSAoVKiQbNmyQsWPHymuvvSYff/xxgq8zAAAAACB5CnFosXEAeemll2TNmjXy888/e52v2c2XL5+8+OKLMmDAADPt/Pnzkjt3bpk2bZq0adNG/v77byldurT8/vvvUrVqVZNm8eLF0qRJEzl8+LB5/4cffiivvPKKHDt2TFKlSuX87O+++0527Nhxx3xq0J45c2bz2VqaDgAAkoaQkHGJnQUAQAw4HLfivUAV05gw4Eq6582bZwLl1q1bS65cuaRSpUryySefOOfv27fPBMpapdyiK1qtWjVZt26dea3PWqXcCriVpg8NDTUl41aa2rVrOwNupaXlO3fuNKXtAAAAAADEVwoJMP/8848phe7fv7+8/PLLprT6+eefN8Fx586dTcCttGTblb625umzBuyuUqRIIdmyZXNLU6RIkSjLsOa5VmdX4eHh5uF6V0NFRkaaBwAASBpCA67IAQDgTaDHWTHNX4pAzLiWUL/55pvmtZZ0b9261bTf1qA7sYwePVpGjBgRZfrJkyfd2pIDAIDAVqVK+sTOAgAgBk6cOCGB7OLFi0kz6NYeybU9tqtSpUrJN998Y/7PkyePeT5+/LhJa9HXFStWdKbx/IJu3rxpejS33q/P+h5X1msrjashQ4aY0nfXkm7t8Txnzpy06QYAIAnZsOFyYmcBABADnrWXA42OgpUkg27tuVzbVbvatWuX6WVcaZVwDYqXLVvmDLI1ANa22j179jSva9SoIefOnTO9klepUsVMW758uSlF17bfVhrtSO3GjRump3SlPZ2XKFEiStVylTp1avPwpO3E9QEAAJKGAK+tCAD4T6DHWTHNX4yC7q5du8YpEyEhITJlypRYvadfv35y//33m+rlTzzxhKxfv94M42UN5aXL7Nu3r7zxxhtSrFgxE4S/+uqrpkfyFi1aOEvGH3roIenevbuplq6Bde/evU3P5ppOtWvXzlQX1/G7Bw8ebKqwT5gwQcaPHx+ndQUAAAAAIE5DhvmK4DUA9vZ2a7o+R0RESGzpuNpanXv37t0mqNZq3RpAW3TZw4cPN4G4lmjXqlVLJk2aJMWLF3em0arkGmjPnz/f5L9Vq1ZmbO8MGTI402zZskV69eplOmvLkSOH9OnTxwTgMcGQYQAAJE0MGQYASYMjmQwZFqOg+8CBA26vtZr2Cy+8IL/++qt5fuCBB0zP39omevXq1Sa41erbWmp89913S3JE0A0AQNJE0A0ASYMjmQTdMapebrWntrz11lumDfWff/7p1pmZtofWsa+7dOlieh2fM2eODBo0KD7rAQAAAABAkhWnlunaTlvbW7sG3K7uuusuM/+TTz6Jb/4AAAAAAAiuoPvw4cN37B5d52s6AAAAAACCVZyC7vz588vcuXPl2rVrXudfuXLFzNd0AAAAAAAEqzgF3U8//bT8888/Zkzt77//Xk6fPm2m6/N3331nehPfv3+/W4/jAAAAAAAEmxh1pOZp4MCBsmvXLpk6daq0bNnSTNNhubRXc6UdomtnapoOAAAAAIBgFaegWwNs7UytU6dO8vnnn5vxrrWbdO0uvUKFCtKxY0epW7eu/3MLAAAAAEByD7otderUMQ8AAAAAAOCnNt0AAAAAAMDGoPvmzZsyfvx4ue+++yRTpkySIsXtQvPNmzfLc889Z9p9AwAAAAAQrOJUvfzq1avSqFEjWbt2reTIkcME3ZcvX3bOL1KkiOlkLVu2bPLGG2/4M78AAAAAACTvku4333xT1qxZI6NHj5Zjx46ZIcRcaYdq2tZ7yZIl/sonAAAAAADBEXTPnDlT6tWrJ4MGDZKQkBDz8HT33XfLwYMH/ZFHAAAAAACCJ+jWYLpq1arRpsmYMaMZRgwAAAAAgGAVp6BbA+oTJ05Em2bv3r2SM2fOuOYLAAAAAIDgDLqrV68u8+fPl3Pnznmdf+jQIfnhhx+kdu3a8c0fAAAAAABJVpyC7oEDB8rZs2elQYMGpkM1HT5MXblyRZYtWyaNGzc20/r37+/v/AIAAAAAkLyHDNMS7A8++EBeeOEFt9JsrXauwsLCZNKkSVKlShX/5RQAAAAAgGAIulXPnj2lbt26MnnyZPntt9/kzJkzZrzuatWqyXPPPSdlypTxb04BAAAAAAiWoFuVKlVKJkyY4L/cAAAAAAAQ7G26oxMeHi43btzw92IBAAAAAAiOoHv16tUybNgwt97LT58+LQ8//LBkyJBBMmfOLC+99JI/8wkAAAAAQHAE3ePGjZMZM2ZIlixZnNNefPFFWbJkiRQpUsRMHzt2rMyaNcufeQUAAAAAIPkH3Zs2bZJatWo5X1+7ds0E2I0aNZJdu3bJzp07pWDBgvLhhx/6M68AAAAAACT/oFurkt91113O1+vWrTOBd5cuXZxDhz3yyCMm+AYAAAAAIFjFKehOmzatXLx40fl6xYoVEhISInXq1HFO07bdZ8+e9U8uAQAAAAAIliHDihYtKosXLzY9lWuw/fXXX0vp0qUlT548zjQHDx6UXLly+TOvAAAAAAAk/5Lu7t27y549e0zwrWN1792711m13LJhwwYTiAMAAAAAEKziFHR369ZNBg4cKFevXpXz589Lz549pW/fvm5tvLVDtQYNGvgzrwAAAAAAJCkhDofD4e+FXr9+3QTk6dOnlxQp4lSDPeBduHDBjEeuNx0yZcqU2NkBAAAxFBIyLrGzAACIAYdjgCSHmNCWiDhVqlTmAQAAAABAMItx0K0do0UnNDTURPk6XBgAAAAAAIhF0F24cGHTU/mdFCxYUDp37ixDhgyR1KlTxzd/AAAAAAAk/6C7du3a0QbdkZGRcurUKdm9e7e8/vrrsmzZMlm+fLmkTJnSX3kFAAAAACB5Bt0rV66MUbozZ87IgAED5PPPP5dJkybJCy+8EJ/8AQAAAAAQXEOGRSdbtmwyZcoUKVGihHz99df+XjwAAAAAAMEbdCuthv7ggw/Kjh077Fg8AAAAAADBG3QrHafsypUrdi0eAAAAAIDgDboPHDggOXLksGvxAAAAAAAEZ9D977//yvfffy/Vq1e3Y/EAAAAAACSv3ssPHjwY7XwdMuz06dOybt06GTt2rFy+fFmef/55f+QRAAAAAIDkHXQXLlw42nG6LQ6HQ0JDQ2XcuHFSp06d+OYPAAAAAIDkH3TXrl072qBbA+3MmTNLuXLlpH379lK8eHF/5REAAAAAgOQddK9cudLenAAAAAAAkMzY1ns5AAAAAADBjqAbAAAAAACbEHQDAAAAABAsQfdrr71mOmxzfZQsWdI5/9q1a9KrVy/Jnj27ZMiQQVq1aiXHjx+PMrxZ06ZNJV26dJIrVy4ZOHCg3Lx5M0ob9cqVK0vq1KmlaNGiMm3atARbRwAAAABAcAi4oFuVKVNGjh496nz88ssvznn9+vWT+fPny+zZs2XVqlVy5MgRadmypXN+RESECbivX78ua9eulc8//9wE1MOGDXOm2bdvn0lTr1492bx5s/Tt21eefvppWbJkSYKvKwAAAAAg+Ypx7+UJKUWKFJInT54o08+fPy9TpkyRGTNmSP369c20qVOnSqlSpeTXX3+V6tWry48//ijbt2+Xn376SXLnzi0VK1aU119/XQYPHmxK0VOlSiWTJ0+WIkWKyDvvvGOWoe/XwH78+PHSuHHjBF9fAAAAAEDyFJAl3bt375Z8+fLJ3Xffbcb81uriasOGDXLjxg1p2LChM61WPS9YsKCsW7fOvNZnHStcA26LBtIXLlyQbdu2OdO4LsNKYy0DAAAAAICAK+nWwPa3336TNGnSSK1atUx77NiqVq2aqQ5eokQJU7V8xIgR8sADD8jWrVvl2LFjpqQ6S5Ysbu/RAFvnKX12Dbit+da86NJo/q9evSpp06aNkq/w8HDzcF1XFRkZaR4AACBpCA3IIgcAgKdAj7Nimr84Bd2ffPKJTJ8+Xb777jvJmjWrmfbnn3/Kww8/7OzUrEaNGqaqt3ZmFhu6DEv58uVNEF6oUCGZNWuW12A4oYwePdrcAPB08uRJ07kbAABIGqpUSZ/YWQAAxMCJEyckkF28eNG+oPt///uf6ajMCrjViy++aDZKly5dTOD9ww8/yIcffmimx4eWahcvXlz27NkjDz74oPncc+fOuZV26+dZbcD1ef369W7LsG4EuKbx7PFcX2fKlMlnYD9kyBDp37+/W0l3gQIFJGfOnOZ9AAAgadiw4XJiZwEAEAM6ElUg0xretgXdu3btkubNmztfnz59WlasWCHdu3c3nZQp7dTsyy+/jHfQfenSJdm7d6907NhRqlSpIilTppRly5aZocLUzp07TZtvLVlX+jxq1ChzA8D6kpYuXWoC49KlSzvT6E0BV5rGWoY3OrSYPjyFhoaaBwAASBoCvLYiAOA/gR5nxTR/cVoLLWnWEl7Lzz//bJ5dh+7SNt379++P9bIHDBhghgLT9+qQX4899piEhYVJ27ZtJXPmzNKtWzdT4qxBvnaspiXrGixrkK8aNWpkgmsN0rXKuw4DNnToUDO2txU09+jRQ/755x8ZNGiQ7NixQyZNmmSqr+twZAAAAAAA+EucSrqzZ89uOjmzaMmzBsY1a9Z0TnM4HKan8dg6fPiwCbC19FwDew3edTgwK8jXYb30joKWdGvHZtrruAbNFs3HggULpGfPniYYT58+vXTu3FlGjhzpTKPDhS1cuNAE2RMmTJD8+fPLp59+ynBhAAAAAAC/CnFodBxL2tnZ77//LitXrjT12LWzM+30TEufLRoU//XXX6YqenKkbbq15F3HDqdNNwAASUdIyLjEzgIAIAYcjgGSHGLCOFUv12rZZ8+elQoVKpihvbS6uWsnY9p1+i+//GLaYAMAAAAAEKziVL28Xr16Mm/ePJk6dap53aZNG2nWrJlz/po1ayRfvnxubbwBAAAAAAg2capeDqqXAwCQVFG9HACSBkcwVy8HAAAAAAA2VS+3rF+/3nSopm26IyIioswPCQmRV199NT4fAQAAAABAcAXdZ86ckRYtWpi229HVTifoBgAAAAAEszgF3dpTufZOXrduXTMGto5znSJFvArNAQAAAABIduIUKS9YsEDuu+8+WbZsmSnNBgAAAAAAfupI7erVq1K7dm0CbgAAAAAA/B10V6xYUfbv3x+XtwIAAAAAEDTiFHQPHz5c5s2bJ7/++qv/cwQAAAAAQDC36T527Jg0bdpU6tSpI+3bt5fKlSv7HAy8U6dO8c0jAAAAAABJUogjujG/fAgNDTXtuV3f6tm+W+fpNG/jdycHFy5ckMyZM8v58+d93nAAAACBJyRkXGJnAQAQAw7HAEkOMWGcSrqnTp0an7wBAAAAABAU4hR069jcAAAAAADAho7UAAAAAACAzUH33Llz5YknnpDy5ctL0aJFndN37NghY8aMkX///dcfeQQAAAAAIHiql0dGRkrbtm1lzpw55nXatGnl6tWrzvlZs2aVV155xXSiNmTIEP/lFgAAAACA5F7SPX78eJk9e7Y8++yzcvbsWRkwwL1Xudy5c8sDDzwgCxcu9Fc+AQAAAAAIjqB72rRpcu+998qkSZNM1+iew4UprW6+b98+f+QRAAAAAIDgCbr37NljSrKjkz17djl9+nRc8wUAAAAAQHAG3dqGWwcAj86BAwckS5Yscc0XAAAAAADBGXRXqlRJlixZIteuXfM6/8yZM7J48WKpXr16fPMHAAAAAEBwBd3PP/+8HD58WFq1amWeXe3du1cee+wxUxKu6QDAm1GjRpn+IMqWLRtl3tq1a6VWrVqSLl06yZMnjzmWXLp0KUq6DRs2yEMPPWT6lsiYMaM0atRINm/e7PXzrl+/Lm+++aaULFlS0qRJYzp8bNq0aZRjGAAAAJDoQ4Y1b95cBg8eLG+//bYUKlRI0qdPb6bnypXLtON2OBzy6quvSv369f2aWQDJgwa6GgBbxw5XGjQ3aNBASpUqJe+++65JO27cONm9e7csWrTImW7jxo0mMC9QoIAMHz7cDGWonTvWqVNH1q9fLyVKlHCmvXHjhgmwNZjv3r27lC9f3oy88Ntvv5kbhPnz50+wdQcAAEBwiVPQrUaPHm2C6g8++MBcuGpVc73o1VInLZVq3Lixf3MKINnQYQa1+UlERIScOnXKbd7LL78sWbNmlZUrV5oSbFW4cGETLP/444+mNFvpjT3tX2LdunWm40bVoUMHKV68uFnGN9984zbM4apVq+SXX36R++67L0HXFQAAAMEtTtXLL1++bJ4ffPBB+f777+XYsWOm6qZePOvY3FbAvWPHDv/mFkCSt3r1apkzZ4689957UeZduHBBli5daoJnK+BWnTp1kgwZMsisWbOc037++Wdp2LChM+BWefPmNSXdCxYscFZH15uBEyZMMM1eNOC+efOmXLlyxfb1BAAAAOIcdLdo0cJcuEZHA26qlwNwpSXbffr0kaefflrKlSsXZf5ff/1lji1Vq1Z1m54qVSqpWLGibNq0yTktPDzclHR70nbgehNw69at5vX27dvlyJEjpkr5M888Y6q060Nfr1ixwpb1BAAAAOIVdC9fvlw6duzoc/6uXbtMwO2t4yMAwWvy5MlmOMHXX3/d6/yjR486S6w96TQNni3aZvvXX381gbxFg21t7qL+/fdf86xtwa0q5lpl/aOPPpKpU6eaJjHaHGbLli1+XksAAAAgnkH32LFjZebMmfLCCy9EmacXuHXr1jXVRLWKJwAo7WRx2LBhpi12zpw5vaa5evWqeU6dOnWUedrjuDVfPffcc+YGX7du3UxptpZsazV0K3C30lo3/y5evCjLli2Tp556yjx++ukn0+njmDFjbFlfAAAAIM5Bd//+/U1HSNqJmg774xlwa2/AGnDXrl2brQzAGDp0qGTLls1UL/fFqi6uVcc9acm0a3XyHj16mA7TZsyYIWXKlDHV1XXIwkGDBpn52gbcdZk1a9Y0PZ1bChYsaHo/1x7NAQAAgIAKupWWDmlnR1py9emnn8qePXtMwH3u3DkTcOv/AGDdkPv444/NyAZaRXz//v3moYG0Duel/585c8ZZrdwqrXal0/Lly+c2TW/6HT9+3HSqptXEf//9d9NxmtJezJX1Hh2X25MOc6hDhwEAAAABN2SY+uyzz0yP5T179jQ9CGuV8nnz5km9evX8l0MASZ62r9ZgWINufXgqUqSIaa4yYsQISZEihfzxxx/yxBNPuLXV1vG7XadZdHgxLbG2aLVxHXe7ZMmS5rWWgKdMmdLZxtuV3gDwVdUdAAAASPSgOywszAz906BBA3NBrMOH6RA+AOCqbNmyMnfuXK9VzrWttQ7pdc8990jmzJnNMWT69Omm7XfGjBlNuv/973+mbXbr1q2j/Rzta0JLu8eNGyehobcq8ugymjRpYmrg6KgKVjD+999/m6rlzz77rC3rDAAAAKgQh/YkdAd33313tPO1wyK9cNaqmq5CQkJMG8vkSEv1NUDQ9uuu4wkDiDlthqK1ZazhvdTGjRvl/vvvl9KlS5shvg4fPizvvPOO6SNiyZIlbuN9jxw5Uho1amRq2mhP5tor+YMPPijz5883JeYW7WitWrVqJgC3Strff/99MzyZDkN21113JfCaA0hMISHjEjsLAIAYcDgGSHKICWNU0q3VQjWA9kV7FdaHZ/weg3geANxUrlzZVBEfPHiw9OvXzwTK2kP56NGj3dJpoKy1bXQ0Bb3pp1XU33jjDdPRo2vArTSAX7VqlVmmptFScB3WUN9LwA0AAIBEL+lGVJR0AwCQNFHSDQBJgyOZlHTHufdyAAAAAABgY0dqSttE7ty500T5Gt2XKFEiStVOAAAAAACCUZxLunVM3e7du5vi9PLly5she/Q5S5YspvOj06dP+zenAAAAAAAkMSniGnBXr15d9uzZI9myZZMHHnhA8ubNK8eOHTPj63766aem06J169aZ+QAAAAAABKM4lXS//vrrJuAeOHCgHDhwQBYvXmyG6lm0aJF5rT0E7969W0aNGuX/HAMAAAAAkJx7L9dxuwsXLizLly/3mUaH49m/f7/8888/khzRezkAAEkTvZcDQNLgCObey48cOSI1atSINo3O13QAAAAAAASrOLXp1mheq5FHR+drumTv2jWRVKmiTg8NdZ+u6XyJT9rwcL0F5D1tSIhI6tRxS3v9ukhkpO98pEmT+Gk1v5pvdeOGSESE/9PevHnr4Y+0+r3p9+fvtClTioSFxT6tbgPdFr7oKATWSASxSavfmX53/k6r+67uw/5Iq9tAt4W/0ybU755jRMzScoy4hWNE1LTikNTieztESKjclDC/p42UELnhcumVWm4ketpUclNCxPvv3iEhcj2OaVPKTQn1kVaFS8oASKv5vfX7TCEREiaRfk8bJhGSwk9pr0uYOP4rL/Nn2htmbWKfNlQiJaX4Plbq1tctFdu0IRIpqWxIe6ffZ2zScoxI2GOEBPJ1RHTXZPENuuvUqSOzZ8+Wp556Sho2bBhl/rJly8z8Fi1aSLLXqdPtC3JXVauKDB9++3WHDr4vBsqWFRk9+vbrbt20roL3tMWKibz77u3Xzz0ncuKE97QFCohMmnT7db9+IocOeU+bK5fIlCm3X7/0ksju3d7TatWJL7+8/VrXc+tW3zvrnDm3X+t6/vGH+DR//u3/dT3XrPGddvbs2z+ciRN1x/Oddvp0vVt06/9PPxX54QffaXU76PZQX3whMneu77T6uQUL3vp/1iyRr77ynVbXR78/NW+eyNSpvtO++aZIuXK3/l+yRGTyZN9phw0TuffeW/+vWiXy3nu+0w4eLFKr1q3/160Teftt32n79hVp0ODW/xs3iowc6Tttjx4iTZve+n/bNpGXX/adtksXkZYtb/2/d69I//6+07ZtK9Ku3a3/dd/t1ct32sceE+na9db/J0/e+h350qSJSM+et/7X35r+Pn3RbaDbQulvuHVr32lr1rz127FEl5ZjxC0cI9zXh2NEghwjcsplmSKzfCb9QUrKZLnf/J9Jrsl08f29LZNiMkEeMP/rxfRs+Z/PtGuksLwt9Z2vo0v7h+SXkdLI+Vrz4OtifavkkZelifP1FJlt8u3NbskhL8qjzteT5FvJJZe8pj0kWaSX/PddiMh4mScF5JzXtCckgzwtTzhfvyU/SDE55TXtBUkjHeS/701ERsiPUlaO+QxKW0sn5+shslyqymHx5VH57zwgIv1ltdSU/T7TtpaOzgv7XrJWGoiPY5oeoqWtXJC05v+n5TdpIjt8pu0mT8hJyWD+7yQb5DHxcfwzn/uYHJKs5v8nZIu0lU0+0/aXZrJHcv63ntuli/zuM+3L8rBslbzm/8ayS3rIOp9pR8qD8ocUMP/XkX+kr/zsM+3bUk/WSBHzfw05IINlhc+078kDslxuHdMqy78yTJb6TDtZasgPUsr8X0aOy5uyyGfaqXKvzJVbx7975LS8Ky7nBQ9fSSXzULrvThTfx+u5Ulamyn3mf44RgXWMkEC+jojuhnNcgm5to61BdqdOnWTYsGGycOFCady4sTRp0sQE4blz55bjx4/LypUrTYdq6dKlM+mQuN7adHtnbnTqmmQ6773E4HLYNVnkkrb+iauSzUfa8Ihwme+Sts7xK5LTR9qbqUS+c0lb8+gVyesjrZrjkrb6kcuSP5q0czefkojUt34IVQ9fksLRpJ3/52kJz3jrR1Hp0CW5J5q0P/x1Wq5ku3UXt/yBi1I8mrQ/bj0jF06nM/+X3n9RSkeTdtn2M3L20q31K/7PBSkfTdpVf5+Vkzdvpb1n73mpFE3aX3aek2MpbqUttPu83BtN2l93nZPD6W+lzb/rnFSPJu3vu8/LgWy30ubZeU5qRZN2097zsve/7y7n7rNSJ5q0W/65ILv+S5v14BlpEE3a7fsvyvb/0mY6ekYaRZN214GLsuW/tOnOnJYm0aTde+iSbPovbeqLF6RZNGn3H74kf/yXNiz8mjwWTdrDRy7Lry778OPRpD169IqscUnb4ly4pPBRonfy+BVZ5ZK22dlwSX3Je9ozJ67Kcpe0D5++Jul95ONC2mvyI8eIgDlGFPU5BwAABEVHaqGhofLaa685A+lffvnFBOFWR2khISFiLeqee+6RadOmSU0t9YmHt956S4YMGSIvvPCCvPffnflr167Jiy++KF9//bWEh4ebwH/SpEkm6LccPHhQevbsKStWrJAMGTJI586dZfTo0ZLCWa1MzM2B/v37y7Zt26RAgQIydOhQsz6xbjR//Lj3RvMBUnX0re0XnS/DrkefNiLV7aqjoTeuS0g01S2sC9lETZvqdpWP0Bs3JCQywu9pQ27elNCIm/5Jm/J2dVB/po1MkVIc/1UHjVXaiAgJvRlN9aKwFOL47zcTm7RaTSfsxnX/p3U4bu3DfkjrCA2TSJcq4/5LGyqR+t39R4P0RE8bi989x4jEPUYMvC8f1csTqHp5SMhYqo4GUNVRqpdTvZzq5bdwjIj6WzYdqQVw9XITE+bOfceO1OJUvVzVqlXLDAu2Zs0a2bRpk/lA/aBKlSqZYFuD8Pj4/fff5aOPPpLy5cu7Te/Xr58pZdfq6xr09u7dW1q2bGnyoSIiIqRp06aSJ08eWbt2rRw9etSUzqdMmVLe1Op4IrJv3z6TpkePHvLll1+a6vBPP/20GWtcg/hY0S/O9cuLLl1slhlTrm0svboddLteMN+J60V70kirP8yUfk+rQVyEy82aZJU2LEwirItrP6bVQMA1MPJbWg36klJajwAx0dLG4nfPMSL2af36+7SC6Cjtj+/ArrT6m4/p7z42aXU9Y3qei01ave6I8fkzxL29YKKklYBI63oR7M+0N5JYWg2KbgdG/kurQVxEMk2rwXd4DPtkjk1ah01pA+N3zzEiLr9Pr/1nJXRavTbw1qQ4uhvD/gi6lQbWGnzrw58uXbok7du3l08++UTeeOMN53S9gzBlyhSZMWOGqe6udHzwUqVKya+//irVq1eXH3/8UbZv3y4//fSTKf2uWLGiGVdcxw7XkvpUqVLJ5MmTpUiRIvLOO++YZej7teR+/PjxsQ+6AQAAAACwI+i2S69evUxJtHbS5hp0b9iwQW7cuOHWeVvJkiWlYMGCsm7dOhN063O5cuXcqptrIK3VzbUquZbEaxrPDuA0TV+rsyQvtCq7Pixasq8iIyPNI2DFfhh2AEAiCOhzSTLjWqkAABC4IgP83BjT/MUq6NZ22toWOjYl4Vp1Oza0rfbGjRtN9XJPx44dMyXVWbJkcZuuAbbOs9K4BtzWfGtedGk0kL569aqkTXurd0pX2iZ8xIgRUaafPHnStDMPVBmu+ujhGAAQUE6ciGaYMvhVlSrpEzsLAIAYOOFrBJYAcfHi7aa8fgu69+/fbx4xFdt23YcOHTKdpi1dulTSxKZdcwLQDt204zWLBujaAVvOnDmjbTSf2C4diWEbOwBAosqVK3tiZyFobNhwObGzAACIgVzWEJ0BKqYxa6yCbq1+rUGxXbT6uN7NqFy5snOadoy2evVq+eCDD2TJkiVy/fp1OXfunFtptw5Vph2nKX1ev36923J1vjXPeramuabR4NlbKbdKnTq1eXjr1V0fASueHdoBABJGQJ9LkpkAr60IAEgi58aY5i9WQbcGuoUKFRK7NGjQQP766y+3aV26dDHttrUjNC1Z1l7Itcp6q1atzPydO3eaIcJq1KhhXuvzqFGjTPBu3RnRknMNqEuXLu1M88MPP7h9jqaxlgEAAAAAQLLrSC1jxoxStmxZt2np06eX7NmzO6d369bNVPPOli2bCaT79OljgmXtRE01atTIBNcdO3aUMWPGmPbbOga3ds5mlVTrUGFacj5o0CDp2rWrLF++XGbNmmWGIgMAAAAAIFkG3TGhw3ppMb6WdGtv4trr+KRJk5zzw8LCZMGCBaa3cg3GNWjv3LmzjBw50plGhwvTAFvH/J4wYYLkz59fPv30U4YLAwAAAAAEV9Dt2Vu6NlafOHGiefiiVeA9q497qlu3rmzatMlv+QQAAAAAIM5B94oVK6Rw4cIxTQ4AAAAAQNCLcdBdp04de3MCAAAAAEAyE9h9sAMAAAAAkIQRdAMAAAAAYBOCbgAAAAAAbELQDQAAAACATQi6AQAAAAAIpKA7LCxMXn/99WjTjBo1SlKkCPhhwAEAAAAACKyg2+FwmEdM0gEAAAAAEKxsq15+8uRJSZs2rV2LBwAAAAAg4MW4/vcXX3zh9nrz5s1RpqmIiAg5dOiQmVe2bFn/5BIAAAAAgOQcdD/11FMSEhJi/tfn77//3jx8VSnXUu7XXnvNn3kFAAAAACB5Bt1Tp051BtVdu3aVFi1aSPPmzb12spYtWzapUaOGZM2a1b+5BQAAAAAgOQbdnTt3dv6/atUqeeyxx+TRRx+1K18AAAAAACR5cRrTyyr1BgAAAAAAfg66Dx48GOO0BQsWjMtHAAAAAAAQnEF34cKFnZ2qRUfT3Lx5My4fAQAAAABAcAbdnTp18hp0nz9/Xv7880/Zt2+f1KlTxwTnAAAAAAAEqzgF3dOmTfM5T3s3f+edd2TMmDEyZcqU+OQNAAAAAIAkLdTfC9QS8AEDBkiZMmVk4MCB/l48AAAAAADBG3RbqlatKsuXL7dr8QAAAAAABG/QvXfvXjpRAwAAAAAEtTi16fYlMjJS/v33X9Pm+/vvv5cGDRr4c/EAAAAAACT/oDs0NDTaIcO0M7WsWbOaDtUAAAAAAAhWcQq6a9eu7TXo1mBcg+17771XunTpIrly5fJHHgEAAAAACJ6ge+XKlf7PCQAAAAAAyYxtHakBAAAAABDs4tWRWnh4uPzwww+yadMmOX/+vGTOnFkqVaokTZo0kdSpU/svlwAAAAAABFPQPW/ePHnmmWfk5MmTpuM0i7b11rbcH3/8sTRr1sxf+QQAAAAAIDiC7mXLlkmrVq0kLCxMunbtKg888IDkzp1bjh8/LqtXr5bp06dLy5YtZcmSJVK/fn3/5xoAAAAAgOQadA8fPlzSpk0ra9eulbJly7rN69Spkzz//PNSs2ZNk46gGwAAAAAQrOLUkZq24X7yySejBNyW8uXLyxNPPCEbN26Mb/4AAAAAAAiuoDtdunSSM2fOaNNou25NBwAAAABAsIpT0N2wYUP56aefok2j8x988MG45gsAAAAAgOAMuseNGycnTpww7bcPHTrkNk9fd+zYUU6dOmXSAQAAAAAQrOLUkZoG1VmzZpUvv/xSvv76aylYsKCz9/KDBw9KRESEadfdoUMHt/fpcGLa8zkAAAAAAMEgTkH3ypUrnf/fvHlT/vnnH/Nw9eeff0Z5nwbdAAAAAAAEizgF3ZGRkf7PCQAAAAAAyUyc2nQDAAAAAACbgu769evLF198EW2a6dOnm3QAAAAAAASr0Li26d6/f3+0aQ4cOCCrVq2Ka74AAAAAAEjybKtefvnyZUmZMqVdiwcAAAAAIPl0pKZDgbk6d+5clGlKhwvTsbq/+eYbKVy4sH9yCQAAAABAcg66NYC2hvzS5wkTJpiHLw6HQ8aOHeufXAIAAAAAkJyD7k6dOplgW4Np7UStQoUKUrFixSjpwsLCJFu2bKYTtYceesjf+QUAAAAAIPkF3dOmTXP+rx2kdenSRZ5//nm78gUAAAAAQPAE3a727dvn/5wAAAAAAJDM2NZ7eVx9+OGHUr58ecmUKZN51KhRQxYtWuScf+3aNenVq5dkz55dMmTIIK1atZLjx4+7LUM7eGvatKmkS5dOcuXKJQMHDpSbN29GGfascuXKkjp1ailatKhbST4AAAAAAIlW0n333XfHKJ22Ad+7d2+slp0/f3556623pFixYqb9+Oeffy7NmzeXTZs2SZkyZaRfv36ycOFCmT17tmTOnFl69+4tLVu2lDVr1jh7T9eAO0+ePLJ27Vo5evSoaY+uw5e9+eabzpJ6TdOjRw/58ssvZdmyZfL0009L3rx5pXHjxnHYIgAAAAAARBXi0Mg2llx7Mnd1/vx5M5SY0gA2VapUfqmKrh2zaU/ojz/+uOTMmVNmzJhh/lc7duyQUqVKybp166R69eqmVPyRRx6RI0eOSO7cuU2ayZMny+DBg+XkyZMmT/q/Bu5bt251fkabNm1M3hcvXhyjPF24cMEE/brOWiIfqN7adCqxswAAiIGXKuVI7CwEjZCQcYmdBQBADDgcAySQxTQmjFNJ9/79+6Od179/f1Ple+nSpRIfWmqtJdqXL1821cw3bNggN27ckIYNGzrTlCxZUgoWLOgMuvW5XLlyzoBbael1z549Zdu2bVKpUiWTxnUZVpq+ffv6zEt4eLh5uG5gFRkZaR4BK/b3VAAAiSCgzyXJTGjANa4DACTFc2NM8xenoPtOpeAzZ840Q4q98sorMn78+Fgv46+//jJBtrbf1nbbc+fOldKlS8vmzZtNSXWWLFnc0muAfezYMfO/PrsG3NZ8a150aTSQvnr1qqRNmzZKnkaPHi0jRoyIMl1LzzWfgSrD1Vs3BwAAge3EiYjEzkLQqFIlfWJnAQAQAydOnJBAdvHixcQJupW2n37wwQdl1qxZcQq6S5QoYQJsLaafM2eOdO7c2QxTlpiGDBliSvAtGqAXKFDAVHcP5Orll46EJXYWAAAxkCtX9sTOQtDYsOFyYmcBABAD2il2IEuTJk3iBd3qypUrcubMmTi9V0uztUdxVaVKFfn9999lwoQJ8uSTT8r169dN22vX0m6tyq4dpyl9Xr9+vdvyrN7NXdN49niurzV49lbKrbSXc314Cg0NNY+A5aXtPQAg8AT0uSSZCfDaigCAJHJujGn+bFmLn3/+Wb766itTYu2vuvLanloDcC1F197GLTt37jRDhGl1dKXPWj3dtSqCti3XgFqrqFtpXJdhpbGWAQAAAACAP8SppLt+/fpep+tY2P/++6+zo7Vhw4bFqRr3ww8/bDpH0zry2lO5jqm9ZMkS0zNct27dTDVv7dFcA+k+ffqYYFk7UVONGjUywXXHjh1lzJgxpv320KFDzdjeVkm1DhX2wQcfyKBBg6Rr166yfPlyUxVeezQHAAAAACBRg24Ngr3RYcSyZs1qAl8NjLVdd2xpCbWOq63ja2uQXb58eRNwW8vSNuJajN+qVStT+q29jk+aNMn5/rCwMFmwYIHprVyD8fTp05s24SNHjnSmKVKkiAmwdcxvrbauY4N/+umnjNENAAAAAEj8cbrBON0AAP9inO6EwzjdAJA0OJLJON2B3TIdAAAAAIAkLF69l2v7ba0GrvLmzSt33XWXv/IFAAAAAEDwBd2XLl2ScePGyWeffWaCblcadGtHZy+++KJkyJDBn/kEAAAAACB5B9179+41PYvrszYFz5cvnxQoUMDMO3TokBw+fNh0WKY9ji9evNh0WAYAAAAAQLCKcZtu7Sm8adOmsmfPHmnbtq38/fffJshet26deej/Oq1du3aye/duadKkiXkPAAAAAADBKsZB94cffii7du2S4cOHy/Tp06VEiRJR0ui0//3vfzJixAjZuXOnTJ482d/5BQAAAAAg+QXd33zzjRQtWlSGDRt2x7RDhw6VYsWKyezZs+ObPwAAAAAAkn/QvX37dmnUqJGEhITcMa2m0bRa3RwAAAAAgGAV46D78uXLZuDvmNLBwfU9AAAAAAAEqxgH3bly5TKdqMWU9nCeM2fOuOYLAAAAAIDgCbpr1KghixYtkmPHjt0xraZZuHCh1KxZM775AwAAAAAg+QfdPXr0kEuXLsljjz0mp06d8pnu9OnTJs2VK1fkmWee8Vc+AQAAAABIclLENGG9evWke/fu8sknn0ipUqXk2Weflfr160uBAgXM/EOHDsmyZcvMfA3Ku3XrZuYDAAAAABCsYhx0q0mTJpkO0saPHy+jR482D1cOh0NCQ0OlX79+MmbMGH/nFQAAAACA5Bt0h4WFydixY0218WnTpsm6deucbbzz5Mkj999/v3Tq1EmKFy9uV34BAAAAAEieQbelWLFiMmrUKP/nBgAAAACAYOxIDQAAAAAAxA5BNwAAAAAANiHoBgAAAADAJgTdAAAAAADYhKAbAAAAAACbEHQDAAAAAGATgm4AAAAAAGxC0A0AAAAAgE0IugEAAAAAsAlBNwAAAAAANiHoBgAAAADAJgTdAAAAAADYhKAbAAAAAACbEHQDAAAAAGATgm4AAAAAAGxC0A0AAAAAgE0IugEAAAAAsAlBNwAAAAAANiHoBgAAAADAJgTdAAAAAADYhKAbAAAAAACbEHQDAAAAAGATgm4AAAAAAGxC0A0AAAAAgE0IugEAAAAAsAlBNwAAAAAANiHoBgAAAADAJgTdAAAAAADYhKAbAAAAAACbEHQDAAAAAGATgm4AAAAAAIIl6B49erTce++9kjFjRsmVK5e0aNFCdu7c6Zbm2rVr0qtXL8mePbtkyJBBWrVqJcePH3dLc/DgQWnatKmkS5fOLGfgwIFy8+ZNtzQrV66UypUrS+rUqaVo0aIybdq0BFlHAAAAAEBwCLige9WqVSag/vXXX2Xp0qVy48YNadSokVy+fNmZpl+/fjJ//nyZPXu2SX/kyBFp2bKlc35ERIQJuK9fvy5r166Vzz//3ATUw4YNc6bZt2+fSVOvXj3ZvHmz9O3bV55++mlZsmRJgq8zAAAAACB5CnE4HA4JYCdPnjQl1Rpc165dW86fPy85c+aUGTNmyOOPP27S7NixQ0qVKiXr1q2T6tWry6JFi+SRRx4xwXju3LlNmsmTJ8vgwYPN8lKlSmX+X7hwoWzdutX5WW3atJFz587J4sWL75ivCxcuSObMmU1+MmXKJIHqrU2nEjsLAIAYeKlSjsTOQtAICRmX2FkAAMSAwzFAAllMY8IUEuB0BVS2bNnM84YNG0zpd8OGDZ1pSpYsKQULFnQG3fpcrlw5Z8CtGjduLD179pRt27ZJpUqVTBrXZVhptMTbm/DwcPNw3cAqMjLSPAJWYN9TAQD8J6DPJclMaMDV8wMAJMVzY0zzlyLQV0KD4Jo1a0rZsmXNtGPHjpmS6ixZsril1QBb51lpXANua741L7o0GkxfvXpV0qZNG6Wt+YgRI6LkUUvOtY15oMpw9dbNAQBAYDtxIiKxsxA0qlRJn9hZAADEwIkTJySQXbx4MekH3dq2W6t///LLL4mdFRkyZIj079/f+VqD8wIFCpiq7oFcvfzSkbDEzgIAIAZy5cqe2FkIGhs23O4nBgAQuHLlyiWBLE2aNEk76O7du7csWLBAVq9eLfnz53dOz5Mnj+kgTdteu5Z2a+/lOs9Ks379erflWb2bu6bx7PFcX2sA7VnKrbSHc314Cg0NNY+AFRKS2DkAAMRAQJ9LkpkAr60IAEgi58aY5i/g1kL7ddOAe+7cubJ8+XIpUqSI2/wqVapIypQpZdmyZc5pOqSYDhFWo0YN81qf//rrL7fqCNoTugbUpUuXdqZxXYaVxloGAAAAAADxlSIQq5Rrz+Tff/+9GavbaoOtvcJpCbQ+d+vWzVT11s7VNJDu06ePCZa1EzWlQ4xpcN2xY0cZM2aMWcbQoUPNsq3S6h49esgHH3wggwYNkq5du5oAf9asWaZHcwAAAAAA/CHgSro//PBD02N53bp1JW/evM7HzJkznWnGjx9vhgRr1aqVGUZMq4p/++23zvlhYWGmaro+azDeoUMH6dSpk4wcOdKZRkvQNcDW0u0KFSrIO++8I59++qnpwRwAAAAAgKAYpztQMU43AMCfGKc74TBONwAkDY5kMk53wJV0AwAAAACQXBB0AwAAAABgE4JuAAAAAABsQtANAAAAAIBNCLoBAAAAALAJQTcAAAAAADYh6AYAAAAAwCYE3QAAAAAA2ISgGwAAAAAAmxB0AwAAAABgE4JuAAAAAABsQtANAAAAAIBNCLoBAAAAALAJQTcAAAAAADYh6AYAAAAAwCYE3QAAAAAA2ISgGwAAAAAAmxB0AwAAAABgE4JuAAAAAABsQtANAAAAAIBNCLoBAAAAALAJQTcAAAAAADYh6AYAAAAAwCYE3QAAAAAA2ISgGwAAAAAAmxB0AwAAAABgE4JuAAAAAABsQtANAAAAAIBNCLoBAAAAALAJQTcAAAAAADYh6AYAAAAAwCYE3QAAAAAA2ISgGwAAAAAAmxB0AwAAAABgE4JuAAAAAABsQtANAAAAAIBNCLoBAAAAALAJQTcAAAAAADYh6AYAAAAAwCYE3QAAAAAA2ISgGwAAAAAAmxB0AwAAAABgE4JuAAAAAABsQtANAAAAAIBNCLoBAAAAALAJQTcAAAAAAMESdK9evVqaNWsm+fLlk5CQEPnuu+/c5jscDhk2bJjkzZtX0qZNKw0bNpTdu3e7pTlz5oy0b99eMmXKJFmyZJFu3brJpUuX3NJs2bJFHnjgAUmTJo0UKFBAxowZkyDrBwAAAAAIHgEXdF++fFkqVKggEydO9Dpfg+P3339fJk+eLL/99pukT59eGjduLNeuXXOm0YB727ZtsnTpUlmwYIEJ5J955hnn/AsXLkijRo2kUKFCsmHDBhk7dqy89tpr8vHHHyfIOgIAAAAAgkMKCTAPP/yweXijpdzvvfeeDB06VJo3b26mffHFF5I7d25TIt6mTRv5+++/ZfHixfL7779L1apVTZr/+7//kyZNmsi4ceNMCfqXX34p169fl88++0xSpUolZcqUkc2bN8u7777rFpwDAAAAAJCsSrqjs2/fPjl27JipUm7JnDmzVKtWTdatW2de67NWKbcCbqXpQ0NDTcm4laZ27dom4LZoafnOnTvl7NmzCbpOAAAAAIDkK+BKuqOjAbfSkm1X+tqap8+5cuVym58iRQrJli2bW5oiRYpEWYY1L2vWrFE+Ozw83Dxcq6iryMhI8whYDkdi5wAAEAMBfS5JZkKTVJEDAASvyAA/N8Y0f0kq6E5Mo0ePlhEjRkSZfvLkSbf25IEmw9VbNwcAAIHtxImIxM5C0KhSJX1iZwEAEAMnTpyQQHbx4sXkF3TnyZPHPB8/ftz0Xm7R1xUrVnSm8fxybt68aXo0t96vz/oeV9ZrK42nIUOGSP/+/d1KurXX85w5c5pe0gPVpSNhiZ0FAEAM5MqVPbGzEDQ2bLic2FkAAMSAZw3mQKMjYSW7oFurhGtQvGzZMmeQrcGvttXu2bOneV2jRg05d+6c6ZW8SpUqZtry5ctN0b+2/bbSvPLKK3Ljxg1JmTKlmaY9nZcoUcJr1XKVOnVq8/CkbcX1EbBCQhI7BwCAGAjoc0kyE+C1FQEASeTcGNP8Bdxa6Hja2pO4PqzO0/T/gwcPmnG7+/btK2+88YbMmzdP/vrrL+nUqZPpkbxFixYmfalSpeShhx6S7t27y/r162XNmjXSu3dv07O5plPt2rUznajp+N06tNjMmTNlwoQJbiXZAAAAAADEV8CVdP/xxx9Sr14952srEO7cubNMmzZNBg0aZMby1qG9tES7Vq1aZogw16J9HRJMA+0GDRqYuw+tWrUyY3u79nj+448/Sq9evUxpeI4cOWTYsGEMFwYAAAAA8KsQhw5+jVjTau0avJ8/fz6g23S/telUYmcBABADL1XKkdhZCBohIeMSOwsAgBhwOAZIcogJA656OQAAAAAAyQVBNwAAAAAANiHoBgAAAADAJgTdAAAAAADYhKAbAAAAAACbEHQDAAAAAGATgm4AAAAAAGxC0A0AAAAAgE0IugEAAAAAsAlBNwAAAAAANiHoBgAAAADAJgTdAAAAAADYhKAbAAAAAACbEHQDAAAAAGATgm4AAAAAAGxC0A0AAAAAgE0IugEAAAAAsAlBNwAAAAAANiHoBgAAAADAJgTdAAAAAADYhKAbAAAAAACbEHQDAAAAAGATgm4AAAAAAGxC0A0AAAAAgE0IugEAAAAAsAlBNwAAAAAANiHoBgAAAADAJgTdAAAAAADYhKAbAAAAAACbEHQDAAAAAGATgm4AAAAAAGxC0A0AAAAAgE0IugEAAAAAsAlBNwAAAAAANiHoBgAAAADAJgTdAAAAAADYhKAbAAAAAACbEHQDAAAAAGATgm4AAAAAAGxC0A0AAAAAgE0IugEAAAAAsAlBNwAAAAAANiHoBgAAAADAJgTdAAAAAADYhKAbAAAAAACbEHQDAAAAAGATgm4AAAAAAGwS9EH3xIkTpXDhwpImTRqpVq2arF+/PrGzBAAAAABIJoI66J45c6b0799fhg8fLhs3bpQKFSpI48aN5cSJE4mdNQAAAABAMhDUQfe7774r3bt3ly5dukjp0qVl8uTJki5dOvnss88SO2sAAAAAgGQgaIPu69evy4YNG6Rhw4bOaaGhoeb1unXrEjVvAAAAAIDkIYUEqVOnTklERITkzp3bbbq+3rFjR5T04eHh5mE5f/68eT537pxERkZKoLp28UJiZwEAEAPnzgXtKTnBhYRcS+wsAABiQGOtQHbhwq1Yy+FwRJuOM3wMjR49WkaMGBFleqFChRIlPwCA5CXqGQYAgOCWNeurkhRcvHhRMmfO7HN+0AbdOXLkkLCwMDl+/LjbdH2dJ0+eKOmHDBliOl2zaOn2mTNnJHv27BISEpIgeQZw645igQIF5NChQ5IpU6bEzg4AAImOcyOQOLSEWwPufPnyRZsuaIPuVKlSSZUqVWTZsmXSokULZyCtr3v37h0lferUqc3DVZYsWRIsvwDc6UUFFxYAANzGuRFIeNGVcEuwB91KS647d+4sVatWlfvuu0/ee+89uXz5sunNHAAAAACA+ArqoPvJJ5+UkydPyrBhw+TYsWNSsWJFWbx4cZTO1QAAAAAAiIugDrqVViX3Vp0cQGDSZh7Dhw+P0twDAIBgxbkRCGwhjjv1bw4AAAAAAOIkNG5vAwAAAAAAd0LQDQAAAACATQi6gSRKx4f/7rvvbP+cunXrSt++fW3/HAAA4otzI4BARNANBCDtTb9Pnz5y9913m05RChQoIM2aNTPjyCdFzz77rNxzzz2SNm1ayZkzpzRv3lx27NgR7Xueeuopc/Hk+njooYeifY+ORtCzZ08pWLCg2W558uSRxo0by5o1ayTQvPbaa2bEhPi6du2a2VblypWTFClSSIsWLfySPwAINJwbOTfG1MqVK832zJs3r6RPn94s88svv/RLHoG4CPrey4FAs3//fqlZs6ZkyZJFxo4da4KpGzduyJIlS6RXr153PCEHoipVqkj79u3NCf/MmTPmpNqoUSPZt2+fhIWF+XyfXkhMnTrV+fpOvbK2atVKrl+/Lp9//rm5KDt+/Li5GDt9+rQkVxEREeaC7fnnn5dvvvkmsbMDALbg3Hgb58Y7W7t2rZQvX14GDx5shgJesGCBdOrUSTJnziyPPPJIYmcPwUh7LwcQOB5++GHHXXfd5bh06VKUeWfPnnX+rz/fuXPnOl8PGjTIUaxYMUfatGkdRYoUcQwdOtRx/fp15/zOnTs7mjdv7ra8F154wVGnTh3na/3Mjh07OtKnT+/IkyePY9y4cWa+prNcu3bN8eKLLzry5cvnSJcuneO+++5zrFixIlbr+Oeff5r879mzx2cab/mNjm4bXebKlSujTXfgwAHHo48+atYxY8aMjtatWzuOHTvmnD98+HBHhQoVHF988YWjUKFCjkyZMjmefPJJx4ULF5xpdJv06dPHMXDgQEfWrFkduXPnNu/zzE+3bt0cOXLkMJ9Tr149x+bNm828qVOnmry6PnSapyVLljhSp07t9r2r559/3iwvvtsMAJIKzo2+8xsdzo23NWnSxNGlS5cYbDXA/6heDgQQvdO9ePFic9deq0N50jv8vmTMmFGmTZsm27dvlwkTJsgnn3wi48ePj9XnDxw4UFatWiXff/+9/Pjjj6Z61saNG93S6Lj269atk6+//lq2bNkirVu3Nnfdd+/eHaPPuHz5srlDX6RIEVM1MDr6+bly5ZISJUqYqnHR3ZXPkCGDeWhbvvDwcK9pIiMjTXUz3c66nkuXLpV//vlHnnzySbd0e/fuNcvRO+P60LRvvfWWWxotMdDv6LfffpMxY8bIyJEjzfIsul1OnDghixYtkg0bNkjlypWlQYMG5rP181588UUpU6aMHD161Dw886A0vX7nriXYWrI9c+ZMUzoCAMGAc6M7zo1xOzeeP39esmXL5nM+YCsbAnkAcfTbb7+ZO7vffvvtHdN63s33NHbsWEeVKlVifDf/4sWLjlSpUjlmzZrlnH/69GlTOmDdzdc74WFhYY5///3XbTkNGjRwDBkyJNr8Tpw40dxB13yXKFEi2jv56quvvnJ8//33ji1btpj1LFWqlOPee+913Lx50+d75syZY+6up0mTxnH//febPGnJgeXHH380+T948KBz2rZt20ye1q9fb17rXXktpXC9e6937atVq+Z8rdusVq1abp+teRs8eLD5/+effzalAFry4eqee+5xfPTRR26lBnei275+/fp3vMOvKOkGkBxxbryNc2Psz41q5syZ5nvcunXrHZcN2IGSbiCA3LpeiBu9w6vt3bSDFL2rPXToUDl48GCM3693sLXNV7Vq1ZzT9I6w3km3/PXXX+ZucvHixZ13z/Whd7v1/dHRu8+bNm0yafX9TzzxhOkEzJc2bdrIo48+atrtaedgelf9999/N3f4o2u3duTIEZk3b54pYdC0ehddSznU33//bUoQXEsRSpcube6Y6zxL4cKFTemIRTti0TvzrrStmCvXNH/++adcunRJsmfP7radtJ3enbaTt+2m66HrpbQjmKZNm0ZbsgMAyQnnxts4N8b+3LhixQrp0qWLqeWgpehAYqAjNSCAFCtWzPREGtsOYbRKm56ARowYYXok1Y5CtIrbO++840wTGhoa5cJFO6GJDT1ZaucuWiXMs5MXPXFGR/OkD13H6tWrS9asWWXu3LnStm3bGH22dv6SI0cO2bNnj6la5kuaNGnkwQcfNI9XX31Vnn76aRk+fLjp8TWmUqZM6fZavxOtfhfTNLqd9ELD20VQbIPle++91/Ruq9+nViPUbWZdKAFAMODc6BvnxujPjXozQ3u41yYF2pEakFgIuoEAonfP9cJg4sSJpjdqz7Zr586d83pi0l46CxUqJK+88opz2oEDB9zS6HAkW7dudZu2efNm5wlST176v7bD0p5U1dmzZ2XXrl1Sp04d87pSpUrmbr7etX7ggQfivJ56gaMPX+3LvDl8+LBpt6Yn7NjQu/XWmK2lSpWSQ4cOmYd1R1/b+el21XT+oiUIOrSNDuGlJQPepEqVymzLmNCLRr2Lnz9/fnOBqHfzASBYcG70jXOj73OjBvfaU/nbb78tzzzzjF/WAYgrqpcDAUYvKvSEc99995lOQrQTFq3e9f7770uNGjW8vkfvkGt1Ob3jq1W0NK3e9XVVv359+eOPP+SLL74wy9Q73K4XGno3vlu3bqbDmOXLl5t5egdcT2QWrfqmJzm9W/ztt9+aKmHr16+X0aNHy8KFC73mTTtj0flaAqB51Isg7UhFh7lq0qSJM13JkiWdeda74ZqPX3/91QwTo0ObaCcvRYsWNRde3uhFh67j9OnTTSc2mrfZs2ebjlz0vaphw4amSp6ug3aCo3nXddELp6pVq4q/6Ofod6VV/7TTHV0HXW+98NPvQOkFh+ZRL+5OnToV7UWWld9Ro0bJ448/HmV4GL040uVoRzTaUYz+rw8ASC44N3JujM25UauUaxCuN2m0er0G+/rQ8ySQKGxpKQ4gXo4cOeLo1auXGZZDO/7QYVJ0KA/X4Uc8O4vRDk2yZ8/uyJAhgxnGY/z48Y7MmTO7LXfYsGFmCA+d3q9fP0fv3r3dhkXRDmM6dOhgOkvRdGPGjIkyLIoOtaLLKVy4sCNlypSOvHnzOh577DHTqYs32rGMDvWSK1cukz5//vyOdu3aOXbs2OGWznVokCtXrjgaNWrkyJkzp3mPbofu3bu7DV/iSTtmeemllxyVK1c266froJ3S6PAwurzYDoviSrel5sHiuU2UdsSjHfJYtLMZHTpFh4/RdShQoICjffv2zo5qNL+tWrVyZMmSxeewKK50+BlNt3z58ijzNG+ew6xweAeQ3HBu5NwY03Ojfqa386Lr9wokpBD9kzjhPgAAAAAAyRvVywEAAAAAsAlBNwAAAAAANiHoBgAAAADAJgTdAAAAAADYhKAbAAAAAACbEHQDAAAAAGATgm4AAAAAAGxC0A0AAAAAgE0IugEASMKmTZsmISEh5jk+dBl169aV5GT//v1mvZ566qnEzgoAIIgRdAMAEIdATh958uSRmzdvek33999/O9MVLlxYkov777/frNO6deuiTbd7926TrkSJEgmWNwAAAhFBNwAAcZAiRQo5fvy4/PDDD17nT5kyRUJDQ80jOenWrZt5/uyzz6JNZ83v2rWrJJa77rrL3PwYPXp0ouUBAIDkdSUAAEAClvhmzpzZa/Cppd/Tp0+Xhg0bSsqUKSU5efLJJyVDhgwyc+ZMuXLlitc0ERER8sUXX5gbE507d5bEotu+ZMmSkjdv3kTLAwAABN0AAMRB2rRppU2bNrJw4UI5ceKE27wFCxaYUvDoSnkvX74sw4cPN0FhmjRpJFu2bNK0aVNZs2aN1/RnzpyRHj16SO7cuSVdunRy7733yty5c6PN45YtW0weNehMlSqVFCpUSPr06SOnT5+O41qLCbifeOIJuXjxosyePdtrmsWLF8uRI0ekSZMmpgq+cjgc5gZFzZo1JVOmTGYdqlat6vWmxWuvvWaqpq9cudK0Va9cubJJb7U5j4yMlE8//VTuu+8+s930u8ifP780a9bMvCcmbboPHDhgSu21NFy3jb5fXx88eDBKWv1cXc6NGzdM3rS5QOrUqaV48eIyadKkOG9LAEBwIOgGACCONKjWUu3//e9/btM1kNRgsEWLFl7fd+3aNalfv76MHDlS0qdPL3379pXmzZvLihUrpE6dOlGCWS1R1sDvo48+knvuuUdeeOEF01ZaS53nzJnj9TPmzZtnglJ91vfqZ5QrV04++OADqVGjhpw9e9a2KuZTp051S6cBd/v27c3rkydPSrt27eTpp582Nx502oABA7wuZ+zYsfLcc8+ZdX3++edNwK6GDBki3bt3NzcidFm6bro9t23bJj/99NMd879r1y5z00LzX6VKFXnxxRelUqVK5rXeCND53rRt29akady4scm3fn6vXr3kk08+ieGWAwAEJQcAAIixffv2OfT02bhxY/O6bNmyjjJlyjjnHz161JEiRQpHnz59zOvUqVM7ChUq5LaMESNGmGW0b9/eERkZ6Zy+ceNGR6pUqRxZsmRxXLhwwTl9+PDhJn337t3dlrN48WIzXR9Tp051Tj916pQjU6ZMjrvuusuxf/9+t/d89dVXJn3v3r3dpuu0OnXqxHg7lCxZ0hESEuLYs2eP2/STJ0+adciTJ4/jxo0bZtrHH39slt+lSxfH9evXnWnDw8MdzZo1M/P++OOPKOubPn16x5YtW6J8drZs2Rz58uVzXL58Ocq806dPR/muOnfu7JamXr16ZvpHH33kNn3ixIlmev369d2m63bR6dWqVXOcP3/eOX3Hjh3muy5RokSMthkAIDhR0g0AQDxLu7WE9bfffjOvP//8c1P6HV3Vck2j7Y3feustU23ZoqWt2gb63Llz8t133zmna/torQKtJeOutMS1QYMGUZav6S9cuGA6ENMq5a60urlW1/7666/jtd5a0mtVGXelbdmvX78unTp1Mm26lZaua4n+xIkT3dq46zqNGjXK/P/VV19F+YxnnnnGlM57o+8NCwuLMl1rGERHq49rjYLSpUub0nJXWn1fq/svX75cDh06FOW9uj21arxFS+C19H3nzp2muj0AAN7cOhsCAIA46dChgwwePNgEn9WqVTNVqzV4rlixotf0Ggz/888/UqpUKdOO2FO9evVMdeXNmzdLx44dTfp9+/aZINFqH+3qgQcekGXLlrlN+/XXX82z3gjYu3ev1+rtp06dMo8cOXLEab01qH755ZdNgP/66687e2m3qpZbNx20avxff/0l+fLlk7fffjvKcrSdtNqxY0eUeVo93hu9caBtqcuWLWv+122mVea1bfed6HZVWo3f9YaH0nWoXbu2yYumK1CggNt8rYruyfoO9UZJxowZ7/j5AIDgQ9ANAEA85MyZ03TgpSXHrVu3NqWe//d//+czvQbRSjtE88bqadtKZz3nypXLa3pvy9G2xkpLlqOjbarjGnRrfnS9v/32W1myZIk8/PDD8scff5jO22rVquUcn1vbjmuJ+L///isjRoyINi+efG2jCRMmSJEiRUyA/8Ybb5iHdkanHby988470a5TbLe/K9dSbotVmq89tgMA4A3VywEAiCetaq1BmvaSrcGfdhrmixW4ae/m3hw7dswtnfXs2UO6xdtyrPdoCbMGvL4enlXPY8vqKE3HJPfWgZprXrSUOLq8aJVvT54l0a6Brna+ptX6NZifMWOGKfHXUvfotn1ctj8AAPFF0A0AQDxp22odekoDQO2xPGvWrD7TajB39913y549e0x6T9aQV1b1dE2vpbqa3goIXf38889Rpmk1d7Vu3TpJiPWeP3++HD582LTL1irWWuJv0ddalf7vv/82VbD9Tauta6/iOkxZ0aJFTe/lV69e9Zne2q6rV682wb4rfa3TXdMBABBfBN0AAMSTduilHZ/puNna2dadaGdp2pZZh75yDfy0araOS505c2a34ca0bbd2TjZs2DC35fz4449R2nOrLl26mGD3lVdeMaXBnrSdtdXuO77rraX7mjdtW61VyfVZO01zpcN96Wdqx2XeqpFrm3UdUzsmwsPDZe3atVGm63IvXbpkOmqz2pd7U7BgQdMGXLeLZydwH3/8sbk5oMOPebbnBgAgrmjTDQCAH+j4zvqIiUGDBsnChQvN+N4a5GkP5Fp9fObMmabnc+1IzbVTLk2vbad1ugaL2tmX9q49a9Ysadq0qVmWZztzLXXWEucKFSrIQw89ZHrl1oBVg9tVq1bJ/fffb0qH40s7THvzzTdlzZo1UaqWW5599lkT5Guv7ZquYcOGpoRaq3hrp2Xa4ZtWES9cuPAdP09LsbXH8OLFi5sq6xpEa7C9YMECUxNAq52nTp062mV8+OGHpt253gTQUnrtpE63q45prttO5wMA4C8E3QAAJDBt963DUmlv3hpojx8/XtKlS2d61NYewTUgdKUlxxooa8m4lqZv3LhRypQpY957/vz5KEG30mB806ZNMnbsWFPleunSpWY52tu2loRrr+v+oFXl69ata9pka56squ2ebbO1BL9JkybmxoEGyBooa2dsxYoVk3HjxplAPCZ0HXS7aQm/Vq3XmxVanV87btNaBlrSfieaVjt9047d9MaDbj8NtnW7DB8+PN5t3QEAcBWig3W7TQEAAAAAAH5Bm24AAAAAAGxC0A0AAAAAgE0IugEAAAAAsAlBNwAAAAAANiHoBgAAAADAJgTdAAAAAADYhKAbAAAAAACbEHQDAAAAAGATgm4AAAAAAGxC0A0AAAAAgE0IugEAAAAAsAlBNwAAAAAANiHoBgAAAABA7PH/EGyiplu9GNsAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1000x600 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Create a dataframe for visualization\n",
+    "df = pd.DataFrame({\n",
+    "    'Model': list(results.keys()),\n",
+    "    'Output Tokens': [r.get('output_tokens', 0) for r in results.values()],\n",
+    "    'Stop Reason': [r.get('stop_reason', 'N/A') for r in results.values()]\n",
+    "})\n",
+    "\n",
+    "# Create the visualization\n",
+    "plt.figure(figsize=(10, 6))\n",
+    "bars = plt.bar(df['Model'], df['Output Tokens'], color=['skyblue', 'darkblue'])\n",
+    "\n",
+    "# Add labels and title\n",
+    "plt.title('Claude 3.5 Sonnet Output Token Limit Comparison', fontsize=16)\n",
+    "plt.xlabel('Model Version', fontsize=14)\n",
+    "plt.ylabel('Output Tokens Used', fontsize=14)\n",
+    "plt.grid(axis='y', alpha=0.3)\n",
+    "\n",
+    "# Add token count labels on top of each bar\n",
+    "for bar in bars:\n",
+    "    height = bar.get_height()\n",
+    "    plt.text(bar.get_x() + bar.get_width()/2., height + 100,\n",
+    "            f'{int(height)}',\n",
+    "            ha='center', va='bottom', fontsize=12)\n",
+    "\n",
+    "# Add horizontal lines indicating the limits\n",
+    "plt.axhline(y=4096, color='red', linestyle='--', alpha=0.7, label='v1 Limit (4k)')\n",
+    "plt.axhline(y=8192, color='green', linestyle='--', alpha=0.7, label='v2 Limit (8k)')\n",
+    "plt.legend()\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Detailed Results Table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Model</th>\n",
+       "      <th>Output Tokens</th>\n",
+       "      <th>Input Tokens</th>\n",
+       "      <th>Stop Reason</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Claude 3.5 Sonnet v1</td>\n",
+       "      <td>4096</td>\n",
+       "      <td>128</td>\n",
+       "      <td>max_tokens</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Claude 3.5 Sonnet v2</td>\n",
+       "      <td>6270</td>\n",
+       "      <td>128</td>\n",
+       "      <td>end_turn</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                  Model  Output Tokens  Input Tokens Stop Reason\n",
+       "0  Claude 3.5 Sonnet v1           4096           128  max_tokens\n",
+       "1  Claude 3.5 Sonnet v2           6270           128    end_turn"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Create a detailed table of results\n",
+    "detail_df = pd.DataFrame({\n",
+    "    'Model': list(results.keys()),\n",
+    "    'Output Tokens': [r.get('output_tokens', 0) for r in results.values()],\n",
+    "    'Input Tokens': [r.get('input_tokens', 0) for r in results.values()],\n",
+    "    'Stop Reason': [r.get('stop_reason', 'N/A') for r in results.values()]\n",
+    "})\n",
+    "\n",
+    "detail_df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "This experiment clearly demonstrates the difference in output token capacity between Claude 3.5 Sonnet versions:\n",
+    "\n",
+    "- **Claude 3.5 Sonnet v1** has a 4k (4,096) output token limit\n",
+    "- **Claude 3.5 Sonnet v2** has an 8k (8,192) output token limit\n",
+    "\n",
+    "The v2 model can generate responses that are twice as long as the v1 model, making it more suitable for tasks requiring detailed, lengthy outputs such as code examples, extensive documentation, or comprehensive analyses.\n",
+    "\n",
+    "We can observe this from:\n",
+    "\n",
+    "1. The difference in token counts in the responses\n",
+    "2. The stop reasons (max_tokens_reached vs. end_turn)\n",
+    "3. The completeness of the generated content\n",
+    "\n",
+    "This increased output limit provides significant advantages for applications that require verbose or comprehensive AI-generated content."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Adds a simple testing notebook for verifying upgraded Claude Sonnet 3.5 v2 8k output token limit on Amazon Bedrock