### PR TITLE
fix: correct claude binary acquisition instructions in gateway CDK docs (#238)

### DIFF
--- a/claude-apps-gateway/cdk/README.md
+++ b/claude-apps-gateway/cdk/README.md
@@ -71,10 +71,14 @@ npm install -g aws-cdk
 
 ### 5. The Claude Code linux-x64 binary
 
-The gateway container needs the Linux build of Claude Code. Extract it from the tarball:
+The gateway container needs the Linux build of Claude Code. Download it from the public releases endpoint:
 
 ```bash
-tar -xzf claude-gateway-*-all.tar.gz linux-x64/claude
+VERSION=$(curl -fsSL https://downloads.claude.ai/claude-code-releases/stable)
+mkdir -p linux-x64
+curl -fL -o linux-x64/claude \
+  "https://downloads.claude.ai/claude-code-releases/${VERSION}/linux-x64/claude"
+chmod +x linux-x64/claude
 ```
 
 Or download it via the standard installer on a Linux machine.
@@ -348,7 +352,7 @@ This works because the Claude Code CLI accepts `127.0.0.1` (loopback) as a valid
 ### What you need
 
 - PostgreSQL running locally (`brew install postgresql@16 && brew services start postgresql@16`)
-- The gateway binary for your platform (macOS: `darwin-arm64/claude` from the tarball)
+- The gateway binary for your platform (macOS: `darwin-arm64/claude`, from a Claude Code install or the releases endpoint used in step 5)
 - An OIDC provider configured (Auth0 free tier works for testing)
 - A self-signed TLS certificate
 

--- a/claude-apps-gateway/cdk/scripts/deploy.sh
+++ b/claude-apps-gateway/cdk/scripts/deploy.sh
@@ -4,7 +4,7 @@
 #
 # Prerequisites:
 #   1. .env file configured (cp .env.example .env)
-#   2. claude linux-x64 binary staged (from the gateway tarball) as either
+#   2. claude linux-x64 binary staged (see cdk/README.md step 5) as either
 #      linux-x64/claude or ./claude — the latter is where the tracked CDK Dockerfile expects it
 #   3. AWS CLI configured
 #   4. npm install already run
@@ -141,8 +141,8 @@ if ! aws codebuild batch-get-projects --names claude-gateway-build --query "proj
     --service-role "arn:aws:iam::${ACCOUNT_ID}:role/claude-gateway-codebuild" >/dev/null
 fi
 
-# Find the linux binary. Accept the tarball's linux-x64/ layout OR the location the
-# tracked CDK Dockerfile uses (cdk/claude, i.e. ./claude relative to cdk/), so the
+# Find the linux binary. Accept the README step 5 linux-x64/ layout OR the location
+# the tracked CDK Dockerfile uses (cdk/claude, i.e. ./claude relative to cdk/), so the
 # two documented build paths agree on where the binary lives.
 LINUX_BINARY=""
 if [ -f "../linux-x64/claude" ]; then
@@ -154,7 +154,7 @@ elif [ -f "./claude" ]; then
 elif [ -f "../claude" ]; then
   LINUX_BINARY="../claude"
 else
-  echo "❌ claude binary not found (looked for linux-x64/claude and ./claude). Extract it from the gateway tarball."
+  echo "❌ claude binary not found (looked for linux-x64/claude and ./claude). Download it (see cdk/README.md step 5)."
   exit 1
 fi
 


### PR DESCRIPTION
Fixes #238.

## Problem

`claude-apps-gateway/cdk/README.md` (step 5) instructed users to obtain the `linux-x64/claude` binary by extracting it from a tarball:

```bash
tar -xzf claude-gateway-*-all.tar.gz linux-x64/claude
```

The `*` is a shell glob for a local filename, so the command isn't malformed — but it points at a distribution artifact that doesn't exist. The [official gateway deployment docs](https://code.claude.com/docs/en/claude-apps-gateway-deploy#container-image) describe no `claude-gateway-*-all.tar.gz` bundle; they say to build the image around the standard Claude Code release binary:

> Build your own image around the native `claude` binary from the standard Claude Code release:
> 1. Download the Linux build for your image architecture from a pinned release
> 2. Verify it against the release's GPG-signed `manifest.json`

So a reader following step 5 goes looking for a file the documented process never produces — which is exactly what #238 reported ("does not seem to be publicly available... where do I get this?"). The repo's own `cdk/scripts/setup.sh` already does the right thing: it downloads the per-version binary from the public releases endpoint and verifies it against the signed manifest. The docs just didn't match that.

Verified the correct acquisition path works:

| URL | Status |
|---|---|
| `.../claude-code-releases/stable` | 200 (returns the version string) |
| `.../claude-code-releases/<version>/linux-x64/claude` | 200 |
| `.../claude-code-releases/<version>/darwin-arm64/claude` | 200 |

Running the step-5 `curl` snippet end-to-end fetches a valid ~245 MB Linux x86-64 ELF binary.

## Changes

Kept as close to the original wording as possible — only the clauses that referenced the nonexistent tarball changed:

- **`cdk/README.md` step 5** — the `tar -xzf` command is replaced with a `curl` from the public releases endpoint (`downloads.claude.ai/claude-code-releases`). Original prose and the "standard installer" fallback are preserved.
- **`cdk/README.md` local-testing note** — the macOS `darwin-arm64/claude` line no longer says "from the tarball"; it points to a Claude Code install or the step-5 endpoint.
- **`cdk/scripts/deploy.sh`** — the header comment and not-found error no longer reference the tarball; they point to README step 5.

Docs/comments only — no behavior change. `bash -n` passes on `deploy.sh`.