### PR TITLE
chore: migrate mergify to commit_message_format (supersedes #205)

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,10 +8,9 @@ queue_rules:
       - -label~=(do-not-merge)
       - status-success=build
     merge_method: squash
-    commit_message_template: |-
-      {{ title }} (#{{ number }})
-
-      {{ body }}
+    commit_message_format:
+      title: pr-title
+      body: pr-body
 pull_request_rules:
   - name: Automatic merge on approval and successful build
     actions:

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -42,6 +42,19 @@ classificationWithIntercom(root);
 
 root.addUpgradeSubmodulesWorkflow();
 
+// Projen (0.101.4) still emits Mergify's deprecated `commit_message_template`
+// on the queue rule, which Mergify is retiring on 2026-09-30. Override the
+// generated .mergify.yml to the current declarative `commit_message_format`
+// until projen emits it natively.
+const mergifyFile = root.tryFindObjectFile('.mergify.yml');
+if (mergifyFile) {
+  mergifyFile.addDeletionOverride('queue_rules.0.commit_message_template');
+  mergifyFile.addOverride('queue_rules.0.commit_message_format', {
+    title: 'pr-title',
+    body: 'pr-body',
+  });
+}
+
 const common_exclude = [
   '.yalc',
   'cdk.out',


### PR DESCRIPTION
## Summary
Mergify is retiring the `commit_message_template` field on **2026-09-30**. This migrates the queue rule to the current declarative `commit_message_format`.

## Why not just merge #205?
Mergify's automated PR (#205) edits `.mergify.yml` directly, but that file is **projen-generated** (`# ~~ Generated by projen`). Projen's `self-mutation` build step regenerates it back to the old format — which is exactly why #205's `build`/`self-mutation` checks fail. Merging it wouldn't stick.

## Fix
Override the generated `.mergify.yml` in `.projenrc.js`:
- delete `queue_rules.0.commit_message_template`
- add `queue_rules.0.commit_message_format: { title: pr-title, body: pr-body }`

projen 0.101.4 still hardcodes the deprecated field (`auto-merge.js`) with no config option, so an override is the only path until projen emits the new format natively. The resulting `.mergify.yml` diff is byte-identical to #205's, but survives re-synth.

**Supersedes #205** — that PR should be closed.