### PR TITLE
Add missing CDK stacks for cowork oidc

### DIFF
--- a/cowork-3p-in-bedrock/identity-federation/cdk/.gitignore
+++ b/cowork-3p-in-bedrock/identity-federation/cdk/.gitignore
@@ -5,3 +5,7 @@ cdk.out/
 *.d.ts
 .DS_Store
 *.log
+
+# Override root .gitignore which excludes **/bin/ and **/lib/
+!bin/
+!lib/

--- a/cowork-3p-in-bedrock/identity-federation/cdk/bin/cowork-federation.ts
+++ b/cowork-3p-in-bedrock/identity-federation/cdk/bin/cowork-federation.ts
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+import "source-map-support/register";
+import * as cdk from "aws-cdk-lib";
+import { CoworkFederationStack } from "../lib/cowork-federation-stack";
+import { CoworkCognitoStack } from "../lib/cowork-cognito-stack";
+
+const app = new cdk.App();
+
+const createCognito =
+  app.node.tryGetContext("createCognito") === "true" ||
+  app.node.tryGetContext("createCognito") === true;
+
+const bedrockRegions = app.node.tryGetContext("bedrockRegions") as
+  | string
+  | undefined;
+const allowedModels = app.node.tryGetContext("allowedModels") as
+  | string
+  | undefined;
+const roleName = app.node.tryGetContext("roleName") as string | undefined;
+const sessionDurationHours = app.node.tryGetContext("sessionDurationHours")
+  ? Number(app.node.tryGetContext("sessionDurationHours"))
+  : undefined;
+
+if (createCognito) {
+  const cognitoStack = new CoworkCognitoStack(app, "CoworkCognitoStack", {
+    domainPrefix: app.node.tryGetContext("cognitoDomainPrefix") as string,
+    callbackPort: app.node.tryGetContext("cognitoCallbackPort")
+      ? Number(app.node.tryGetContext("cognitoCallbackPort"))
+      : undefined,
+  });
+
+  new CoworkFederationStack(app, "CoworkFederationStack", {
+    issuerUrl: cognitoStack.issuerUrl,
+    audience: cognitoStack.clientId,
+    cognitoUserPoolId: cognitoStack.userPoolId,
+    bedrockRegions,
+    allowedModels,
+    roleName,
+    sessionDurationHours,
+  });
+} else {
+  const issuerUrl = app.node.tryGetContext("issuerUrl") as string;
+  const audience = app.node.tryGetContext("audience") as string;
+
+  if (!issuerUrl || !audience) {
+    throw new Error(
+      "When createCognito is not true, you must provide --context issuerUrl=<URL> and --context audience=<CLIENT_ID>"
+    );
+  }
+
+  new CoworkFederationStack(app, "CoworkFederationStack", {
+    issuerUrl,
+    audience,
+    bedrockRegions,
+    allowedModels,
+    roleName,
+    sessionDurationHours,
+  });
+}
+
+app.synth();

