### PR TITLE
feat: Add AgentCore Memory + Claude Agent SDK experiment

### DIFF
--- a/agent-sdk-agentcore-memory/README.md
+++ b/agent-sdk-agentcore-memory/README.md
@@ -1,0 +1,108 @@
+# AgentCore Memory + Claude Agent SDK
+
+> Proof-of-concept demonstrating how to bridge Amazon Bedrock AgentCore Memory (STM + LTM) with the Claude Agent SDK for persistent, memory-aware conversations.
+
+## The problem
+
+**Claude Agent SDK** runs Claude as an autonomous agent — it handles the turn loop, tool execution, and streaming. But it is stateless: every call to `query()` starts with no memory of previous turns or sessions.
+
+**Amazon Bedrock AgentCore Memory** is a managed memory service that stores conversation history (STM) and extracts long-term summaries across sessions (LTM). But it has no built-in integration with the Claude Agent SDK.
+
+**There is no native bridge between them.** This module builds one manually by wrapping every `query()` call: fetch memory before, save memory after.
+
+## Components
+
+| Component | What it does | Why we need it |
+|---|---|---|
+| `claude_agent_sdk.query()` | Runs Claude on Amazon Bedrock, handles the agentic loop | The agent itself — processes prompts, uses tools, streams responses |
+| `bedrock_agentcore` (AgentCore SDK) | Reads and writes memory in AWS | Provides STM (per-session turn history) and LTM (cross-session summaries) |
+| `MemorySessionManager` | Data-plane interface for AgentCore Memory | Reads STM with `get_last_k_turns`, searches LTM with `search_long_term_memories`, saves turns with `add_turns` |
+| `MemoryClient` | Control-plane interface for AgentCore Memory | Creates and configures memory resources — **setup only** |
+
+## How the integration works
+
+Because the Claude Agent SDK has no memory API, context must be injected as text. The `MemoryAwareAgent` wrapper does three things around every `query()` call:
+
+```
+User message
+    │
+    ▼
+claude_agent_sdk.query(user_msg)
+    │
+    ├─► UserPromptSubmit hook fires
+    │       ├─► STM: session.get_last_k_turns(k=5)          ← last 5 turns, current session only
+    │       ├─► LTM: session_manager.search_long_term_memories(query, "/summaries/{actorId}/")
+    │       │                                                 ← semantic search, all past sessions
+    │       └─► returns additionalContext (STM + LTM text)   ← injected into model context
+    │
+    ▼
+Response
+    │
+    └─► session.add_turns([user_msg, reply])         ← saved to STM immediately
+        AgentCore extracts LTM summaries async (~90s)
+```
+
+## Prerequisites
+
+- AWS account with the following IAM managed policies: `BedrockAgentCoreFullAccess`, `AmazonBedrockFullAccess`
+- AWS CLI configured (`aws configure`)
+- Python 3.11+
+- Claude Sonnet available in your AWS region via Amazon Bedrock
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+```
+
+### 1. Create a memory resource (once)
+
+```bash
+python setup_memory.py
+```
+
+Creates an AgentCore Memory store with a summary LTM strategy using an actor-scoped namespace. Prints the memory ID when done.
+
+```bash
+export AGENTCORE_MEMORY_ID=<id printed above>
+```
+
+### 2. Run the demo
+
+```bash
+python agent.py
+```
+
+The demo runs two sessions:
+
+- **Session 1** — establishes facts (name, tech stack). STM stores each turn in real time.
+- **Session 2** — starts fresh (new session ID, STM resets). Queries LTM for summaries from Session 1.
+
+> **Note:** AgentCore extracts LTM summaries ~90 seconds after session events are written. If Session 2 shows no LTM recall, wait a moment and re-run it with the same `AGENTCORE_MEMORY_ID`.
+
+## Sample output
+
+```
+SESSION 1 — Establishing user preferences
+[Memory] New session: session-a1b2c3d4
+
+User: Hi! My name is Alex and I work as a software engineer.
+Agent: Nice to meet you, Alex! ...
+
+User: What do you know about me so far?
+  [STM] Recent conversation: | USER: I mainly use Python and AWS... | ASSISTANT: Thanks for sharing...
+Agent: You're Alex, a software engineer who works with Python and AWS ...
+
+SESSION 2 — Cross-session recall via LTM
+[Memory] New session: session-e5f6a7b8
+
+User: What's my name?
+  [LTM] Long-term memory (past sessions): | Alex introduced himself as a software engineer ...
+Agent: Your name is Alex.
+```
+
+## Clean up
+
+```bash
+python delete_memory.py
+```

--- a/agent-sdk-agentcore-memory/agent.py
+++ b/agent-sdk-agentcore-memory/agent.py
@@ -1,0 +1,239 @@
+"""
+AgentCore Memory + Claude Agent SDK Experiment
+
+Demonstrates how to integrate Amazon Bedrock AgentCore Memory (STM + LTM)
+with the Claude Agent SDK for persistent, memory-aware conversations.
+
+Memory integration approach:
+  - STM and LTM context is fetched via a UserPromptSubmit hook and injected
+    as additionalContext before each model call.
+
+Run:
+    export AGENTCORE_MEMORY_ID=<id>   # from setup_memory.py
+    python agent.py
+"""
+
+import asyncio
+import os
+import uuid
+
+from bedrock_agentcore.memory.constants import ConversationalMessage, MessageRole
+from bedrock_agentcore.memory.session import MemorySessionManager
+from claude_agent_sdk import (
+    AssistantMessage,
+    ClaudeAgentOptions,
+    ProcessError,
+    TextBlock,
+    query,
+)
+from claude_agent_sdk.types import HookMatcher
+
+# Use Amazon Bedrock for model inference (no Anthropic API key needed)
+os.environ.setdefault("CLAUDE_CODE_USE_BEDROCK", "1")
+
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+ACTOR_ID = "demo-user"
+MODEL = "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
+
+# Search prefix is actor-scoped (/summaries/{actorId}/) — intentionally broader than
+# the strategy namespace (/summaries/{actorId}/{sessionId}/). Using a prefix search
+# returns summaries from all past sessions for this actor, not just the current one.
+LTM_NAMESPACE_PREFIX = "/summaries/{actorId}/"
+
+
+class MemoryAwareAgent:
+    """
+    Wraps Claude Agent SDK with AgentCore Memory for persistent conversations.
+
+    A UserPromptSubmit hook fetches STM + LTM before each call and injects
+    them as additionalContext so the model can use prior conversation history.
+    """
+
+    def __init__(self, memory_id: str, actor_id: str = ACTOR_ID):
+        self.memory_id = memory_id
+        self.actor_id = actor_id
+        self.session = None
+        self.session_id: str | None = None
+        self._session_manager = MemorySessionManager(memory_id=memory_id, region_name=REGION)
+        self._options = ClaudeAgentOptions(
+            model=MODEL,
+            allowed_tools=[],
+            hooks={"UserPromptSubmit": [HookMatcher(hooks=[self._memory_hook])]},
+        )
+
+    # ── Session management ─────────────────────────────────────────────────────
+
+    def start_session(self, session_id: str | None = None) -> str:
+        """Begin a new conversation session. STM resets; LTM persists."""
+        self.session_id = session_id or f"session-{uuid.uuid4().hex[:8]}"
+        self.session = self._session_manager.create_memory_session(
+            actor_id=self.actor_id,
+            session_id=self.session_id,
+        )
+        print(f"\n[Memory] New session: {self.session_id}")
+        return self.session_id
+
+    # ── STM ────────────────────────────────────────────────────────────────────
+
+    def _fetch_stm(self) -> str:
+        if not self.session:
+            return ""
+        turns = self.session.get_last_k_turns(k=5)
+        if not turns:
+            return ""
+        lines = []
+        for turn in turns:
+            for msg in turn:
+                role = msg.get("role", "UNKNOWN")
+                content = msg.get("content", {})
+                text = content.get("text", "") if isinstance(content, dict) else str(content)
+                lines.append(f"{role}: {text}")
+        return "Recent conversation:\n" + "\n".join(lines)
+
+    def _save_to_stm(self, user_msg: str, agent_reply: str) -> None:
+        if not self.session:
+            return
+        self.session.add_turns(
+            messages=[
+                ConversationalMessage(user_msg, MessageRole.USER),
+                ConversationalMessage(agent_reply, MessageRole.ASSISTANT),
+            ]
+        )
+
+    # ── LTM ────────────────────────────────────────────────────────────────────
+
+    def _fetch_ltm(self, query_text: str) -> str:
+        namespace = LTM_NAMESPACE_PREFIX.format(actorId=self.actor_id)
+        records = self._session_manager.search_long_term_memories(
+            query=query_text,
+            namespace_prefix=namespace,
+            top_k=3,
+        )
+        snippets = [
+            r.get("content", {}).get("text", "") or str(r.get("content", ""))
+            for r in records
+            if r.get("content")
+        ]
+        if not snippets:
+            return ""
+        return "Long-term memory (past sessions):\n" + "\n---\n".join(snippets)
+
+    # ── Hook ───────────────────────────────────────────────────────────────────
+
+    async def _memory_hook(self, input_data, tool_use_id, context) -> dict:
+        """UserPromptSubmit hook: fetch STM + LTM and inject as additionalContext."""
+        try:
+            stm, ltm = await asyncio.gather(
+                asyncio.to_thread(self._fetch_stm),
+                asyncio.to_thread(self._fetch_ltm, input_data["prompt"]),
+            )
+        except Exception as e:
+            print(f"  [Memory] Warning: could not fetch memory ({e})")
+            return {}
+        parts = [p for p in [stm, ltm] if p]
+        if stm:
+            print(f"  [STM] {stm[:120].replace(chr(10), ' | ')}...")
+        if ltm:
+            print(f"  [LTM] {ltm[:120].replace(chr(10), ' | ')}...")
+        if not parts:
+            return {}
+        return {
+            "hookSpecificOutput": {
+                "hookEventName": "UserPromptSubmit",
+                "additionalContext": "\n\n".join(parts),
+            }
+        }
+
+    # ── Chat ───────────────────────────────────────────────────────────────────
+
+    async def chat(self, user_msg: str) -> str:
+        """Send a memory-aware message and return the response."""
+        if not self.session:
+            self.start_session()
+
+        response_parts: list[str] = []
+        try:
+            async for message in query(prompt=user_msg, options=self._options):
+                if isinstance(message, AssistantMessage):
+                    for block in message.content:
+                        if isinstance(block, TextBlock):
+                            response_parts.append(block.text)
+        except ProcessError as e:
+            return f"[Error] Agent SDK process failed: {e.stderr or str(e)}"
+
+        reply = "".join(response_parts)
+        if reply:
+            self._save_to_stm(user_msg, reply)
+        return reply
+
+
+# ── Demo ──────────────────────────────────────────────────────────────────────
+
+async def main():
+    memory_id = os.environ.get("AGENTCORE_MEMORY_ID")
+    if not memory_id:
+        print("Error: AGENTCORE_MEMORY_ID is not set.")
+        print("  python setup_memory.py")
+        print("  export AGENTCORE_MEMORY_ID=<id>")
+        return
+
+    agent = MemoryAwareAgent(memory_id=memory_id)
+
+    # ── Session 1: establish facts ─────────────────────────────────────────────
+    print("\n" + "=" * 60)
+    print("SESSION 1 — Establishing user preferences")
+    print("=" * 60)
+    agent.start_session()
+
+    for msg in [
+        "Hi! My name is Alex and I work as a software engineer.",
+        "I mainly use Python and AWS. My go-to web framework is FastAPI.",
+        "What do you know about me so far?",
+    ]:
+        print(f"\nUser: {msg}")
+        reply = await agent.chat(msg)
+        print(f"Agent: {reply}")
+
+    # ── STM check: within the same session ────────────────────────────────────
+    print("\n" + "─" * 60)
+    print("STM CHECK — recall within session (should pass immediately)")
+    print("─" * 60)
+    stm_questions = {
+        "What's my name?": ["alex"],
+        "What cloud platform do I use?": ["aws"],
+    }
+    for question, expected_keywords in stm_questions.items():
+        print(f"\nUser: {question}")
+        reply = await agent.chat(question)
+        print(f"Agent: {reply}")
+        passed = all(kw in reply.lower() for kw in expected_keywords)
+        print(f"  {'✅ PASS' if passed else '❌ FAIL'} (expected: {expected_keywords})")
+
+    # ── Wait for LTM extraction ────────────────────────────────────────────────
+    wait_seconds = 90
+    print(f"\n{'=' * 60}")
+    print("SESSION 2 — Cross-session recall via LTM")
+    print(f"Waiting {wait_seconds}s for AgentCore to extract session summaries...")
+    print("=" * 60)
+    print(f"  Waiting {wait_seconds}s...", flush=True)
+    await asyncio.sleep(wait_seconds)
+    print("  Done. Starting Session 2.\n")
+
+    agent.start_session()  # new session_id — STM resets, LTM persists
+
+    # ── LTM check: across sessions ─────────────────────────────────────────────
+    ltm_questions = {
+        "What's my name?": ["alex"],
+        "What's my job?": ["engineer"],
+        "What web framework do I use?": ["fastapi"],
+    }
+    for question, expected_keywords in ltm_questions.items():
+        print(f"\nUser: {question}")
+        reply = await agent.chat(question)
+        print(f"Agent: {reply}")
+        passed = all(kw in reply.lower() for kw in expected_keywords)
+        print(f"  {'✅ PASS' if passed else '❌ FAIL'} (expected: {expected_keywords})")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/agent-sdk-agentcore-memory/delete_memory.py
+++ b/agent-sdk-agentcore-memory/delete_memory.py
@@ -1,0 +1,37 @@
+"""
+Deletes the AgentCore Memory resource created by setup_memory.py.
+
+    python delete_memory.py
+"""
+
+import os
+
+from bedrock_agentcore.memory.client import MemoryClient
+
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+MEMORY_NAME = "ClaudeAgentSDKMemory"
+
+
+def main():
+    client = MemoryClient(region_name=REGION)
+    memories = client.list_memories()
+    memory = next(
+        (m for m in memories
+         if (m.get("memoryId") or m.get("id", "")).startswith(MEMORY_NAME)
+         and m.get("status") != "DELETING"),
+        None,
+    )
+    if not memory:
+        print(f"No memory named '{MEMORY_NAME}' found.")
+        return
+    memory_id = memory.get("memoryId") or memory.get("id")
+    if memory.get("status") not in ("ACTIVE", "FAILED"):
+        print(f"Memory is in '{memory.get('status')}' state. Wait for it to become ACTIVE and retry.")
+        return
+    print(f"Deleting memory {memory_id}...")
+    client.delete_memory(memory_id)
+    print("Deleted.")
+
+
+if __name__ == "__main__":
+    main()

--- a/agent-sdk-agentcore-memory/requirements.txt
+++ b/agent-sdk-agentcore-memory/requirements.txt
@@ -1,0 +1,2 @@
+bedrock-agentcore>=1.0.0,<2
+claude-agent-sdk>=0.1.0,<1

--- a/agent-sdk-agentcore-memory/setup_memory.py
+++ b/agent-sdk-agentcore-memory/setup_memory.py
@@ -1,0 +1,82 @@
+"""
+Setup script for AgentCore Memory resource.
+
+Creates a memory store with:
+  - STM: built-in via MemorySessionManager (no extra config needed)
+  - LTM: summary extraction strategy that condenses sessions into queryable records
+
+Run once, then export the memory ID:
+    python setup_memory.py
+    export AGENTCORE_MEMORY_ID=<id printed above>
+    python agent.py
+
+To delete the memory resource:
+    python delete_memory.py
+"""
+
+import os
+
+from bedrock_agentcore.memory.client import MemoryClient
+
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+MEMORY_NAME = "ClaudeAgentSDKMemory"
+
+
+def _find_existing(client: MemoryClient) -> dict | None:
+    memories = client.list_memories()
+    return next(
+        (m for m in memories
+         if (m.get("memoryId") or m.get("id", "")).startswith(MEMORY_NAME)
+         and m.get("status") != "DELETING"),
+        None,
+    )
+
+
+def main():
+    client = MemoryClient(region_name=REGION)
+    existing = _find_existing(client)
+    if existing:
+        memory_id = existing.get("memoryId") or existing.get("id")
+        print(f"Memory '{MEMORY_NAME}' already exists: {memory_id}")
+        print(f"  export AGENTCORE_MEMORY_ID={memory_id}")
+        print("Run delete_memory.py first to create a new one.")
+        return
+
+    print(f"Creating AgentCore Memory in {REGION}...")
+    try:
+        memory = client.create_memory_and_wait(
+            name=MEMORY_NAME,
+            strategies=[],
+            description="Memory store for Claude Agent SDK STM + LTM experiment",
+        )
+    except Exception as e:
+        if "already exists" in str(e):
+            print("Previous memory is still being deleted. Wait a moment and retry.")
+            return
+        raise
+
+    memory_id = memory.get("memoryId") or memory.get("id")
+    print(f"Memory created: {memory_id}")
+
+    # Add a summary LTM strategy and wait for the memory to return to ACTIVE state.
+    # AgentCore will use this strategy to automatically extract session summaries
+    # into a queryable namespace after each session.
+    print("Adding summary LTM strategy...")
+    try:
+        client.add_summary_strategy_and_wait(
+            memory_id=memory_id,
+            name="ConversationSummary",
+            description="Summarizes conversation sessions for long-term recall",
+            namespaces=["/summaries/{actorId}/{sessionId}/"],
+        )
+        print("Summary strategy added.")
+    except Exception as e:
+        print(f"Warning: could not add summary strategy ({e}). Memory will work as STM only.")
+
+    print("\nNext steps:")
+    print(f"  export AGENTCORE_MEMORY_ID={memory_id}")
+    print("  python agent.py")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds a proof-of-concept showing how to bridge Amazon Bedrock AgentCore Memory (STM + LTM) with the Claude Agent SDK
- Uses a `UserPromptSubmit` hook to fetch memory context and inject it before each model call
- Includes setup, demo, and cleanup scripts