### PR TITLE
feat(otel): Replace awsemf exporter with CloudWatch native OTLP    ingestion

### DIFF
--- a/claude-apps-gateway/.gitignore
+++ b/claude-apps-gateway/.gitignore
@@ -6,3 +6,6 @@
 # Architecture decision records are kept local to the maintainers' repo, not
 # shipped with the example. Rationale lives inline in the docs and comments.
 /docs/adr/
+claude-apps-gateway/local-test/
+claude-apps-gateway/test-direct-otlp/
+claude-apps-gateway/cdk/package-lock.json

--- a/claude-apps-gateway/README.md
+++ b/claude-apps-gateway/README.md
@@ -199,23 +199,24 @@ Tool/permission policies are defense-in-depth (a patched client can ignore them)
 
 ### 3. Telemetry: per-user usage attribution
 
-**What it does:** The gateway relays OpenTelemetry Protocol (OTLP) metrics to a collector you configure. Each export is stamped with the developer's identity (user ID, email, groups), so you get per-user cost and usage breakdowns with no developer-side configuration.
+**What it does:** The gateway relays OpenTelemetry Protocol (OTLP) metrics to a destination you configure. Each export is stamped with the developer's identity (user ID, email, groups), so you get per-user cost and usage breakdowns with no developer-side configuration.
 
-**How it's configured:**
+**How it's configured:** this example ships pointed straight at CloudWatch's native OTLP metrics endpoint (bearer-token auth, no collector to run):
 
 ```yaml
 telemetry:
   forward_to:
-    - url: https://otel-collector.internal.customer.com
+    - url: https://monitoring.us-east-1.amazonaws.com
       headers:
-        Authorization: Bearer ${OTLP_TOKEN}
+        Authorization: Bearer ${CW_METRICS_API_KEY}
       metrics: true     # token counts, latency, model (default: true)
       logs: false       # bash commands, file paths (opt-in, sensitive)
       traces: false     # full tool inputs (opt-in, most sensitive)
 ```
 