--- a/cowork-3p-in-bedrock/identity-federation/cdk/lib/cowork-cognito-stack.ts
+++ b/cowork-3p-in-bedrock/identity-federation/cdk/lib/cowork-cognito-stack.ts
@@ -1,0 +1,141 @@
+import * as cdk from "aws-cdk-lib";
+import * as cognito from "aws-cdk-lib/aws-cognito";
+import { Construct } from "constructs";
+
+export interface CoworkCognitoStackProps extends cdk.StackProps {
+  /**
+   * Globally unique prefix for the Cognito hosted-UI domain.
+   * If not provided, an auto-generated name is used.
+   */
+  readonly domainPrefix?: string;
+
+  /**
+   * Loopback port the OIDC helper listens on for the callback.
+   * @default 8765
+   */
+  readonly callbackPort?: number;
+}
+
+export class CoworkCognitoStack extends cdk.Stack {
+  /** The OIDC issuer URL for this Cognito User Pool. */
+  public readonly issuerUrl: string;
+
+  /** The app client ID (audience). */
+  public readonly clientId: string;
+
+  /** The User Pool ID (for admin operations like creating users). */
+  public readonly userPoolId: string;
+
+  constructor(scope: Construct, id: string, props?: CoworkCognitoStackProps) {
+    super(scope, id, props);
+
+    const callbackPort = props?.callbackPort ?? 8765;
+    const domainPrefix =
+      props?.domainPrefix ??
+      `cowork-${cdk.Aws.ACCOUNT_ID}-${cdk.Aws.REGION}`.toLowerCase();
+
+    // --- Cognito User Pool ---
+    const userPool = new cognito.UserPool(this, "CoworkUserPool", {
+      userPoolName: "CoworkBedrockUsers",
+      selfSignUpEnabled: false,
+      signInAliases: {
+        email: true,
+      },
+      autoVerify: {
+        email: true,
+      },
+      standardAttributes: {
+        email: {
+          required: true,
+          mutable: true,
+        },
+      },
+      passwordPolicy: {
+        minLength: 12,
+        requireLowercase: true,
+        requireUppercase: true,
+        requireDigits: true,
+        requireSymbols: true,
+        tempPasswordValidity: cdk.Duration.days(7),
+      },
+      accountRecovery: cognito.AccountRecovery.EMAIL_ONLY,
+      // DESTROY is appropriate for demos/samples. Use RETAIN for production.
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+
+    // --- Hosted UI Domain ---
+    const domain = userPool.addDomain("CoworkDomain", {
+      cognitoDomain: {
+        domainPrefix,
+      },
+    });
+
+    // --- App Client (Authorization Code + PKCE) ---
+    const appClient = userPool.addClient("CoworkAppClient", {
+      userPoolClientName: "CoworkDesktop",
+      generateSecret: false, // Public client — PKCE only, no client secret
+      authFlows: {
+        userSrp: true,
+      },
+      oAuth: {
+        flows: {
+          authorizationCodeGrant: true,
+        },
+        scopes: [
+          cognito.OAuthScope.OPENID,
+          cognito.OAuthScope.EMAIL,
+          cognito.OAuthScope.PROFILE,
+        ],
+        callbackUrls: [`http://localhost:${callbackPort}/callback`],
+        logoutUrls: [`http://localhost:${callbackPort}/logout`],
+      },
+      preventUserExistenceErrors: true,
+      accessTokenValidity: cdk.Duration.hours(1),
+      idTokenValidity: cdk.Duration.hours(1),
+      refreshTokenValidity: cdk.Duration.days(30),
+    });
+
+    // --- Expose values for the federation stack ---
+    this.issuerUrl = `https://cognito-idp.${cdk.Aws.REGION}.amazonaws.com/${userPool.userPoolId}`;
+    this.clientId = appClient.userPoolClientId;
+    this.userPoolId = userPool.userPoolId;
+
+    // --- Construct the hosted UI URL ---
+    const hostedUiUrl = `https://${domainPrefix}.auth.${cdk.Aws.REGION}.amazoncognito.com`;
+
+    // --- CloudFormation Outputs ---
+    new cdk.CfnOutput(this, "UserPoolId", {
+      value: userPool.userPoolId,
+      description: "Cognito User Pool ID (for admin-create-user)",
+      exportName: "CoworkCognito-UserPoolId",
+    });
+
+    new cdk.CfnOutput(this, "IssuerUrl", {
+      value: this.issuerUrl,
+      description: "OIDC issuer URL for this Cognito User Pool",
+      exportName: "CoworkCognito-IssuerUrl",
+    });
+
+    new cdk.CfnOutput(this, "ClientId", {
+      value: appClient.userPoolClientId,
+      description: "App client ID (audience for OIDC federation)",
+      exportName: "CoworkCognito-ClientId",
+    });
+
+    new cdk.CfnOutput(this, "HostedUiUrl", {
+      value: hostedUiUrl,
+      description: "Cognito hosted UI base URL",
+      exportName: "CoworkCognito-HostedUiUrl",
+    });
+
+    new cdk.CfnOutput(this, "AuthorizationEndpoint", {
+      value: `${hostedUiUrl}/oauth2/authorize`,
+      description: "OIDC authorization endpoint",
+    });
+
+    new cdk.CfnOutput(this, "TokenEndpoint", {
+      value: `${hostedUiUrl}/oauth2/token`,
+      description: "OIDC token endpoint",
+    });
+  }
+}

--- a/cowork-3p-in-bedrock/identity-federation/cdk/lib/cowork-federation-stack.ts
+++ b/cowork-3p-in-bedrock/identity-federation/cdk/lib/cowork-federation-stack.ts
@@ -1,0 +1,195 @@
+import * as cdk from "aws-cdk-lib";
+import * as iam from "aws-cdk-lib/aws-iam";
+import { Construct } from "constructs";
+
+export interface CoworkFederationStackProps extends cdk.StackProps {
+  /**
+   * OIDC issuer URL of the identity provider.
+   * Examples:
+   *   - Cognito: https://cognito-idp.us-west-2.amazonaws.com/<pool-id>
+   *   - Entra ID: https://login.microsoftonline.com/<tenant-id>/v2.0
+   *   - Okta: https://<org>.okta.com/oauth2/default
+   *   - Auth0: https://<tenant>.auth0.com/
+   *   - Google: https://accounts.google.com
+   */
+  readonly issuerUrl: string;
+
+  /**
+   * Expected audience claim (aud) — typically the OIDC app client ID.
+   */
+  readonly audience: string;
+
+  /**
+   * When using Cognito (createCognito=true), pass the User Pool ID here
+   * so the stack can construct the OIDC provider URL using CloudFormation
+   * intrinsics instead of synth-time string manipulation.
+   */
+  readonly cognitoUserPoolId?: string;
+
+  /**
+   * Comma-separated list of AWS regions the role may invoke Bedrock in.
+   * @default "us-west-2"
+   */
+  readonly bedrockRegions?: string;
+
+  /**
+   * Comma-separated list of model ARN patterns to allow.
+   * @default Claude Opus, Sonnet, Haiku inference-profile ARN patterns
+   */
+  readonly allowedModels?: string;
+
+  /**
+   * IAM role name.
+   * @default "CoworkBedrockUser"
+   */
+  readonly roleName?: string;
+
+  /**
+   * Maximum session duration in hours (1–12).
+   * @default 12
+   */
+  readonly sessionDurationHours?: number;
+}
+
+export class CoworkFederationStack extends cdk.Stack {
+  public readonly role: iam.IRole;
+  public readonly oidcProvider: iam.IOpenIdConnectProvider;
+
+  constructor(scope: Construct, id: string, props: CoworkFederationStackProps) {
+    super(scope, id, props);
+
+    const {
+      issuerUrl,
+      audience,
+      cognitoUserPoolId,
+      bedrockRegions = "us-west-2",
+      allowedModels,
+      roleName = "CoworkBedrockUser",
+      sessionDurationHours = 12,
+    } = props;
+
+    // Normalize issuer URL.
+    // Auth0 includes a trailing slash in the iss claim. AWS STS matches the
+    // token's iss literally against registered OIDC providers, so we must
+    // preserve the URL exactly as the IdP issues it.
+    const normalizedIssuer = issuerUrl;
+    let issuerHostPath: string;
+
+    if (cognitoUserPoolId) {
+      // Token-safe: build the host+path from region + pool ID
+      issuerHostPath = `cognito-idp.${cdk.Aws.REGION}.amazonaws.com/${cognitoUserPoolId}`;
+    } else {
+      // Strip protocol and trailing slash. AWS IAM strips trailing slashes
+      // from the provider URL when constructing OIDC condition context keys.
+      issuerHostPath = normalizedIssuer.replace(/^https?:\/\//, "").replace(/\/$/, "");
+    }
+
+    // --- IAM OIDC Identity Provider ---
+    this.oidcProvider = new iam.OpenIdConnectProvider(this, "OidcProvider", {
+      url: normalizedIssuer,
+      clientIds: [audience],
+    });
+
+    // --- IAM Role with WebIdentity trust ---
+    const sessionDuration = cdk.Duration.hours(
+      Math.min(Math.max(sessionDurationHours, 1), 12)
+    );
+
+    // Use CfnJson to defer condition-key resolution to deploy time.
+    // This handles both concrete strings and CDK tokens (Cognito case).
+    const conditionJson = new cdk.CfnJson(this, "OidcCondition", {
+      value: {
+        [`${issuerHostPath}:aud`]: audience,
+      },
+    });
+
+    this.role = new iam.Role(this, "CoworkRole", {
+      roleName,
+      maxSessionDuration: sessionDuration,
+      assumedBy: new iam.WebIdentityPrincipal(
+        this.oidcProvider.openIdConnectProviderArn,
+        {
+          StringEquals: conditionJson,
+        }
+      ),
+    });
+
+    // --- Bedrock least-privilege policy ---
+    const regions = bedrockRegions.split(",").map((r) => r.trim());
+
+    const modelResources = allowedModels
+      ? allowedModels.split(",").map((m) => m.trim())
+      : [
+          "arn:aws:bedrock:*::foundation-model/anthropic.*",
+          "arn:aws:bedrock:*:*:inference-profile/us.anthropic.*",
+          "arn:aws:bedrock:*:*:inference-profile/eu.anthropic.*",
+          "arn:aws:bedrock:*:*:inference-profile/global.anthropic.*",
+          "arn:aws:bedrock:*:*:application-inference-profile/*",
+        ];
+
+    const invokeStatement = new iam.PolicyStatement({
+      sid: "InvokeClaudeModels",
+      effect: iam.Effect.ALLOW,
+      actions: [
+        "bedrock:InvokeModel",
+        "bedrock:InvokeModelWithResponseStream",
+        "bedrock:Converse",
+        "bedrock:ConverseStream",
+      ],
+      resources: modelResources,
+    });
+
+    // Cross-region inference profiles (us.*, eu.*, global.*) route requests to
+    // any region within the prefix group. Adding an aws:RequestedRegion condition
+    // would break these profiles, so we intentionally omit it on InvokeModel.
+
+    const discoverStatement = new iam.PolicyStatement({
+      sid: "DiscoverModels",
+      effect: iam.Effect.ALLOW,
+      actions: [
+        "bedrock:ListFoundationModels",
+        "bedrock:GetFoundationModel",
+        "bedrock:ListInferenceProfiles",
+        "bedrock:GetInferenceProfile",
+      ],
+      resources: ["*"],
+      conditions: {
+        StringEquals: {
+          "aws:RequestedRegion": regions,
+        },
+      },
+    });
+
+    const bedrockPolicy = new iam.ManagedPolicy(this, "BedrockAccessPolicy", {
+      managedPolicyName: `${roleName}-BedrockAccess`,
+      statements: [invokeStatement, discoverStatement],
+    });
+
+    this.role.addManagedPolicy(bedrockPolicy);
+
+    // --- CloudFormation Outputs ---
+    new cdk.CfnOutput(this, "RoleArn", {
+      value: this.role.roleArn,
+      description: "ARN of the IAM role for Cowork federation",
+      exportName: "CoworkFederation-RoleArn",
+    });
+
+    new cdk.CfnOutput(this, "OidcProviderArn", {
+      value: this.oidcProvider.openIdConnectProviderArn,
+      description: "ARN of the IAM OIDC identity provider",
+      exportName: "CoworkFederation-OidcProviderArn",
+    });
+
+    new cdk.CfnOutput(this, "IssuerUrl", {
+      value: normalizedIssuer,
+      description: "OIDC issuer URL configured for this federation",
+      exportName: "CoworkFederation-IssuerUrl",
+    });
+
+    new cdk.CfnOutput(this, "Audience", {
+      value: audience,
+      description: "OIDC audience (client ID) for this federation",
+      exportName: "CoworkFederation-Audience",
+    });
+  }
+}

--- a/cowork-3p-in-bedrock/identity-federation/cdk/package-lock.json
+++ b/cowork-3p-in-bedrock/identity-federation/cdk/package-lock.json
@@ -1,0 +1,714 @@
+{
+  "name": "cowork-federation-cdk",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cowork-federation-cdk",
+      "version": "1.0.0",
+      "license": "MIT-0",
+      "dependencies": {
+        "aws-cdk-lib": "^2.250.0",
+        "constructs": "^10.3.0"
+      },
+      "bin": {
+        "cowork-federation": "bin/cowork-federation.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "aws-cdk": "^2.1120.0",
+        "source-map-support": "^0.5.21",
+        "ts-node": "^10.9.2",
+        "typescript": "~5.5.0"
+      }
+    },
+    "node_modules/@aws-cdk/asset-awscli-v1": {
+      "version": "2.2.273",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.273.tgz",
+      "integrity": "sha512-X57HYUtHt9BQrlrzUNcMyRsDUCoakYNnY6qh5lNwRCHPtQoTfXmuISkfLk0AjLkcbS5lw1LLTQFiQhTDXfiTvg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.1.tgz",
+      "integrity": "sha512-We4bmHaowOPHr+IQR4/FyTGjRfjgBj4ICMjtqmJeBDWad3Q/6St12NT07leNtyuukv2qMhtSZJQorD8KpKTwRA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema": {
+      "version": "53.22.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.22.0.tgz",
+      "integrity": "sha512-2GLhjjf7Db697rRyYt6rjN06fwbBIiewPo/jxSCyUN259ejF7NQQRwvrdAQb9Aq2jPaIIp1cfHSoEdXyA6Bb7Q==",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "~1.4.1",
+        "semver": "^7.7.4"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
+      "version": "1.4.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
+      "version": "7.7.4",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.18.tgz",
+      "integrity": "sha512-9v00a+dn2yWVsYDEunWC4g/TcRKVq3r8N5FuZp7u0SGrPvdN9c2yXI9bBuf5Fl0hNCb+QTIePTn5pJs2pwBOQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk": {
+      "version": "2.1121.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1121.0.tgz",
+      "integrity": "sha512-cG7CHt/SytYTfwrK+BUNQpqmS1dwhjt8z6ExKL6GK4n+8/6ZCwFzxlZWA/jUd2+Y9xPc+Q8cLKfMqGmgxEXbkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "cdk": "bin/cdk"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib": {
+      "version": "2.253.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.253.1.tgz",
+      "integrity": "sha512-vy+hA15/ZfSQpivkNdlIn2ZDA2hesp3WJgmtIZJDFwu6xzwv7wH7glbAdu5xCHGcOjepOaTKZSvCPC6sN+0/Vw==",
+      "bundleDependencies": [
+        "@balena/dockerignore",
+        "@aws-cdk/cloud-assembly-api",
+        "case",
+        "fs-extra",
+        "ignore",
+        "jsonschema",
+        "minimatch",
+        "punycode",
+        "semver",
+        "table",
+        "yaml",
+        "mime-types"
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/asset-awscli-v1": "2.2.273",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
+        "@aws-cdk/cloud-assembly-api": "^2.2.2",
+        "@aws-cdk/cloud-assembly-schema": "^53.18.0",
+        "@balena/dockerignore": "^1.0.2",
+        "case": "1.6.3",
+        "fs-extra": "^11.3.3",
+        "ignore": "^5.3.2",
+        "jsonschema": "^1.5.0",
+        "mime-types": "^2.1.35",
+        "minimatch": "^10.2.3",
+        "punycode": "^2.3.1",
+        "semver": "^7.7.4",
+        "table": "^6.9.0",
+        "yaml": "1.10.3"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "constructs": "^10.5.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
+      "version": "2.2.2",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "~1.4.1",
+        "semver": "^7.7.4"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/cloud-assembly-schema": ">=53.15.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/aws-cdk-lib/node_modules/ajv": {
+      "version": "8.18.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/astral-regex": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/case": {
+      "version": "1.6.3",
+      "inBundle": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/color-convert": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/color-name": {
+      "version": "1.1.4",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/fast-uri": {
+      "version": "3.1.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "inBundle": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/aws-cdk-lib/node_modules/fs-extra": {
+      "version": "11.3.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/aws-cdk-lib/node_modules/ignore": {
+      "version": "5.3.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/jsonfile": {
+      "version": "6.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/jsonschema": {
+      "version": "1.5.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/mime-db": {
+      "version": "1.52.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/mime-types": {
+      "version": "2.1.35",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/minimatch": {
+      "version": "10.2.5",
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/punycode": {
+      "version": "2.3.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/require-from-string": {
+      "version": "2.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/semver": {
+      "version": "7.7.4",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/string-width": {
+      "version": "4.2.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/table": {
+      "version": "6.9.0",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/universalify": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/yaml": {
+      "version": "1.10.3",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/constructs": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.6.0.tgz",
+      "integrity": "sha512-TxHOnBO5zMo/G76ykzGF/wMpEHu257TbWiIxP9K0Yv/+t70UzgBQiTqjkAsWOPC6jW91DzJI0+ehQV6xDRNBuQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/cowork-3p-in-bedrock/identity-federation/helper/cowork-credential-helper.sh
+++ b/cowork-3p-in-bedrock/identity-federation/helper/cowork-credential-helper.sh
@@ -30,6 +30,7 @@ export COWORK_OIDC_CLIENT_ID="${COWORK_OIDC_CLIENT_ID:-REPLACE_WITH_CLIENT_ID}"
 export COWORK_ROLE_ARN="${COWORK_ROLE_ARN:-REPLACE_WITH_ROLE_ARN}"
 export COWORK_AWS_REGION="${COWORK_AWS_REGION:-us-west-2}"
 export COWORK_CALLBACK_PORT="${COWORK_CALLBACK_PORT:-8765}"
+export COWORK_SCOPES="${COWORK_SCOPES:-openid email profile offline_access}"
 export COWORK_SESSION_DURATION="${COWORK_SESSION_DURATION:-3600}"
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds the CDK stack source files (`bin/` and `lib/`) for the Cowork 3P identity federation setup. These files were referenced in the README and `cdk.json` but never committed to the repository.

## Why were these files missing?

The root `.gitignore` contains blanket rules `**/bin/` and `**/lib/` (lines 62-63), intended to exclude compiled JavaScript output from projen-managed packages. These rules inadvertently prevented the CDK TypeScript source files from being tracked. A local `.gitignore` override (`!bin/` and `!lib/`) has been added to the CDK project to fix this.

## What's added

- `cowork-federation.ts` — CDK app entry point, handles both Cognito and external IdP scenarios via context parameters
- `cowork-federation-stack.ts` — IAM OIDC provider, role with `AssumeRoleWithWebIdentity` trust, least-privilege Bedrock policy
- `cowork-cognito-stack.ts` — Optional Cognito User Pool with hosted UI, Auth Code + PKCE app client
- `.gitignore` — Added `!bin/` and `!lib/` overrides


