### PR TITLE
chore: give dependabot PRs a conventional-commit title prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,8 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 0
+    commit-message:
+      prefix: "chore(deps)"
     groups:
       npm-security:
         applies-to: security-updates
@@ -28,6 +30,8 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 0
+    commit-message:
+      prefix: "chore(deps)"
     groups:
       pip-security:
         applies-to: security-updates
@@ -39,6 +43,8 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 0
+    commit-message:
+      prefix: "chore(deps)"
     groups:
       actions-security:
         applies-to: security-updates
@@ -51,6 +57,8 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 0
+    commit-message:
+      prefix: "chore(deps)"
     groups:
       docker-security:
         applies-to: security-updates
@@ -63,6 +71,8 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 0
+    commit-message:
+      prefix: "chore(deps)"
     groups:
       gomod-security:
         applies-to: security-updates


### PR DESCRIPTION
## Summary
Dependabot's default `Bump X from A to B` PR title fails this repo's `Validate PR title` check (`amannn/action-semantic-pull-request`, which only accepts `feat`/`fix`/`chore`). That's why the recent Dependabot PRs (#206–#210) all showed a red title check and had to be retitled by hand before merging.

This adds `commit-message.prefix: "chore(deps)"` to every ecosystem block in `.github/dependabot.yml`, so future Dependabot PRs are titled `chore(deps): bump ...` and pass the lint automatically — no manual retitling.

## Scope
All 5 ecosystems: npm, pip, github-actions, docker, gomod.

## Behavior
Title-only change. Does not affect the security-only, grouped update posture.