+See [`docs/deployment.md`](docs/deployment.md#telemetry) for generating the API key. Any OTLP-compatible backend works — swap `url`/`headers` for Datadog, Splunk, or a self-hosted collector.
+
 **Key points:**
-- Any OTLP-compatible backend works
 - Metrics include: token counts, model used, user identity, request latency
 - Logs and traces are opt-in and carry sensitive data (commands, file paths)
 - The gateway itself does not log or store prompt/completion content

--- a/claude-apps-gateway/README.md
+++ b/claude-apps-gateway/README.md
@@ -201,20 +201,18 @@ Tool/permission policies are defense-in-depth (a patched client can ignore them)
 
 **What it does:** The gateway relays OpenTelemetry Protocol (OTLP) metrics to a destination you configure. Each export is stamped with the developer's identity (user ID, email, groups), so you get per-user cost and usage breakdowns with no developer-side configuration.
 
-**How it's configured:** this example ships pointed straight at CloudWatch's native OTLP metrics endpoint (bearer-token auth, no collector to run):
+**How it's configured:** this example ships with a ADOT collector sidecar in the same Fargate task — the gateway sends OTLP to localhost, and the collector forwards to CloudWatch via SigV4 using the task role:
 
 ```yaml
 telemetry:
   forward_to:
-    - url: https://monitoring.us-east-1.amazonaws.com
-      headers:
-        Authorization: Bearer ${CW_METRICS_API_KEY}
+    - url: http://localhost:4318
       metrics: true     # token counts, latency, model (default: true)
       logs: false       # bash commands, file paths (opt-in, sensitive)
       traces: false     # full tool inputs (opt-in, most sensitive)
 ```
 
-See [`docs/deployment.md`](docs/deployment.md#telemetry) for generating the API key. Any OTLP-compatible backend works — swap `url`/`headers` for Datadog, Splunk, or a self-hosted collector.
+See [`docs/deployment.md`](docs/deployment.md#telemetry) for deployment details. Any OTLP-compatible backend works — swap `url` (and add `headers` if needed) for Datadog, Splunk, or a self-hosted collector.
 
 **Key points:**
 - Metrics include: token counts, model used, user identity, request latency

--- a/claude-apps-gateway/cdk/gateway.yaml.example
+++ b/claude-apps-gateway/cdk/gateway.yaml.example
@@ -118,22 +118,25 @@ upstreams:
   #  first-party model IDs; if you curate `models:`, key the entry `anthropicAws:`)
 
 telemetry:
-  # The ADOT collector is reached over the gateway ALB's HTTPS :4318 listener.
-  # The gateway REQUIRES https:// for any non-loopback forward_to target and
-  # offers no custom-CA/skip-verify option for it, so the collector sits behind
-  # the ALB's publicly-trusted ACM cert (TLS terminates at the ALB; the collector
-  # speaks plain OTLP/HTTP behind it). Telemetry turns on only when forward_to AND
-  # listen.public_url are both set; the gateway then pushes OTEL_* env to clients
-  # (one-time client approval dialog).
+  # Forwards straight to CloudWatch's native OTLP metrics endpoint — no collector
+  # to run or maintain. Auth is a CloudWatch Metrics API key (bearer token; see
+  # docs/deployment.md "Telemetry"), NOT SigV4: the gateway signs no requests, it
+  # only attaches the static Authorization header below, and the metrics endpoint
+  # accepts that as an alternative to SigV4 for workloads outside the AWS SDK.
+  # Telemetry turns on only when forward_to AND listen.public_url are both set;
+  # the gateway then pushes OTEL_* env to clients (one-time client approval dialog).
   forward_to:
-    - url: https://claude-gateway.example.com:4318
+    # No /v1/metrics suffix: the gateway appends the OTLP-standard signal path
+    # itself (like any OTLP HTTP exporter), so a base URL that already ends in
+    # /v1/metrics gets it doubled and 404s — see gotchas.md.
+    - url: https://monitoring.us-east-1.amazonaws.com
+      headers:
+        Authorization: Bearer ${CW_METRICS_API_KEY}
       # Default is metrics-only. Metrics are aggregate counters (tokens, requests,
-      # latency). logs/traces can carry full bash commands, tool inputs, and file
-      # paths — enable them ONLY on a destination with the access controls and
-      # retention that data warrants.
+      # latency). The CloudWatch metrics OTLP endpoint doesn't accept logs/traces —
+      # those need the separate logs (SigV4 or its own bearer token) or traces
+      # (SigV4-only) endpoints, out of scope for this bearer-token setup.
       metrics: true
-      # logs: false
-      # traces: false
 
 # Constrain the model picker to a curated allowlist. This turns the silent
 # Bedrock AccessDenied trap into an explicit allowlist: align this with the
@@ -149,6 +152,13 @@ managed:
     #     availableModels: [claude-haiku-4-5]
     #     enforceAvailableModels: true
     #     permissions: { allow: [Read, Grep] }
+    # Per-team cost attribution: OTEL_RESOURCE_ATTRIBUTES is stamped on every
+    # OTLP export, so CloudWatch's PromQL layer can group spend/usage by team
+    # (sum by ("@resource.team.id") (...)) same as user.id/user.email already are.
+    # - match: { groups: [team-platform] }
+    #   cli:
+    #     env:
+    #       OTEL_RESOURCE_ATTRIBUTES: "team.id=platform,department=engineering,cost_center=cc-1001"
     # Catch-all base: matches every authenticated user.
     - match: {}
       cli:

--- a/claude-apps-gateway/cdk/gateway.yaml.example
+++ b/claude-apps-gateway/cdk/gateway.yaml.example
@@ -120,22 +120,19 @@ upstreams:
 telemetry:
   # Forwards straight to CloudWatch's native OTLP metrics endpoint — no collector
   # to run or maintain. Auth is a CloudWatch Metrics API key (bearer token; see
-  # docs/deployment.md "Telemetry"), NOT SigV4: the gateway signs no requests, it
-  # only attaches the static Authorization header below, and the metrics endpoint
-  # accepts that as an alternative to SigV4 for workloads outside the AWS SDK.
+  # Forwards to a CloudWatch Agent sidecar running in the same Fargate task.
+  # The agent receives OTLP on localhost:4318 and relays to CloudWatch using
+  # SigV4 via the task role — no bearer token to manage or rotate.
   # Telemetry turns on only when forward_to AND listen.public_url are both set;
   # the gateway then pushes OTEL_* env to clients (one-time client approval dialog).
   forward_to:
     # No /v1/metrics suffix: the gateway appends the OTLP-standard signal path
     # itself (like any OTLP HTTP exporter), so a base URL that already ends in
     # /v1/metrics gets it doubled and 404s — see gotchas.md.
-    - url: https://monitoring.us-east-1.amazonaws.com
-      headers:
-        Authorization: Bearer ${CW_METRICS_API_KEY}
+    - url: http://localhost:4318
       # Default is metrics-only. Metrics are aggregate counters (tokens, requests,
-      # latency). The CloudWatch metrics OTLP endpoint doesn't accept logs/traces —
-      # those need the separate logs (SigV4 or its own bearer token) or traces
-      # (SigV4-only) endpoints, out of scope for this bearer-token setup.
+      # latency, model, user identity). logs/traces carry sensitive data and should
+      # only be enabled on destinations with appropriate access controls.
       metrics: true
 
 # Constrain the model picker to a curated allowlist. This turns the silent

--- a/claude-apps-gateway/cdk/gateway.yaml.template
+++ b/claude-apps-gateway/cdk/gateway.yaml.template
@@ -123,22 +123,25 @@ upstreams:
   #  first-party model IDs; if you curate `models:`, key the entry `anthropicAws:`)
 
 telemetry:
-  # The ADOT collector is reached over the gateway ALB's HTTPS :4318 listener.
-  # The gateway REQUIRES https:// for any non-loopback forward_to target and
-  # offers no custom-CA/skip-verify option for it, so the collector sits behind
-  # the ALB's publicly-trusted ACM cert (TLS terminates at the ALB; the collector
-  # speaks plain OTLP/HTTP behind it). Telemetry turns on only when forward_to AND
-  # listen.public_url are both set; the gateway then pushes OTEL_* env to clients
-  # (one-time client approval dialog).
+  # Forwards straight to CloudWatch's native OTLP metrics endpoint — no collector
+  # to run or maintain. Auth is a CloudWatch Metrics API key (bearer token; see
+  # docs/deployment.md "Telemetry"), NOT SigV4: the gateway signs no requests, it
+  # only attaches the static Authorization header below, and the metrics endpoint
+  # accepts that as an alternative to SigV4 for workloads outside the AWS SDK.
+  # Telemetry turns on only when forward_to AND listen.public_url are both set;
+  # the gateway then pushes OTEL_* env to clients (one-time client approval dialog).
   forward_to:
-    - url: @@PUBLIC_URL@@:4318
+    # No /v1/metrics suffix: the gateway appends the OTLP-standard signal path
+    # itself (like any OTLP HTTP exporter), so a base URL that already ends in
+    # /v1/metrics gets it doubled and 404s — see gotchas.md.
+    - url: https://monitoring.@@AWS_REGION@@.amazonaws.com
+      headers:
+        Authorization: Bearer ${CW_METRICS_API_KEY}
       # Default is metrics-only. Metrics are aggregate counters (tokens, requests,
-      # latency). logs/traces can carry full bash commands, tool inputs, and file
-      # paths — enable them ONLY on a destination with the access controls and
-      # retention that data warrants.
+      # latency). The CloudWatch metrics OTLP endpoint doesn't accept logs/traces —
+      # those need the separate logs (SigV4 or its own bearer token) or traces
+      # (SigV4-only) endpoints, out of scope for this bearer-token setup.
       metrics: true
-      # logs: false
-      # traces: false
 
 # Constrain the model picker to a curated allowlist. This turns the silent
 # Bedrock AccessDenied trap into an explicit allowlist: align this with the
@@ -154,6 +157,13 @@ managed:
     #     availableModels: [claude-haiku-4-5]
     #     enforceAvailableModels: true
     #     permissions: { allow: [Read, Grep] }
+    # Per-team cost attribution: OTEL_RESOURCE_ATTRIBUTES is stamped on every
+    # OTLP export, so CloudWatch's PromQL layer can group spend/usage by team
+    # (sum by ("@resource.team.id") (...)) same as user.id/user.email already are.
+    # - match: { groups: [team-platform] }
+    #   cli:
+    #     env:
+    #       OTEL_RESOURCE_ATTRIBUTES: "team.id=platform,department=engineering,cost_center=cc-1001"
     # Catch-all base: matches every authenticated user.
     - match: {}
       cli:

--- a/claude-apps-gateway/cdk/gateway.yaml.template
+++ b/claude-apps-gateway/cdk/gateway.yaml.template
@@ -44,6 +44,8 @@ oidc:
   client_id: @@OIDC_CLIENT_ID@@
   client_secret: ${OIDC_CLIENT_SECRET}   # the one secret in this block (env-injected)
   allowed_email_domains: [@@ALLOWED_EMAIL_DOMAINS@@]
+  # Cognito does not support offline_access; override default scopes here.
+  # scopes: [openid, email, profile]
   # Per-IdP notes — uncomment what your provider needs:
   #   Okta (org server https://example.okta.com): id_token omits email/groups →
   #     userinfo_fallback: true
@@ -123,24 +125,19 @@ upstreams:
   #  first-party model IDs; if you curate `models:`, key the entry `anthropicAws:`)
 
 telemetry:
-  # Forwards straight to CloudWatch's native OTLP metrics endpoint — no collector
-  # to run or maintain. Auth is a CloudWatch Metrics API key (bearer token; see
-  # docs/deployment.md "Telemetry"), NOT SigV4: the gateway signs no requests, it
-  # only attaches the static Authorization header below, and the metrics endpoint
-  # accepts that as an alternative to SigV4 for workloads outside the AWS SDK.
+  # Forwards to an ADOT collector sidecar running in the same Fargate task.
+  # The agent receives OTLP on localhost:4318 and relays to CloudWatch using
+  # The agent authenticates to CloudWatch using SigV4 via the task role.
   # Telemetry turns on only when forward_to AND listen.public_url are both set;
   # the gateway then pushes OTEL_* env to clients (one-time client approval dialog).
   forward_to:
     # No /v1/metrics suffix: the gateway appends the OTLP-standard signal path
     # itself (like any OTLP HTTP exporter), so a base URL that already ends in
     # /v1/metrics gets it doubled and 404s — see gotchas.md.
-    - url: https://monitoring.@@AWS_REGION@@.amazonaws.com
-      headers:
-        Authorization: Bearer ${CW_METRICS_API_KEY}
+    - url: http://localhost:4318
       # Default is metrics-only. Metrics are aggregate counters (tokens, requests,
-      # latency). The CloudWatch metrics OTLP endpoint doesn't accept logs/traces —
-      # those need the separate logs (SigV4 or its own bearer token) or traces
-      # (SigV4-only) endpoints, out of scope for this bearer-token setup.
+      # latency, model, user identity). logs/traces carry sensitive data and should
+      # only be enabled on destinations with appropriate access controls.
       metrics: true
 
 # Constrain the model picker to a curated allowlist. This turns the silent

--- a/claude-apps-gateway/cdk/lib/claude-gateway-stack.ts
+++ b/claude-apps-gateway/cdk/lib/claude-gateway-stack.ts
@@ -161,20 +161,6 @@ export class GatewayStack extends cdk.Stack {
     // ALB -> task on 8080 is wired by the pattern; here we only add task -> endpoints.
     vpceSg.connections.allowFrom(taskSg, ec2.Port.tcp(443), 'tasks to VPC endpoints');
 
-    // Collector is reached over the gateway ALB's HTTPS :4318 listener (the gateway
-    // requires https:// for a non-loopback telemetry target, and there's no
-    // custom-CA/skip-verify option for forward_to — so it must be a publicly-trusted
-    // cert, which the ALB already has). Ingress rules for the ALB<->collector hop
-    // are wired after the ALB exists, below.
-    const otelSg = new ec2.SecurityGroup(this, 'OtelSg', {
-      vpc,
-      description: 'ADOT collector: 4318 (OTLP) + 13133 (health) from the ALB only',
-      allowAllOutbound: true,
-    });
-    // The collector also needs the VPC endpoints (CloudWatch logs + metrics) — it
-    // logs to the same group and exports metrics via the monitoring endpoint.
-    vpceSg.connections.allowFrom(otelSg, ec2.Port.tcp(443), 'collector to VPC endpoints');
-
     // ── RDS PostgreSQL 16 (private, not public, encrypted, managed master secret)─
     // Example posture: easy teardown. See README "Productionising" to harden
     // (deletion protection, multi-AZ, longer backups, RETAIN) the moment you
@@ -220,6 +206,15 @@ export class GatewayStack extends cdk.Stack {
       //     --secret-string '<your-oidc-client-secret>'
       secretStringValue: cdk.SecretValue.unsafePlainText('REPLACE_ME'),
     });
+    // CloudWatch Metrics OTLP endpoint bearer token (a service-specific credential
+    // for an IAM user with the CloudWatchAPIKeyAccess policy — see docs/deployment.md
+    // "Telemetry"). Not an AWS-managed secret: create it out of band, then either
+    // `put-secret-value` here or pass it as CW_METRICS_API_KEY at deploy time.
+    const cwMetricsApiKeySecret = new secretsmanager.Secret(this, 'CwMetricsApiKeySecret', {
+      secretName: `${gatewayName}-cw-metrics-api-key`,
+      description: 'CloudWatch Metrics OTLP bearer token (service-specific credential) — set the real value after deploy',
+      secretStringValue: cdk.SecretValue.unsafePlainText('REPLACE_ME'),
+    });
 
     // ── Log group (gateway stderr: audit events + operational logs) ───────────
     const logGroup = new logs.LogGroup(this, 'GatewayLogGroup', {
@@ -234,72 +229,6 @@ export class GatewayStack extends cdk.Stack {
       clusterName: gatewayName,
     });
 
-
-    // ── ADOT collector — its own small Fargate service (metrics-only default) ─
-    // A SEPARATE service, not a sidecar: the gateway's SSRF guard blocks loopback
-    // by default, and a sidecar in the same awsvpc task is loopback. A separate
-    // service on a private IP passes the guard with no CLAUDE_GATEWAY_ALLOW_LOOPBACK.
-    // health_check extension on :13133 gives the ALB target group something to GET
-    // (raw OTLP/:4318 doesn't answer GET). TLS is terminated at the ALB, so the
-    // collector itself listens plain HTTP on 4318.
-    const adotConfig = [
-      'extensions:',
-      '  health_check:',
-      '    endpoint: 0.0.0.0:13133',
-      'receivers:',
-      '  otlp:',
-      '    protocols:',
-      '      http:',
-      '        endpoint: 0.0.0.0:4318',
-      'processors:',
-      '  batch: {}',
-      'exporters:',
-      '  awsemf:',
-      '    namespace: ClaudeGateway',
-      '    log_group_name: /claude-gateway/otel-metrics',
-      'service:',
-      '  extensions: [health_check]',
-      '  pipelines:',
-      '    metrics:',
-      '      receivers: [otlp]',
-      '      processors: [batch]',
-      '      exporters: [awsemf]',
-    ].join('\n');
-
-    const otelTaskDef = new ecs.FargateTaskDefinition(this, 'OtelTaskDef', {
-      cpu: 256,
-      memoryLimitMiB: 512,
-    });
-    otelTaskDef.taskRole.addToPrincipalPolicy(
-      new iam.PolicyStatement({
-        actions: [
-          'cloudwatch:PutMetricData',
-          'logs:CreateLogGroup',
-          'logs:CreateLogStream',
-          'logs:PutLogEvents',
-          'logs:DescribeLogGroups',
-          'logs:DescribeLogStreams',
-        ],
-        resources: ['*'],
-      }),
-    );
-    otelTaskDef.addContainer('aws-otel-collector', {
-      image: ecs.ContainerImage.fromRegistry('public.ecr.aws/aws-observability/aws-otel-collector:latest'),
-      environment: { AOT_CONFIG_CONTENT: adotConfig },
-      portMappings: [{ containerPort: 4318 }, { containerPort: 13133 }],
-      logging: ecs.LogDrivers.awsLogs({ streamPrefix: 'otel', logGroup }),
-    });
-    const otelService = new ecs.FargateService(this, 'OtelService', {
-      cluster,
-      taskDefinition: otelTaskDef,
-      desiredCount: 1,
-      minHealthyPercent: 0, // single fire-and-forget collector; fine to replace in place
-      circuitBreaker: { rollback: true }, // fail a bad deploy fast instead of hanging for hours
-      securityGroups: [otelSg],
-      vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
-    });
-    // OTLP is fire-and-forget: if the collector is down, inference is unaffected.
-    // The collector is registered to the gateway ALB's :4318 listener below.
 
     // ── Gateway task role: dual-ARN Bedrock policy ────────────────────────────
     // BOTH inference-profile (us.anthropic.*) AND foundation-model (anthropic.*)
@@ -361,6 +290,7 @@ export class GatewayStack extends cdk.Stack {
           OIDC_CLIENT_SECRET: ecs.Secret.fromSecretsManager(oidcSecret),
           DB_USER: ecs.Secret.fromSecretsManager(dbSecret, 'username'),
           DB_PASSWORD: ecs.Secret.fromSecretsManager(dbSecret, 'password'),
+          CW_METRICS_API_KEY: ecs.Secret.fromSecretsManager(cwMetricsApiKeySecret),
         },
         logDriver: ecs.LogDrivers.awsLogs({ streamPrefix: 'gateway', logGroup }),
       },
@@ -381,36 +311,6 @@ export class GatewayStack extends cdk.Stack {
       healthyHttpCodes: '200',
     });
 
-    // ── Telemetry: HTTPS :4318 listener on the gateway ALB → ADOT collector ────
-    // The gateway requires https:// for a non-loopback forward_to and offers no
-    // custom-CA/skip-verify for it, so the collector must sit behind the ALB's
-    // publicly-trusted ACM cert. TLS terminates at the ALB; the collector speaks
-    // plain OTLP/HTTP on 4318 behind it. The stamped gateway.yaml points
-    // telemetry.forward_to at https://<public_url host>:4318.
-    const otelListener = fargate.loadBalancer.addListener('OtelListener', {
-      port: 4318,
-      protocol: elbv2.ApplicationProtocol.HTTPS,
-      certificates: [certificate],
-      sslPolicy: elbv2.SslPolicy.TLS13_RES,
-    });
-    otelListener.addTargets('OtelTargets', {
-      port: 4318,
-      protocol: elbv2.ApplicationProtocol.HTTP,
-      targets: [otelService.loadBalancerTarget({ containerName: 'aws-otel-collector', containerPort: 4318 })],
-      healthCheck: { port: '13133', path: '/', healthyHttpCodes: '200' },
-      deregistrationDelay: cdk.Duration.seconds(10),
-    });
-    // Only the gateway task SG may reach the ALB's :4318 listener (developers hit 443 only).
-    fargate.loadBalancer.connections.allowFrom(taskSg, ec2.Port.tcp(4318), 'gateway to ALB (OTLP/HTTPS)');
-    // ALB → collector on 4318 (OTLP) and 13133 (health).
-    otelSg.connections.allowFrom(fargate.loadBalancer, ec2.Port.tcp(4318), 'ALB to collector (OTLP)');
-    otelSg.connections.allowFrom(fargate.loadBalancer, ec2.Port.tcp(13133), 'ALB to collector (health)');
-
-    new cdk.CfnOutput(this, 'OtelForwardTo', {
-      value: `https://${recordHost}:4318`,
-      description: 'gateway.yaml telemetry.forward_to (ADOT collector via the gateway ALB)',
-    });
-
     // ── Outputs ───────────────────────────────────────────────────────────────
     new cdk.CfnOutput(this, 'AlbDnsName', { value: fargate.loadBalancer.loadBalancerDnsName });
     new cdk.CfnOutput(this, 'PublicUrl', { value: publicUrl });
@@ -423,6 +323,12 @@ export class GatewayStack extends cdk.Stack {
     new cdk.CfnOutput(this, 'CertFingerprintHint', {
       value: `openssl s_client -connect ${recordHost}:443 -servername ${recordHost} | openssl x509 -noout -fingerprint -sha256`,
       description: 'Run this to get the cert SHA-256 to publish to developers (the CLI pins it)',
+    });
+    new cdk.CfnOutput(this, 'CwMetricsApiKeySecretName', {
+      value: cwMetricsApiKeySecret.secretName,
+      description:
+        'Set this secret to a CloudWatch Metrics API key (iam create-service-specific-credential ' +
+        '--service-name cloudwatch.amazonaws.com) before telemetry works — see docs/deployment.md "Telemetry".',
     });
   }
 }

--- a/claude-apps-gateway/cdk/lib/claude-gateway-stack.ts
+++ b/claude-apps-gateway/cdk/lib/claude-gateway-stack.ts
@@ -206,16 +206,6 @@ export class GatewayStack extends cdk.Stack {
       //     --secret-string '<your-oidc-client-secret>'
       secretStringValue: cdk.SecretValue.unsafePlainText('REPLACE_ME'),
     });
