### PR TITLE
fix(ci): remove orphaned run-task.cjs step from upgrade tasks

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -189,9 +189,6 @@
           "exec": "yarn upgrade commit-and-tag-version"
         },
         {
-          "exec": "scripts/run-task.cjs"
-        },
-        {
           "spawn": "post-upgrade"
         }
       ]

--- a/classification-with-intercom/.projen/tasks.json
+++ b/classification-with-intercom/.projen/tasks.json
@@ -183,9 +183,6 @@
           "exec": "yarn upgrade @stylistic/eslint-plugin @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser aws-cdk esbuild eslint-import-resolver-typescript eslint-plugin-import eslint ts-node typescript @aws-sdk/client-bedrock-runtime @aws-sdk/client-secrets-manager @types/aws-lambda @types/node-fetch aws-cdk-lib constructs dotenv node-fetch"
         },
         {
-          "exec": "scripts/run-task.cjs"
-        },
-        {
           "spawn": "post-upgrade"
         }
       ]

--- a/claude-tools-chatbot/.projen/tasks.json
+++ b/claude-tools-chatbot/.projen/tasks.json
@@ -199,9 +199,6 @@
           "exec": "yarn upgrade @stylistic/eslint-plugin @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser aws-cdk cdk-nag esbuild eslint-import-resolver-typescript eslint-plugin-import eslint ts-node typescript @types/aws-lambda @types/fs-extra @types/jest @types/mocha aws-cdk-lib constructs dotenv fs-extra"
         },
         {
-          "exec": "scripts/run-task.cjs"
-        },
-        {
           "spawn": "post-upgrade"
         }
       ]

--- a/metaprompt-generator/.projen/tasks.json
+++ b/metaprompt-generator/.projen/tasks.json
@@ -199,9 +199,6 @@
           "exec": "yarn upgrade @stylistic/eslint-plugin @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser aws-cdk esbuild eslint-import-resolver-typescript eslint-plugin-import eslint ts-node typescript @anthropic-ai/sdk @apollo/client @aws-sdk/client-sfn @types/aws-lambda @types/fs-extra @types/uuid aws-cdk-lib cdk-nag constructs dotenv fs-extra graphql react"
         },
         {
-          "exec": "scripts/run-task.cjs"
-        },
-        {
           "spawn": "post-upgrade"
         }
       ]

--- a/pdf-knowledge-base-with-citations/.projen/tasks.json
+++ b/pdf-knowledge-base-with-citations/.projen/tasks.json
@@ -200,9 +200,6 @@
           "exec": "yarn upgrade @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser aws-cdk esbuild eslint-import-resolver-typescript eslint-plugin-import eslint ts-node typescript @aws-sdk/client-bedrock-agent @aws-sdk/client-bedrock-agent-runtime @aws-sdk/client-bedrock-runtime @aws-sdk/client-cloudformation @aws-sdk/client-s3 @cdklabs/generative-ai-cdk-constructs @cloudscape-design/components @types/aws-lambda @types/react-pdf aws-cdk-lib constructs dotenv react-pdf"
         },
         {
-          "exec": "scripts/run-task.cjs"
-        },
-        {
           "spawn": "post-upgrade"
         }
       ]


### PR DESCRIPTION
## Problem

The scheduled `upgrade_*` workflows (`upgrade_claude-tools-chatbot`, `upgrade_classification-with-intercom`, `upgrade_anthropic-metaprompt-generator`, and `upgrade-main`) all fail with:

```
👾 upgrade | scripts/run-task.cjs
Error: cannot find command undefined
```

## Root cause

The projen eject (#222) mechanically rewrote every `npx projen` invocation to `scripts/run-task.cjs`. In the `upgrade` task the 4th step was `npx projen` (projen's re-synth), so it became a bare `scripts/run-task.cjs` **with no task-name argument** → `process.argv[2]` is `undefined` → the runner throws `cannot find command undefined` and the workflow exits 1.

Post-eject there is no synth loop to re-run, so the step is removed outright. The upgrade still runs ncu → install → `yarn upgrade` → `post-upgrade`.

## Changes

Removed the orphaned step from the `upgrade` task in all five ejected projects:
- root `.projen/tasks.json` (`upgrade-main`)
- `claude-tools-chatbot`
- `classification-with-intercom`
- `metaprompt-generator`
- `pdf-knowledge-base-with-citations`

## Verification

- All five `tasks.json` validate as JSON; no bare `run-task.cjs` steps remain.
- `node scripts/run-task.cjs post-upgrade` runs cleanly, confirming the failing code path is gone.