-    // CloudWatch Metrics OTLP endpoint bearer token (a service-specific credential
-    // for an IAM user with the CloudWatchAPIKeyAccess policy — see docs/deployment.md
-    // "Telemetry"). Not an AWS-managed secret: create it out of band, then either
-    // `put-secret-value` here or pass it as CW_METRICS_API_KEY at deploy time.
-    const cwMetricsApiKeySecret = new secretsmanager.Secret(this, 'CwMetricsApiKeySecret', {
-      secretName: `${gatewayName}-cw-metrics-api-key`,
-      description: 'CloudWatch Metrics OTLP bearer token (service-specific credential) — set the real value after deploy',
-      secretStringValue: cdk.SecretValue.unsafePlainText('REPLACE_ME'),
-    });
-
     // ── Log group (gateway stderr: audit events + operational logs) ───────────
     const logGroup = new logs.LogGroup(this, 'GatewayLogGroup', {
       logGroupName: `/${gatewayName}/gateway`,
@@ -236,7 +226,7 @@ export class GatewayStack extends cdk.Stack {
     // this up via the ECS container-credentials endpoint (no IMDS, no hop-limit trap).
     const taskRole = new iam.Role(this, 'TaskRole', {
       assumedBy: new iam.ServicePrincipal('ecs-tasks.amazonaws.com'),
-      description: 'Claude gateway task role: Bedrock invoke',
+      description: 'Claude gateway task role: Bedrock invoke + CloudWatch metrics',
     });
     taskRole.addToPolicy(
       new iam.PolicyStatement({
@@ -245,6 +235,12 @@ export class GatewayStack extends cdk.Stack {
           `arn:aws:bedrock:${this.region}:${this.account}:inference-profile/us.anthropic.*`,
           'arn:aws:bedrock:*::foundation-model/anthropic.*',
         ],
+      }),
+    );
+    taskRole.addToPolicy(
+      new iam.PolicyStatement({
+        actions: ['cloudwatch:PutMetricData'],
+        resources: ['*'],
       }),
     );
 
@@ -284,13 +280,13 @@ export class GatewayStack extends cdk.Stack {
           CLAUDE_GATEWAY_LOG_LEVEL: 'info',
           CLAUDE_CONFIG_DIR: '/tmp/.claude',
           DB_HOST: db.dbInstanceEndpointAddress,
+          CLAUDE_GATEWAY_ALLOW_LOOPBACK: '1', // ADOT sidecar is on localhost
         },
         secrets: {
           GATEWAY_JWT_SECRET: ecs.Secret.fromSecretsManager(jwtSecret),
           OIDC_CLIENT_SECRET: ecs.Secret.fromSecretsManager(oidcSecret),
           DB_USER: ecs.Secret.fromSecretsManager(dbSecret, 'username'),
           DB_PASSWORD: ecs.Secret.fromSecretsManager(dbSecret, 'password'),
-          CW_METRICS_API_KEY: ecs.Secret.fromSecretsManager(cwMetricsApiKeySecret),
         },
         logDriver: ecs.LogDrivers.awsLogs({ streamPrefix: 'gateway', logGroup }),
       },
@@ -303,6 +299,46 @@ export class GatewayStack extends cdk.Stack {
       ec2.Port.tcp(443),
       'developers to ALB (HTTPS)',
     );
+
+    // ── ADOT collector sidecar (OTLP receiver → CW native OTLP metrics) ─────
+    // Receives OTLP from the gateway on localhost:4318 and forwards to CloudWatch's
+    // native OTLP endpoint using SigV4 via the task role.
+    // Runs as a sidecar in the same task (no ALB listener, no extra SG).
+    const adotConfig = [
+      'extensions:',
+      '  sigv4auth:',
+      '    service: monitoring',
+      `    region: ${this.region}`,
+      'receivers:',
+      '  otlp:',
+      '    protocols:',
+      '      http:',
+      '        endpoint: 127.0.0.1:4318',
+      'processors:',
+      '  batch:',
+      '    send_batch_size: 200',
+      '    timeout: 10s',
+      'exporters:',
+      '  otlphttp:',
+      `    metrics_endpoint: https://monitoring.${this.region}.amazonaws.com/v1/metrics`,
+      '    auth:',
+      '      authenticator: sigv4auth',
+      '    compression: gzip',
+      'service:',
+      '  extensions: [sigv4auth]',
+      '  pipelines:',
+      '    metrics:',
+      '      receivers: [otlp]',
+      '      processors: [batch]',
+      '      exporters: [otlphttp]',
+    ].join('\n');
+    fargate.taskDefinition.addContainer('otel-collector', {
+      image: ecs.ContainerImage.fromRegistry('public.ecr.aws/aws-observability/aws-otel-collector:latest'),
+      essential: false, // gateway continues if the collector crashes; telemetry is non-critical
+      environment: { AOT_CONFIG_CONTENT: adotConfig },
+      logging: ecs.LogDrivers.awsLogs({ streamPrefix: 'otel', logGroup }),
+      memoryReservationMiB: 128,
+    });
 
     // Health check → /healthz (liveness). Keeps replicas in rotation during a
     // Postgres blip; pointing it at /readyz would drain all replicas at once.
@@ -323,12 +359,6 @@ export class GatewayStack extends cdk.Stack {
     new cdk.CfnOutput(this, 'CertFingerprintHint', {
       value: `openssl s_client -connect ${recordHost}:443 -servername ${recordHost} | openssl x509 -noout -fingerprint -sha256`,
       description: 'Run this to get the cert SHA-256 to publish to developers (the CLI pins it)',
-    });
-    new cdk.CfnOutput(this, 'CwMetricsApiKeySecretName', {
-      value: cwMetricsApiKeySecret.secretName,
-      description:
-        'Set this secret to a CloudWatch Metrics API key (iam create-service-specific-credential ' +
-        '--service-name cloudwatch.amazonaws.com) before telemetry works — see docs/deployment.md "Telemetry".',
     });
   }
 }

--- a/claude-apps-gateway/cdk/scripts/setup.sh
+++ b/claude-apps-gateway/cdk/scripts/setup.sh
@@ -144,11 +144,12 @@ LOG_GROUP="${LOG_GROUP:-/claude-gateway/gateway}"
 LOG_RETENTION_DAYS="${LOG_RETENTION_DAYS:-90}"
 GATEWAY_LOG_LEVEL="${GATEWAY_LOG_LEVEL:-info}"
 
-# Telemetry collector (ADOT) — its own small Fargate service, reached over the
-# gateway ALB's HTTPS :4318 listener (the gateway requires https:// for a
-# non-loopback forward_to target; see the telemetry block in gateway.yaml.template).
-OTEL_SERVICE="${OTEL_SERVICE:-otel}"
-ADOT_IMAGE="${ADOT_IMAGE:-public.ecr.aws/aws-observability/aws-otel-collector:latest}"
+# CloudWatch Metrics OTLP bearer token (a service-specific credential for an IAM
+# user with the CloudWatchAPIKeyAccess policy — see docs/deployment.md "Telemetry").
+# Not created by this script: create it out of band, then export it here so phase 4
+# seeds/updates Secrets Manager from it (same pattern as OIDC_CLIENT_SECRET below).
+CW_METRICS_API_KEY="${CW_METRICS_API_KEY:-}"
+CW_METRICS_API_KEY_SECRET_NAME="${PROJECT}-cw-metrics-api-key"
 
 # Required inputs (no safe default — fail loudly). See header.
 PUBLIC_URL="${PUBLIC_URL:?required: the internal ALB https origin, e.g. https://claude-gateway.example.com}"
@@ -410,11 +411,10 @@ ensure_sg() {
   fi
   echo "${id}"
 }
-ALB_SG="$(ensure_sg "${PROJECT}-alb-sg"  "ALB: 443 from client CIDR, 4318 from task SG")"
+ALB_SG="$(ensure_sg "${PROJECT}-alb-sg"  "ALB: 443 from client CIDR")"
 TASK_SG="$(ensure_sg "${PROJECT}-task-sg" "Gateway tasks: 8080 from ALB only")"
 RDS_SG="$(ensure_sg "${PROJECT}-rds-sg"  "RDS: 5432 from task SG only")"
 VPCE_SG="$(ensure_sg "${PROJECT}-vpce-sg" "VPC endpoints: 443 from task SG")"
-OTEL_SG="$(ensure_sg "${PROJECT}-otel-sg" "ADOT collector: 4318+13133 from ALB SG only")"
 
 # authorize helper: add a rule, tolerating "already exists".
 sg_ingress_cidr() { aws ec2 authorize-security-group-ingress --group-id "$1" \
@@ -423,14 +423,10 @@ sg_ingress_sg()   { aws ec2 authorize-security-group-ingress --group-id "$1" \
   --protocol tcp --port "$2" --source-group "$3" --region "${AWS_REGION}" >/dev/null 2>&1 || true; }
 
 sg_ingress_cidr "${ALB_SG}"  443   "${INGRESS_CIDR}"  # developers → ALB (sign-in)
-sg_ingress_sg   "${ALB_SG}"  4318  "${TASK_SG}"       # gateway task → ALB (OTLP over HTTPS)
 sg_ingress_sg   "${TASK_SG}" 8080  "${ALB_SG}"        # ALB → tasks
 sg_ingress_sg   "${RDS_SG}"  5432  "${TASK_SG}"       # tasks → RDS (NOT a CIDR)
 sg_ingress_sg   "${VPCE_SG}" 443   "${TASK_SG}"       # gateway tasks → VPC endpoints
-sg_ingress_sg   "${VPCE_SG}" 443   "${OTEL_SG}"       # collector → VPC endpoints (CloudWatch logs/metrics)
-sg_ingress_sg   "${OTEL_SG}" 4318  "${ALB_SG}"        # ALB → ADOT collector (OTLP)
-sg_ingress_sg   "${OTEL_SG}" 13133 "${ALB_SG}"        # ALB → ADOT collector (health)
-info "security groups: alb=${ALB_SG} task=${TASK_SG} rds=${RDS_SG} vpce=${VPCE_SG} otel=${OTEL_SG}"
+info "security groups: alb=${ALB_SG} task=${TASK_SG} rds=${RDS_SG} vpce=${VPCE_SG}"
 
 # 3e. Interface VPC endpoints (AWS-backbone, no internet) + S3 gateway endpoint.
 PRIVATE_SUBNETS="${PRI_SUBNET_A} ${PRI_SUBNET_B}"
@@ -547,6 +543,32 @@ if [[ "$(aws_q secretsmanager get-secret-value --secret-id "${OIDC_SECRET_NAME}"
     aws secretsmanager put-secret-value --secret-id ${OIDC_SECRET_NAME} --secret-string '<your-oidc-client-secret>' --region ${AWS_REGION}"
 fi
 
+# CloudWatch Metrics OTLP bearer token — same seed-or-placeholder pattern as the
+# OIDC secret above, but telemetry is optional-by-construction: no preflight/guard
+# blocks the deploy on a REPLACE_ME value here, since the gateway runs fine (just
+# without telemetry) until you set it. See docs/deployment.md "Telemetry" for how
+# to generate the token (aws iam create-service-specific-credential).
+if aws_q secretsmanager describe-secret --secret-id "${CW_METRICS_API_KEY_SECRET_NAME}" >/dev/null; then
+  if [[ -n "${CW_METRICS_API_KEY}" ]] && [[ "$(aws_q secretsmanager get-secret-value \
+       --secret-id "${CW_METRICS_API_KEY_SECRET_NAME}" --query SecretString)" != "${CW_METRICS_API_KEY}" ]]; then
+    aws secretsmanager put-secret-value --secret-id "${CW_METRICS_API_KEY_SECRET_NAME}" \
+      --secret-string "${CW_METRICS_API_KEY}" --region "${AWS_REGION}" >/dev/null
+    info "updated ${CW_METRICS_API_KEY_SECRET_NAME} from CW_METRICS_API_KEY"
+  else
+    skip "secret ${CW_METRICS_API_KEY_SECRET_NAME}"
+  fi
+else
+  aws secretsmanager create-secret --name "${CW_METRICS_API_KEY_SECRET_NAME}" \
+    --description "CloudWatch Metrics OTLP bearer token" \
+    --secret-string "${CW_METRICS_API_KEY:-REPLACE_ME}" --region "${AWS_REGION}" >/dev/null
+  if [[ -n "${CW_METRICS_API_KEY}" ]]; then
+    info "created ${CW_METRICS_API_KEY_SECRET_NAME} (seeded from CW_METRICS_API_KEY)"
+  else
+    info "created ${CW_METRICS_API_KEY_SECRET_NAME} (placeholder REPLACE_ME — telemetry stays off until you set it)"
+  fi
+fi
+CW_METRICS_API_KEY_SECRET_ARN="$(aws_q secretsmanager describe-secret --secret-id "${CW_METRICS_API_KEY_SECRET_NAME}" --query ARN)"
+
 # ──────────────────────────────────────────────────────────────────────────────
 # Phase 5 — IAM roles + CloudWatch log group
 # ──────────────────────────────────────────────────────────────────────────────
@@ -583,7 +605,7 @@ aws iam attach-role-policy --role-name "${EXEC_ROLE}" \
 EXEC_SECRETS_POLICY=$(cat <<JSON
 {"Version":"2012-10-17","Statement":[
   {"Effect":"Allow","Action":["secretsmanager:GetSecretValue"],
-   "Resource":["${JWT_SECRET_ARN}","${OIDC_SECRET_ARN}","${DB_SECRET_ARN}"]},
+   "Resource":["${JWT_SECRET_ARN}","${OIDC_SECRET_ARN}","${DB_SECRET_ARN}","${CW_METRICS_API_KEY_SECRET_ARN}"]},
   {"Effect":"Allow","Action":["logs:CreateLogStream","logs:PutLogEvents"],
    "Resource":"arn:aws:logs:${AWS_REGION}:${ACCOUNT_ID}:log-group:${LOG_GROUP}:*"}
 ]}
@@ -612,14 +634,6 @@ JSON
 aws iam put-role-policy --role-name "${TASK_ROLE}" \
   --policy-name "${PROJECT}-bedrock-invoke" --policy-document "${BEDROCK_POLICY}" >/dev/null
 TASK_ROLE_ARN="$(aws iam get-role --role-name "${TASK_ROLE}" --query Role.Arn --output text)"
-
-# 5c. ADOT collector task role — CloudWatch metrics + logs.
-OTEL_TASK_ROLE="${PROJECT}-otel-task-role"
-ensure_role "${OTEL_TASK_ROLE}"
-OTEL_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["cloudwatch:PutMetricData","logs:CreateLogStream","logs:PutLogEvents","logs:CreateLogGroup","logs:DescribeLogStreams","logs:DescribeLogGroups"],"Resource":"*"}]}'
-aws iam put-role-policy --role-name "${OTEL_TASK_ROLE}" \
-  --policy-name "${PROJECT}-otel" --policy-document "${OTEL_POLICY}" >/dev/null
-OTEL_TASK_ROLE_ARN="$(aws iam get-role --role-name "${OTEL_TASK_ROLE}" --query Role.Arn --output text)"
 info "exec=${EXEC_ROLE_ARN}"
 info "task=${TASK_ROLE_ARN}"
 
@@ -690,99 +704,6 @@ else
   info "created HTTPS:443 listener (cert ${CERT_ARN})"
 fi
 
-# 6b. ADOT collector — reached over the gateway ALB's HTTPS :4318 listener. The
-# gateway requires https:// for a non-loopback forward_to and has no custom-CA/
-# skip-verify option, so the collector sits behind the ALB's publicly-trusted
-# cert (TLS terminates at the ALB; the collector speaks plain OTLP/HTTP behind it).
-# The health_check extension on :13133 gives the target group something to GET.
-OTEL_TG_ARN="$(aws_q elbv2 describe-target-groups --names "${PROJECT}-otel-tg" \
-  --query 'TargetGroups[0].TargetGroupArn' || true)"
-if [[ -z "${OTEL_TG_ARN}" || "${OTEL_TG_ARN}" == "None" ]]; then
-  OTEL_TG_ARN="$(aws_q elbv2 create-target-group --name "${PROJECT}-otel-tg" \
-    --protocol HTTP --port 4318 --vpc-id "${VPC_ID}" --target-type ip \
-    --health-check-protocol HTTP --health-check-port 13133 --health-check-path / \
-    --matcher HttpCode=200 \
-    --query 'TargetGroups[0].TargetGroupArn')"
-  info "created target group ${PROJECT}-otel-tg (health :13133)"
-else
-  skip "target group ${PROJECT}-otel-tg"
-fi
-# shellcheck disable=SC2016  # backticks are JMESPath literal syntax, not shell expansion
-if [[ "$(aws_q elbv2 describe-listeners --load-balancer-arn "${ALB_ARN}" \
-      --query 'Listeners[?Port==`4318`].ListenerArn')" =~ arn: ]]; then
-  skip "HTTPS:4318 listener"
-else
-  aws elbv2 create-listener --load-balancer-arn "${ALB_ARN}" \
-    --protocol HTTPS --port 4318 \
-    --certificates "CertificateArn=${CERT_ARN}" \
-    --ssl-policy ELBSecurityPolicy-TLS13-1-2-2021-06 \
-    --default-actions "Type=forward,TargetGroupArn=${OTEL_TG_ARN}" \
-    --region "${AWS_REGION}" >/dev/null
-  info "created HTTPS:4318 listener → otel target group"
-fi
-
-ADOT_CONFIG='extensions:
-  health_check:
-    endpoint: 0.0.0.0:13133
-receivers:
-  otlp:
-    protocols:
-      http:
-        endpoint: 0.0.0.0:4318
-processors:
-  batch: {}
-exporters:
-  awsemf:
-    namespace: ClaudeGateway
-    log_group_name: /claude-gateway/otel-metrics
-service:
-  extensions: [health_check]
-  pipelines:
-    metrics:
-      receivers: [otlp]
-      processors: [batch]
-      exporters: [awsemf]'
-
-OTEL_TASKDEF=$(cat <<JSON
-{
-  "family": "${PROJECT}-otel",
-  "networkMode": "awsvpc",
-  "requiresCompatibilities": ["FARGATE"],
-  "cpu": "256", "memory": "512",
-  "executionRoleArn": "${EXEC_ROLE_ARN}",
-  "taskRoleArn": "${OTEL_TASK_ROLE_ARN}",
-  "containerDefinitions": [{
-    "name": "aws-otel-collector",
-    "image": "${ADOT_IMAGE}",
-    "essential": true,
-    "portMappings": [{"containerPort": 4318, "protocol": "tcp"}, {"containerPort": 13133, "protocol": "tcp"}],
-    "environment": [{"name": "AOT_CONFIG_CONTENT", "value": $(printf '%s' "${ADOT_CONFIG}" | jq -Rs .)}],
-    "logConfiguration": {"logDriver": "awslogs", "options": {
-      "awslogs-group": "${LOG_GROUP}", "awslogs-region": "${AWS_REGION}", "awslogs-stream-prefix": "otel"}}
-  }]
-}
-JSON
-)
-OTEL_TD_ARN="$(aws_q ecs register-task-definition --cli-input-json "${OTEL_TASKDEF}" \
-  --query 'taskDefinition.taskDefinitionArn')"
-info "registered ADOT task def ${OTEL_TD_ARN}"
-
-# ADOT Fargate service — registered to the otel target group on the ALB.
-if aws_q ecs describe-services --cluster "${CLUSTER}" --services "${OTEL_SERVICE}" \
-     --query "services[?status=='ACTIVE'].serviceName" | grep -q .; then
-  aws ecs update-service --cluster "${CLUSTER}" --service "${OTEL_SERVICE}" \
-    --task-definition "${OTEL_TD_ARN}" --region "${AWS_REGION}" >/dev/null
-  skip "ecs service ${OTEL_SERVICE} (updated task def)"
-else
-  aws ecs create-service --cluster "${CLUSTER}" --service-name "${OTEL_SERVICE}" \
-    --task-definition "${OTEL_TD_ARN}" --desired-count 1 --launch-type FARGATE \
-    --health-check-grace-period-seconds 60 \
-    --network-configuration "awsvpcConfiguration={subnets=[${PRI_SUBNET_A},${PRI_SUBNET_B}],securityGroups=[${OTEL_SG}],assignPublicIp=DISABLED}" \
-    --load-balancers "targetGroupArn=${OTEL_TG_ARN},containerName=aws-otel-collector,containerPort=4318" \
-    --region "${AWS_REGION}" >/dev/null
-  info "created ADOT service ${OTEL_SERVICE} (behind ALB :4318)"
-fi
-
 # 6d. Route 53 private A-record (alias to the ALB).
 RECORD_NAME="${PUBLIC_URL#https://}"
 CHANGE_BATCH=$(cat <<JSON
@@ -820,7 +741,8 @@ GW_TASKDEF=$(cat <<JSON
       {"name": "GATEWAY_JWT_SECRET",  "valueFrom": "${JWT_SECRET_ARN}"},
       {"name": "OIDC_CLIENT_SECRET",  "valueFrom": "${OIDC_SECRET_ARN}"},
       {"name": "DB_USER",     "valueFrom": "${DB_SECRET_ARN}:username::"},
-      {"name": "DB_PASSWORD", "valueFrom": "${DB_SECRET_ARN}:password::"}
+      {"name": "DB_PASSWORD", "valueFrom": "${DB_SECRET_ARN}:password::"},
+      {"name": "CW_METRICS_API_KEY", "valueFrom": "${CW_METRICS_API_KEY_SECRET_ARN}"}
     ],
     "logConfiguration": {"logDriver": "awslogs", "options": {
       "awslogs-group": "${LOG_GROUP}", "awslogs-region": "${AWS_REGION}", "awslogs-stream-prefix": "gateway"}}
@@ -885,6 +807,12 @@ $(log "Deploy complete")
   ${TLS_STEP}
   5. Push forceLoginMethod/forceLoginGatewayUrl to developer machines
      (managed-settings.json — see the Verify section of docs/deployment.md).
+  6. Telemetry is OFF until you set a real CloudWatch Metrics API key:
+        aws iam create-service-specific-credential --user-name <a CloudWatchAPIKeyAccess IAM user> \\
+          --service-name cloudwatch.amazonaws.com
+        aws secretsmanager put-secret-value --secret-id ${CW_METRICS_API_KEY_SECRET_NAME} \\
+          --secret-string '<ServiceCredentialSecret>' --region ${AWS_REGION}
+     (see docs/deployment.md "Telemetry"). Then re-run this script to roll the task def.
 
   Smoke test once DNS + a session route exist:
      curl -fsS ${PUBLIC_URL}/.well-known/oauth-authorization-server | jq .

--- a/claude-apps-gateway/cdk/test/gateway-stack.test.ts
+++ b/claude-apps-gateway/cdk/test/gateway-stack.test.ts
@@ -9,8 +9,8 @@ import { GatewayStack, GatewayStackProps } from '../lib/claude-gateway-stack';
  *
  * The focus is the non-obvious wiring that breaks the gateway if it regresses:
  * the dual-ARN Bedrock policy, the IPv4-only internal ALB, the raised idle
- * timeout, the /healthz target-group check, the HTTPS :4318 telemetry listener,
- * and the createVpcEndpoints opt-out added for VPC reuse.
+ * timeout, the /healthz target-group check, and the createVpcEndpoints opt-out
+ * added for VPC reuse.
  */
 
 const ACCOUNT = '111122223333';
@@ -103,10 +103,24 @@ describe('pass 2 (imageReady: true) — full stack', () => {
     });
   });
 
-  test('there is an HTTPS :4318 telemetry listener (TLS terminates at the ALB)', () => {
+  test('telemetry forwards directly to CloudWatch — no ADOT collector service or :4318 listener', () => {
+    // The CloudWatch OTLP metrics endpoint accepts a bearer token, so
+    // telemetry.forward_to points straight at it — no collector service, no
+    // extra ALB listener needed.
+    template.resourceCountIs('AWS::ECS::Service', 1);
     template.hasResourceProperties('AWS::ElasticLoadBalancingV2::Listener', {
-      Port: 4318,
-      Protocol: 'HTTPS',
+      Port: 443,
+    });
+    const listeners = template.findResources('AWS::ElasticLoadBalancingV2::Listener', {
+      Properties: { Port: 4318 },
+    });
+    expect(Object.keys(listeners)).toHaveLength(0);
+  });
+
+  test('a CloudWatch Metrics API key secret is provisioned as a REPLACE_ME placeholder', () => {
+    template.hasResourceProperties('AWS::SecretsManager::Secret', {
+      Name: 'claude-gateway-cw-metrics-api-key',
+      SecretString: 'REPLACE_ME',
     });
   });
 

--- a/claude-apps-gateway/cdk/test/gateway-stack.test.ts
+++ b/claude-apps-gateway/cdk/test/gateway-stack.test.ts
@@ -103,10 +103,10 @@ describe('pass 2 (imageReady: true) — full stack', () => {
     });
   });
 
-  test('telemetry forwards directly to CloudWatch — no ADOT collector service or :4318 listener', () => {
-    // The CloudWatch OTLP metrics endpoint accepts a bearer token, so
-    // telemetry.forward_to points straight at it — no collector service, no
-    // extra ALB listener needed.
+  test('telemetry forwards via ADOT collector sidecar — no separate service or :4318 ALB listener', () => {
+    // The ADOT collector runs as a sidecar in the same task, receiving OTLP
+    // on localhost:4318 and forwarding to CW via SigV4 (task role). No separate
+    // collector service, no extra ALB listener needed.
     template.resourceCountIs('AWS::ECS::Service', 1);
     template.hasResourceProperties('AWS::ElasticLoadBalancingV2::Listener', {
       Port: 443,
@@ -115,13 +115,6 @@ describe('pass 2 (imageReady: true) — full stack', () => {
       Properties: { Port: 4318 },
     });
     expect(Object.keys(listeners)).toHaveLength(0);
-  });
-
-  test('a CloudWatch Metrics API key secret is provisioned as a REPLACE_ME placeholder', () => {
-    template.hasResourceProperties('AWS::SecretsManager::Secret', {
-      Name: 'claude-gateway-cw-metrics-api-key',
-      SecretString: 'REPLACE_ME',
-    });
   });
 
   test('gateway target group health check points at /healthz, not /readyz', () => {

--- a/claude-apps-gateway/docs/deployment.md
+++ b/claude-apps-gateway/docs/deployment.md
@@ -239,48 +239,27 @@ Publish the cert's SHA-256 fingerprint (printed by `setup.sh`, or the
 
 ## Telemetry
 
-`gateway.yaml`'s `telemetry.forward_to` points straight at CloudWatch's native
-OTLP metrics endpoint (`https://monitoring.<region>.amazonaws.com/v1/metrics`) —
-no collector to run. It authenticates with a CloudWatch Metrics API key (a
-bearer token), not SigV4: the gateway attaches a static `Authorization` header,
-it doesn't sign requests with AWS credentials.
+`gateway.yaml`'s `telemetry.forward_to` sends OTLP metrics to an **ADOT collector
+sidecar** running in the same Fargate task. The gateway pushes to
+`http://localhost:4318` (the ADOT collector's OTLP receiver), and the agent forwards to
+CloudWatch using **SigV4 via the ECS task role**. No
+key rotation, no expiration concerns.
 
-Both tracks provision a Secrets Manager secret (`<project>-cw-metrics-api-key`)
-as a `REPLACE_ME` placeholder — telemetry stays off until you set it, same
-pattern as the OIDC client secret. Generate the token:
+The ADOT sidecar:
+- Authenticates automatically using the task role (needs `cloudwatch:PutMetricData`,
+  already granted in the CDK stack / `setup.sh` IAM policy)
+- Is marked **non-essential** — if the agent crashes, the gateway continues serving
+  inference traffic uninterrupted
+- Requires `CLAUDE_GATEWAY_ALLOW_LOOPBACK=1` on the gateway container (already set)
+  to permit forwarding to a localhost destination (the gateway's SSRF guard blocks
+  loopback by default)
 
-```bash
-# One-time IAM user + managed policy (or use the AWS console "Generate API key"
-# quick start under CloudWatch > Settings > Global, which does this for you).
-aws iam create-user --user-name cloudwatch-metrics-api-key-user
-aws iam attach-user-policy --user-name cloudwatch-metrics-api-key-user \
-  --policy-arn arn:aws:iam::aws:policy/CloudWatchAPIKeyAccess
+Both tracks provision this automatically — no manual credential setup required for
+telemetry. The task role's `cloudwatch:PutMetricData` permission is the only
+prerequisite.
 
-aws iam create-service-specific-credential \
-  --user-name cloudwatch-metrics-api-key-user \
-  --service-name cloudwatch.amazonaws.com
-# No --credential-age-days: the credential never expires. This example has no
-# alerting on telemetry health, so an expiring credential fails silently —
-# the gateway logs a 403 on every export but keeps serving inference traffic.
-# Rotate deliberately with `aws iam reset-service-specific-credential` if your
-# security policy requires it.
-# → note the ServiceCredentialSecret value; it can't be retrieved again.
-```
-
-Then seed it and roll the service:
-
-```bash
-# Track A
-aws secretsmanager put-secret-value --secret-id claude-gateway-cw-metrics-api-key \
-  --secret-string '<ServiceCredentialSecret>'
-aws ecs update-service --cluster claude-gateway --service claude-gateway --force-new-deployment
-
-# Track B — same secretsmanager command with the CDK-stack secret name
-# (CwMetricsApiKeySecretName output), then force-new-deployment as above.
-```
-
-Metrics only: the bearer-token endpoint doesn't accept logs or traces — those
-need SigV4 or a separate logs-specific bearer token, out of scope here. See
+Metrics only: the ADOT sidecar in this example is configured for metrics. Logs and
+traces need additional ADOT pipeline configuration and are out of scope here. See
 [`workshop/03-telemetry/README.md`](../workshop/03-telemetry/README.md) and
 [`gotchas.md`](gotchas.md) §1 for more.
 

--- a/claude-apps-gateway/docs/deployment.md
+++ b/claude-apps-gateway/docs/deployment.md
@@ -2,8 +2,8 @@
 
 The canonical install walkthrough for this example: prerequisites, then one of two
 deployment tracks, then verification. Both tracks provision the **same** ECS Fargate
-deployment (internal ALB, RDS PostgreSQL, ECR, Secrets Manager, IAM task role,
-ADOT telemetry collector); pick by what you want:
+deployment (internal ALB, RDS PostgreSQL, ECR, Secrets Manager, IAM task role);
+pick by what you want:
 
 | Track | Tool | Best when | Teardown |
 |---|---|---|---|
@@ -113,8 +113,8 @@ What it does, in order: stamps `gateway.yaml` from the template (refusing to
 continue if any placeholder is unresolved), downloads the pinned `claude` binary and
 verifies its SHA-256 against the GPG-signed release manifest, builds and pushes the
 distroless image, then provisions VPC + endpoints, RDS, Secrets Manager, the
-internal IPv4 ALB (idle timeout 3600s, `/healthz` health check), the ECS services
-(gateway + ADOT collector), DNS, and IAM.
+internal IPv4 ALB (idle timeout 3600s, `/healthz` health check), the gateway ECS
+service, DNS, and IAM.
 
 It is **idempotent** — re-run it any time to roll a new image or reconcile drift.
 It finishes by printing the ALB hostname, the OAuth redirect URI to register, and
@@ -237,12 +237,55 @@ Publish the cert's SHA-256 fingerprint (printed by `setup.sh`, or the
 `CertFingerprintHint` stack output) so developers can confirm the prompt on first
 `/login`. (A public, browser-trusted ACM cert shows no prompt — see prerequisite 2.)
 
+## Telemetry
+
+`gateway.yaml`'s `telemetry.forward_to` points straight at CloudWatch's native
+OTLP metrics endpoint (`https://monitoring.<region>.amazonaws.com/v1/metrics`) —
+no collector to run. It authenticates with a CloudWatch Metrics API key (a
+bearer token), not SigV4: the gateway attaches a static `Authorization` header,
+it doesn't sign requests with AWS credentials.
+
+Both tracks provision a Secrets Manager secret (`<project>-cw-metrics-api-key`)
+as a `REPLACE_ME` placeholder — telemetry stays off until you set it, same
+pattern as the OIDC client secret. Generate the token:
+
+```bash
+# One-time IAM user + managed policy (or use the AWS console "Generate API key"
+# quick start under CloudWatch > Settings > Global, which does this for you).
+aws iam create-user --user-name cloudwatch-metrics-api-key-user
+aws iam attach-user-policy --user-name cloudwatch-metrics-api-key-user \
+  --policy-arn arn:aws:iam::aws:policy/CloudWatchAPIKeyAccess
+
+aws iam create-service-specific-credential \
+  --user-name cloudwatch-metrics-api-key-user \
+  --service-name cloudwatch.amazonaws.com \
+  --credential-age-days 90
+# → note the ServiceCredentialSecret value; it can't be retrieved again.
+```
+
+Then seed it and roll the service:
+
+```bash
+# Track A
+aws secretsmanager put-secret-value --secret-id claude-gateway-cw-metrics-api-key \
+  --secret-string '<ServiceCredentialSecret>'
+aws ecs update-service --cluster claude-gateway --service claude-gateway --force-new-deployment
+
+# Track B — same secretsmanager command with the CDK-stack secret name
+# (CwMetricsApiKeySecretName output), then force-new-deployment as above.
+```
+
+Metrics only: the bearer-token endpoint doesn't accept logs or traces — those
+need SigV4 or a separate logs-specific bearer token, out of scope here. See
+[`workshop/03-telemetry/README.md`](../workshop/03-telemetry/README.md) and
+[`gotchas.md`](gotchas.md) §1 for more.
+
 ## Cost expectations
 
-A live deploy of this example idles at roughly **US$6–8/day** (us-east-1,
-defaults). The two biggest line items are easy to miss: the **five interface VPC
-endpoints × two AZs (~$2.40/day)** and the **NAT gateway (~$1.15/day + data)**;
-Fargate (2× gateway + 1× collector) is ~$1.50/day, the ALB ~$0.60/day, RDS
+A live deploy of this example idles at roughly **US$5–7/day** (us-east-1,
+defaults). The two biggest line items are easy to miss: the **six interface VPC
+endpoints × two AZs (~$2.90/day)** and the **NAT gateway (~$1.15/day + data)**;
+Fargate (2× gateway) is ~$1/day, the ALB ~$0.60/day, RDS
 `db.t4g.micro` ~$0.45/day. If you build the Client VPN sketch from
 [`connectivity.md`](connectivity.md), add ~$2.40/day per subnet association plus
 $0.05/h per connected client. Tear down when idle ([`teardown.md`](teardown.md)).

--- a/claude-apps-gateway/docs/deployment.md
+++ b/claude-apps-gateway/docs/deployment.md
@@ -258,8 +258,12 @@ aws iam attach-user-policy --user-name cloudwatch-metrics-api-key-user \
 
 aws iam create-service-specific-credential \
   --user-name cloudwatch-metrics-api-key-user \
-  --service-name cloudwatch.amazonaws.com \
-  --credential-age-days 90
+  --service-name cloudwatch.amazonaws.com
+# No --credential-age-days: the credential never expires. This example has no
+# alerting on telemetry health, so an expiring credential fails silently —
+# the gateway logs a 403 on every export but keeps serving inference traffic.
+# Rotate deliberately with `aws iam reset-service-specific-credential` if your
+# security policy requires it.
 # → note the ServiceCredentialSecret value; it can't be retrieved again.
 ```
 

--- a/claude-apps-gateway/docs/gotchas.md
+++ b/claude-apps-gateway/docs/gotchas.md
@@ -12,40 +12,57 @@ live deploy does.
 
 ---
 
-## 1. Telemetry: the OTLP collector must be HTTPS  **[hit live]**
+## 1. Telemetry: `forward_to.url` must be the bare origin, not the OTLP path  **[hit live]**
 
-**Symptom:** gateway fails to boot, logs:
+**Symptom:** the gateway boots fine and relays telemetry, but every export logs:
 ```
-forward_to.url must be https:// (http:// allowed for loopback only)
+otel forward to https://monitoring.<region>.amazonaws.com/v1/metrics failed: Error: 404 Not Found
 ```
 
-**Why:** the gateway requires `https://` for any **non-loopback** `telemetry.forward_to`
-target. A natural AWS design points it at a collector over a private Cloud Map name
-(`http://otel.<ns>:4318`) — but that's plain HTTP, so boot fails. The published
-`aws-otel-collector` image does **not** serve TLS out of the box.
+**Why:** the gateway appends the OTLP-standard signal path itself (`/v1/metrics`
+for metrics, `/v1/logs`, `/v1/traces`) — same convention every OTLP HTTP
+exporter follows. Configuring `forward_to.url` as
+`https://monitoring.<region>.amazonaws.com/v1/metrics` (i.e. already including
+the suffix) makes the actual request go to `.../v1/metrics/v1/metrics`, which
+404s. The upstream config docs' own examples confirm this: they show a bare
+origin (`https://otel-collector.internal.example.com`,
+`https://api.datadoghq.com/api/v2/otlp`) with no signal-specific suffix.
 
-**The tension:** the two obvious ways to satisfy the HTTPS rule both have a catch:
-- **Sidecar collector** in the same task → reachable on `localhost`, but that's
-  *loopback*, which the gateway's SSRF guard blocks unless you set
-  `CLAUDE_GATEWAY_ALLOW_LOOPBACK=1` — and the docs explicitly say keep that unset
-  in production.
-- **Separate collector service** on a private IP → passes the SSRF guard, but now
-  it's non-loopback, so it **must** be HTTPS.
-
-**Fix options:**
-- **Simplest:** leave `telemetry.forward_to` commented out. Telemetry is
-  optional-by-construction; the gateway runs fine without it and inference is
-  unaffected. (This is what the example ships by default.)
-- **To actually forward telemetry:** front the collector with TLS — e.g. an
-  internal NLB/ALB terminating an ACM cert, or give the collector a cert the
-  gateway trusts — and point `forward_to` at its `https://` name.
-
-> Takeaway: budget for TLS on your telemetry collector from day one, or
-> accept telemetry-off. Don't assume a plain private endpoint will work.
+**Fix:** point `forward_to.url` at `https://monitoring.<region>.amazonaws.com`
+— no `/v1/metrics`. `gateway.yaml.template` and `gateway.yaml.example` in this
+repo already do this correctly; this entry exists because an earlier draft of
+the CloudWatch-direct migration got it wrong and only a live deploy caught it
+(the gateway logs the failure but doesn't fail boot or the client request —
+telemetry silently drops).
 
 ---
 
-## 2. Baked config must be world-readable in the image  **[hit live]**
+## 2. Telemetry: OTLP-ingested metrics don't show up in `list-metrics`/`get-metric-data`  **[hit live]**
+
+**Symptom:** the gateway relays telemetry with zero errors, but `list-metrics` /
+`get-metric-data` / `get-metric-statistics` return empty even minutes after real traffic.
+
+**Why:** those classic APIs only surface `PutMetricData`-style metrics. OTLP-ingested
+metrics land in a separate PromQL-native backend — no propagation delay involved, those
+APIs simply never return OTLP data.
+
+**Fix:** verify via the PromQL HTTP API (`https://monitoring.<region>.amazonaws.com/api/v1/query`,
+SigV4-signed) or a PromQL-aware surface (Query Studio, Grafana), e.g. `{"claude_code.session.count"}`.
+
+---
+
+## 3. Telemetry: CloudWatch's OTLP endpoint is metrics-only, and auth is a bearer token, not SigV4
+
+The gateway signs no AWS requests itself, so `telemetry.forward_to`'s static
+`url` + `headers` reaches CloudWatch's native OTLP endpoint directly via a
+bearer-token API key — no collector needed. See `gateway.yaml.template`'s
+`telemetry:` block and [docs/deployment.md](deployment.md) "Telemetry" for setup.
+Logs and traces need SigV4 or their own separate auth, so this example ships
+`logs: false` / `traces: false`.
+
+---
+
+## 4. Baked config must be world-readable in the image  **[hit live]**
 
 **Symptom:** every gateway task crash-loops; logs:
 ```
@@ -87,7 +104,7 @@ COPY --from=config /out/etc/claude /etc/claude
 
 ---
 
-## 3. The ALB pattern opens 443 to the world by default  **[hit live]**
+## 5. The ALB pattern opens 443 to the world by default  **[hit live]**
 
 **Symptom (CDK):** the synthesized template has a security-group ingress of
 `CidrIp: 0.0.0.0/0` on port 443, even though you created a separate, restricted SG.
@@ -113,7 +130,7 @@ svc.loadBalancer.connections.allowFrom(ec2.Peer.ipv4(ingressCidr), ec2.Port.tcp(
 
 ---
 
-## 4. An internal ALB is unreachable from a laptop — and you can't fix that with public exposure  **[hit live]**
+## 6. An internal ALB is unreachable from a laptop — and you can't fix that with public exposure  **[hit live]**
 
 **Symptom:** `claude /login` from a laptop reports
 `Could not resolve gateway host …`, or the connection times out.
@@ -143,7 +160,7 @@ machines. So you cannot "just expose it":
 
 ---
 
-## 5. IPv4-only internal ALB — dual-stack returns public AAAA  **[verified live]**
+## 7. IPv4-only internal ALB — dual-stack returns public AAAA  **[verified live]**
 
 **Symptom:** `/login` rejects the gateway as public even though the ALB is
 "internal".
@@ -157,7 +174,7 @@ deploy: the internal IPv4 ALB resolved to `10.0.x.x` only, with **no AAAA record
 
 ---
 
-## 6. Bedrock model access is a separate, non-IAM prerequisite
+## 8. Bedrock model access is a separate, non-IAM prerequisite
 
 **Symptom:** invoke returns `AccessDeniedException` even though the IAM policy is
 correct.
@@ -172,7 +189,7 @@ failure** and it's easy to miss because IAM looks correct.
 
 ---
 
-## 7. Bedrock IAM needs two ARN families
+## 9. Bedrock IAM needs two ARN families
 
 **Symptom:** `403` on invoke despite granting `bedrock:InvokeModel*`.
 
@@ -187,7 +204,7 @@ account segment — `:*::` — that's correct, not a typo.)
 
 ---
 
-## 8. EC2/EKS-on-EC2: the IMDSv2 hop-limit trap
+## 10. EC2/EKS-on-EC2: the IMDSv2 hop-limit trap
 
 **Symptom:** every Bedrock request `502`s with
 `Could not load credentials from any providers` — but boot and `/readyz` pass.
@@ -205,7 +222,7 @@ reason.)
 
 ---
 
-## 9. The RDS-managed master secret has no `host` field
+## 11. The RDS-managed master secret has no `host` field
 
 **Symptom:** injecting `DB_HOST` from `<rds-secret>:host::` resolves empty / fails.
 
@@ -220,7 +237,7 @@ only needs `postgres://${DB_HOST}:5432/<db>?sslmode=require`.
 
 ---
 
-## 10. `public_url` drives everything — and forces planning, not a redeploy loop
+## 12. `public_url` drives everything — and forces planning, not a redeploy loop
 
 **Why:** the gateway builds its OIDC `redirect_uri` and discovery doc **only** from
 `listen.public_url`, never from `X-Forwarded-*` (those are client-spoofable). So:
@@ -234,7 +251,7 @@ service** (the two-pass deploy).
 
 ---
 
-## 11. Config is baked → the image is per-environment
+## 13. Config is baked → the image is per-environment
 
 **Why:** on ECS the task definition's `secrets:` injects **env vars only**, never
 files, so this example bakes `gateway.yaml` into the image (only secrets + DB facts
@@ -250,7 +267,7 @@ can use `${file:/secrets/…}` and keep the image generic. (See `eks-notes.md`.)
 
 ---
 
-## 12. TLS cert pinning — ACM renewal is a planned event
+## 14. TLS cert pinning — ACM renewal is a planned event
 
 **Why:** the CLI pins the ALB **leaf certificate by SHA-256** on first `/login`.
 When ACM renews the cert, the fingerprint changes.
@@ -261,7 +278,7 @@ cert, developers need the CA in their OS trust store or `NODE_EXTRA_CA_CERTS` se
 
 ---
 
-## 13. Operational papercuts  **[hit live]**
+## 15. Operational papercuts  **[hit live]**
 
 - **`AWS_REGION` overrides `CDK_DEFAULT_REGION`.** A deploy can silently land in the
   wrong region if `AWS_REGION` is set in your shell. Pin region explicitly and
@@ -291,7 +308,7 @@ cert, developers need the CA in their OS trust store or `NODE_EXTRA_CA_CERTS` se
 
 ---
 
-## 14. Smoke-testing without laptop connectivity  **[hit live]**
+## 16. Smoke-testing without laptop connectivity  **[hit live]**
 
 If you can't reach the internal ALB yet, you can still validate the full HTTP
 surface with a **throwaway Fargate task in the VPC** that curls the gateway:
@@ -314,7 +331,7 @@ needs real connectivity + the OIDC client secret set).
 
 ---
 
-## 15. A gateway session and a direct-Bedrock config can't share a config dir  **[hit live]**
+## 17. A gateway session and a direct-Bedrock config can't share a config dir  **[hit live]**
 
 **Symptom:** a developer signs in to the gateway successfully (the gateway audit
 log shows `session.mint` → success and `managed.serve`), but the CLI then exits
@@ -358,7 +375,7 @@ Back up any existing managed-settings file before testing, and restore it after.
 
 ---
 
-## 16. Re-running `/login` when already signed in shows the generic picker  **[hit live]**
+## 18. Re-running `/login` when already signed in shows the generic picker  **[hit live]**
 
 **Symptom:** after a successful gateway sign-in, running `/login` **again** shows
 the normal `1. Claude account / 2. Console / 3. 3rd-party` picker, which looks like

--- a/claude-apps-gateway/docs/gotchas.md
+++ b/claude-apps-gateway/docs/gotchas.md
@@ -51,14 +51,21 @@ SigV4-signed) or a PromQL-aware surface (Query Studio, Grafana), e.g. `{"claude_
 
 ---
 
-## 3. Telemetry: CloudWatch's OTLP endpoint is metrics-only, and auth is a bearer token, not SigV4
+## 3. Telemetry: ADOT collector sidecar handles SigV4 auth
 
-The gateway signs no AWS requests itself, so `telemetry.forward_to`'s static
-`url` + `headers` reaches CloudWatch's native OTLP endpoint directly via a
-bearer-token API key — no collector needed. See `gateway.yaml.template`'s
-`telemetry:` block and [docs/deployment.md](deployment.md) "Telemetry" for setup.
-Logs and traces need SigV4 or their own separate auth, so this example ships
-`logs: false` / `traces: false`.
+This example runs an **ADOT collector sidecar** in the same Fargate task.
+The gateway sends OTLP to `http://localhost:4318` (the ADOT container), which
+forwards metrics to CloudWatch using **SigV4 via the ECS task role** — no bearer
+The task role needs
+`cloudwatch:PutMetricData` (already granted in the CDK stack / `setup.sh`).
+
+The ADOT sidecar is marked **non-essential**: if the agent crashes, the gateway
+continues serving inference traffic. `CLAUDE_GATEWAY_ALLOW_LOOPBACK=1` is set on
+the gateway container to permit forwarding to the localhost destination (the
+gateway's SSRF guard blocks loopback by default).
+
+Logs and traces need additional ADOT pipeline configuration and are out of scope — this
+example ships `logs: false` / `traces: false`.
 
 ---
 

--- a/claude-apps-gateway/docs/teardown.md
+++ b/claude-apps-gateway/docs/teardown.md
@@ -92,7 +92,7 @@ aws rds delete-db-subnet-group --db-subnet-group-name "$P-db-subnets" --region "
 
 ```bash
 # gateway-owned secrets (the RDS-managed master secret is deleted with the instance)
-for SEC in "$P-jwt-secret" "$P-oidc-client-secret" "$P-cw-metrics-api-key"; do
+for SEC in "$P-jwt-secret" "$P-oidc-client-secret"; do
   aws secretsmanager delete-secret --secret-id "$SEC" --force-delete-without-recovery --region "$AWS_REGION"
 done
 # IAM roles: delete inline policies + detach managed, then the role
@@ -107,14 +107,6 @@ for R in "$P-exec-role" "$P-task-role"; do
 done
 # log group
 aws logs delete-log-group --log-group-name /claude-gateway/gateway --region "$AWS_REGION" 2>/dev/null
-
-# If you created a dedicated IAM user + service-specific credential for the
-# CloudWatch Metrics API key (see docs/deployment.md "Telemetry"), remove those too:
-#   aws iam delete-service-specific-credential --user-name cloudwatch-metrics-api-key-user \
-#     --service-specific-credential-id <id> --region "$AWS_REGION"
-#   aws iam detach-user-policy --user-name cloudwatch-metrics-api-key-user \
-#     --policy-arn arn:aws:iam::aws:policy/CloudWatchAPIKeyAccess
-#   aws iam delete-user --user-name cloudwatch-metrics-api-key-user
 ```
 
 ### 5. ECR repo

--- a/claude-apps-gateway/docs/teardown.md
+++ b/claude-apps-gateway/docs/teardown.md
@@ -54,14 +54,12 @@ export AWS_REGION=us-east-1
 P=claude-gateway            # PROJECT
 ```
 
-### 1. ECS services + cluster
+### 1. ECS service + cluster
 
 ```bash
-# scale to 0, delete both services, then the cluster
-for S in "$P" otel; do
-  aws ecs update-service --cluster "$P" --service "$S" --desired-count 0 --region "$AWS_REGION" 2>/dev/null
-  aws ecs delete-service  --cluster "$P" --service "$S" --force --region "$AWS_REGION" 2>/dev/null
-done
+# scale to 0, delete the service, then the cluster
+aws ecs update-service --cluster "$P" --service "$P" --desired-count 0 --region "$AWS_REGION" 2>/dev/null
+aws ecs delete-service  --cluster "$P" --service "$P" --force --region "$AWS_REGION" 2>/dev/null
 aws ecs delete-cluster --cluster "$P" --region "$AWS_REGION"
 ```
 
@@ -75,12 +73,10 @@ for L in $(aws elbv2 describe-listeners --load-balancer-arn "$ALB_ARN" --region 
   aws elbv2 delete-listener --listener-arn "$L" --region "$AWS_REGION"
 done
 aws elbv2 delete-load-balancer --load-balancer-arn "$ALB_ARN" --region "$AWS_REGION"
-sleep 30   # let the ALB finish deleting before removing its target groups
-for TG in "$P-tg" "$P-otel-tg"; do
-  ARN=$(aws elbv2 describe-target-groups --names "$TG" --region "$AWS_REGION" \
-    --query 'TargetGroups[0].TargetGroupArn' --output text 2>/dev/null)
-  [ -n "$ARN" ] && [ "$ARN" != "None" ] && aws elbv2 delete-target-group --target-group-arn "$ARN" --region "$AWS_REGION"
-done
+sleep 30   # let the ALB finish deleting before removing its target group
+ARN=$(aws elbv2 describe-target-groups --names "$P-tg" --region "$AWS_REGION" \
+  --query 'TargetGroups[0].TargetGroupArn' --output text 2>/dev/null)
+[ -n "$ARN" ] && [ "$ARN" != "None" ] && aws elbv2 delete-target-group --target-group-arn "$ARN" --region "$AWS_REGION"
 ```
 
 ### 3. RDS (no final snapshot — example posture)
@@ -96,11 +92,11 @@ aws rds delete-db-subnet-group --db-subnet-group-name "$P-db-subnets" --region "
 
 ```bash
 # gateway-owned secrets (the RDS-managed master secret is deleted with the instance)
-for SEC in "$P-jwt-secret" "$P-oidc-client-secret"; do
+for SEC in "$P-jwt-secret" "$P-oidc-client-secret" "$P-cw-metrics-api-key"; do
   aws secretsmanager delete-secret --secret-id "$SEC" --force-delete-without-recovery --region "$AWS_REGION"
 done
 # IAM roles: delete inline policies + detach managed, then the role
-for R in "$P-exec-role" "$P-task-role" "$P-otel-task-role"; do
+for R in "$P-exec-role" "$P-task-role"; do
   for P_INLINE in $(aws iam list-role-policies --role-name "$R" --query 'PolicyNames[]' --output text 2>/dev/null); do
     aws iam delete-role-policy --role-name "$R" --policy-name "$P_INLINE"
   done
@@ -109,10 +105,16 @@ for R in "$P-exec-role" "$P-task-role" "$P-otel-task-role"; do
   done
   aws iam delete-role --role-name "$R" 2>/dev/null
 done
-# log groups
-for LG in /claude-gateway/gateway /claude-gateway/otel-metrics; do
-  aws logs delete-log-group --log-group-name "$LG" --region "$AWS_REGION" 2>/dev/null
-done
+# log group
+aws logs delete-log-group --log-group-name /claude-gateway/gateway --region "$AWS_REGION" 2>/dev/null
+
+# If you created a dedicated IAM user + service-specific credential for the
+# CloudWatch Metrics API key (see docs/deployment.md "Telemetry"), remove those too:
+#   aws iam delete-service-specific-credential --user-name cloudwatch-metrics-api-key-user \
+#     --service-specific-credential-id <id> --region "$AWS_REGION"
+#   aws iam detach-user-policy --user-name cloudwatch-metrics-api-key-user \
+#     --policy-arn arn:aws:iam::aws:policy/CloudWatchAPIKeyAccess
+#   aws iam delete-user --user-name cloudwatch-metrics-api-key-user
 ```
 
 ### 5. ECR repo

--- a/claude-apps-gateway/workshop/03-telemetry/README.md
+++ b/claude-apps-gateway/workshop/03-telemetry/README.md
@@ -32,21 +32,24 @@ telemetry:
 - Each destination independently opts into metrics, logs, and traces
 - Multiple destinations are supported (e.g., one for metrics, another for logs)
 
-### CloudWatch OTLP (AWS-native, no collector)
+### CloudWatch OTLP via ADOT collector sidecar (AWS-native)
 
-Amazon CloudWatch's native OTLP metrics endpoint accepts requests straight from the gateway — no ADOT collector, no extra ECS service, no ALB listener to run. The endpoint is already HTTPS, and it accepts a **bearer-token API key** as an alternative to SigV4, which is exactly what `telemetry.forward_to`'s `url` + `headers` config already supports:
+This example runs an **AWS Distro for OpenTelemetry (ADOT) collector sidecar** in the same Fargate task as the gateway. The gateway sends OTLP to `http://localhost:4318` (the ADOT container), which forwards metrics to CloudWatch using **SigV4 via the task role**:
 
 ```yaml
 telemetry:
   forward_to:
     # No /v1/metrics suffix — the gateway appends the OTLP signal path itself.
-    - url: https://monitoring.us-east-1.amazonaws.com
-      headers:
-        Authorization: Bearer ${CW_METRICS_API_KEY}
+    - url: http://localhost:4318
       metrics: true
 ```
 
-See [`docs/deployment.md`](../../docs/deployment.md#telemetry) for how to generate the `CW_METRICS_API_KEY` bearer token and seed it. This endpoint is metrics-only: logs and traces need SigV4 or a separate bearer-token setup, so keep them `false` unless you add that separately.
+The ADOT sidecar:
+- Authenticates to CloudWatch automatically using the ECS task role (needs `cloudwatch:PutMetricData`, already granted in the CDK stack)
+- Is marked **non-essential** — if the agent crashes, the gateway continues serving inference traffic
+- Requires `CLAUDE_GATEWAY_ALLOW_LOOPBACK=1` on the gateway container (already set) to permit forwarding to a localhost destination
+
+See [`docs/deployment.md`](../../docs/deployment.md#telemetry) for deployment details. This endpoint is metrics-only: logs and traces need a separate setup, so keep them `false` unless you add that separately.
 
 ### What gets stamped on each metric
 
@@ -114,8 +117,8 @@ The developer doesn't set any of these manually.
 ```
 ✅ Gateway boots with "telemetry relay: 1 destination(s), signals enabled: metrics,logs"
 ✅ Gateway rejects loopback OTLP destinations by default (SSRF guard)
-✅ CLAUDE_GATEWAY_ALLOW_LOOPBACK=1 overrides for local development
+✅ CLAUDE_GATEWAY_ALLOW_LOOPBACK=1 overrides for localhost ADOT sidecar forwarding
 ✅ Per-user attribution proven via /effective endpoint (email, name, spend per period)
-✅ CloudWatch integration documented (direct to the native OTLP metrics endpoint, bearer-token auth, no collector)
+✅ ADOT collector sidecar receives OTLP on localhost:4318, forwards to CW via SigV4 (task role)
 ⚠️ Actual OTLP data flow requires an interactive Claude Code session (CLI sends to gateway, gateway relays to collector)
 ```

--- a/claude-apps-gateway/workshop/03-telemetry/README.md
+++ b/claude-apps-gateway/workshop/03-telemetry/README.md
@@ -32,38 +32,21 @@ telemetry:
 - Each destination independently opts into metrics, logs, and traces
 - Multiple destinations are supported (e.g., one for metrics, another for logs)
 
-### CloudWatch OTLP (AWS-native)
+### CloudWatch OTLP (AWS-native, no collector)
 
-Amazon CloudWatch now supports native OTLP metrics ingestion. To send gateway telemetry to CloudWatch, you need an OTLP collector (such as the AWS Distro for OpenTelemetry) running in your VPC that forwards to CloudWatch. The collector authenticates to CloudWatch using its IAM role.
+Amazon CloudWatch's native OTLP metrics endpoint accepts requests straight from the gateway — no ADOT collector, no extra ECS service, no ALB listener to run. The endpoint is already HTTPS, and it accepts a **bearer-token API key** as an alternative to SigV4, which is exactly what `telemetry.forward_to`'s `url` + `headers` config already supports:
 
-Example collector setup (ADOT running as ECS sidecar or separate service):
-```yaml
-# ADOT collector config
-receivers:
-  otlp:
-    protocols:
-      http:
-        endpoint: 0.0.0.0:4318
-
-exporters:
-  awsemf:
-    namespace: ClaudeGateway
-    region: us-east-1
-
-service:
-  pipelines:
-    metrics:
-      receivers: [otlp]
-      exporters: [awsemf]
-```
-
-Then point the gateway at the collector:
 ```yaml
 telemetry:
   forward_to:
-    - url: https://adot-collector.internal.company.com:4318
+    # No /v1/metrics suffix — the gateway appends the OTLP signal path itself.
+    - url: https://monitoring.us-east-1.amazonaws.com
+      headers:
+        Authorization: Bearer ${CW_METRICS_API_KEY}
       metrics: true
 ```
+
+See [`docs/deployment.md`](../../docs/deployment.md#telemetry) for how to generate the `CW_METRICS_API_KEY` bearer token and seed it. This endpoint is metrics-only: logs and traces need SigV4 or a separate bearer-token setup, so keep them `false` unless you add that separately.
 
 ### What gets stamped on each metric
 
@@ -133,6 +116,6 @@ The developer doesn't set any of these manually.
 ✅ Gateway rejects loopback OTLP destinations by default (SSRF guard)
 ✅ CLAUDE_GATEWAY_ALLOW_LOOPBACK=1 overrides for local development
 ✅ Per-user attribution proven via /effective endpoint (email, name, spend per period)
-✅ CloudWatch integration documented (via ADOT collector pattern)
+✅ CloudWatch integration documented (direct to the native OTLP metrics endpoint, bearer-token auth, no collector)
 ⚠️ Actual OTLP data flow requires an interactive Claude Code session (CLI sends to gateway, gateway relays to collector)
 ```


### PR DESCRIPTION
Switch the ADOT collector from awsemf (lossy CW Logs intermediary) to the native CloudWatch OTLP endpoint (otlphttp + sigv4auth).

Why: awsemf flattens OTel semantics with no PromQL, lost type/temporality, extra CW Logs cost. Native OTLP (GA June 2026) sends metrics directly to the monitoring endpoint, preserving full OTel semantics and enabling rate(), histogram_quantile(), etc.
 