### PR TITLE
fix(claude-apps-gateway): make the CDK deploy.sh convenience path work end-to-end + doc fixes

### DIFF
--- a/claude-apps-gateway/cdk/.env.example
+++ b/claude-apps-gateway/cdk/.env.example
@@ -18,3 +18,13 @@ ALLOWED_EMAIL_DOMAINS=yourcompany.com
 
 # --- AWS / Bedrock ---
 BEDROCK_REGION=us-east-1
+
+# --- TLS (imported ACM cert for GATEWAY_HOSTNAME) ---
+# Required. Import a PUBLIC, browser-trusted cert so DNS validation needs no
+# public endpoint (the ALB stays internal) and the CLI skips the fingerprint
+# prompt on first /login. See the "TLS" section of cdk/README.md.
+CERT_ARN=arn:aws:acm:us-east-1:123456789012:certificate/abc-123
+
+# --- Network ingress ---
+# Required. The VPN/corp CLIENT CIDR developers connect from — NOT the VPC CIDR.
+INGRESS_CIDR=10.0.0.0/8

--- a/claude-apps-gateway/cdk/.env.example
+++ b/claude-apps-gateway/cdk/.env.example
@@ -28,3 +28,10 @@ CERT_ARN=arn:aws:acm:us-east-1:123456789012:certificate/abc-123
 # --- Network ingress ---
 # Required. The VPN/corp CLIENT CIDR developers connect from — NOT the VPC CIDR.
 INGRESS_CIDR=10.0.0.0/8
+
+# --- Optional: reuse an existing VPC (e.g. to keep a Client VPN association intact) ---
+# Leave unset to let CDK create a fresh VPC. If the reused VPC already has the
+# Bedrock/Secrets Manager/ECR/CloudWatch/S3 interface endpoints, also set
+# CREATE_VPC_ENDPOINTS=false — the stack refuses to recreate them.
+# VPC_ID=vpc-0123456789abcdef0
+# CREATE_VPC_ENDPOINTS=false

--- a/claude-apps-gateway/cdk/README.md
+++ b/claude-apps-gateway/cdk/README.md
@@ -102,8 +102,9 @@ validation never needs the hostname to be publicly resolvable.
 > from the tracked distroless `Dockerfile` and SHA-verified binary. The
 > `.env` + `deploy.sh` flow in the steps below is a convenience path: `deploy.sh`
 > builds the image via CodeBuild using its own inline Dockerfile and config, and
-> `npx cdk deploy` still needs the required context values supplied (e.g. in
-> `cdk.context.json`).
+> maps your `.env` values onto the CDK context (`-c`) the stack requires, running
+> both deploy passes for you. Driving `npx cdk deploy` directly (Option B below)
+> means supplying that context yourself.
 
 ### Step 1: Configure
 
@@ -134,6 +135,12 @@ ALLOWED_EMAIL_DOMAINS=company.com
 
 # AWS region where Amazon Bedrock models are available
 BEDROCK_REGION=us-east-1
+
+# Imported ACM cert ARN for GATEWAY_HOSTNAME (use a public, browser-trusted cert)
+CERT_ARN=arn:aws:acm:us-east-1:123456789012:certificate/abc-123
+
+# VPN/corp CLIENT CIDR developers connect from — NOT the VPC CIDR
+INGRESS_CIDR=10.0.0.0/8
 ```
 
 ### Step 2: Install dependencies
@@ -150,19 +157,32 @@ npm install
 ./scripts/deploy.sh
 ```
 
-**Option B: Infrastructure only.** Deploy the stack, then push the image separately:
+**Option B: Drive CDK yourself.** Run the two passes by hand, supplying the
+context the stack requires (`deploy.sh` does this for you from `.env`). Pass 1
+creates just the ECR repo; build and push the image to the ECR URI shown in its
+outputs; then pass 2 brings up the full stack (the service starts automatically
+at `desiredCount 2` — no manual scale-up):
 
 ```bash
 npx cdk bootstrap    # first time only
-npx cdk deploy
+
+# Pass 1: ECR repo only
+npx cdk deploy -c imageReady=false \
+  -c publicUrl=https://claude-gateway.internal.company.com \
+  -c zoneName=internal.company.com -c ingressCidr=10.0.0.0/8 \
+  -c certArn=arn:aws:acm:us-east-1:123456789012:certificate/abc-123
+
+# ...build + push the image to the ECR repo...
+
+# Pass 2: full stack (imageReady defaults to true)
+npx cdk deploy \
+  -c publicUrl=https://claude-gateway.internal.company.com \
+  -c zoneName=internal.company.com -c ingressCidr=10.0.0.0/8 \
+  -c certArn=arn:aws:acm:us-east-1:123456789012:certificate/abc-123
 ```
 
-After the stack completes, build and push the gateway image to the ECR URI shown in the outputs, then scale up:
-
-```bash
-aws ecs update-service --cluster claude-gateway --service claude-gateway-svc \
-  --desired-count 1 --force-new-deployment
-```
+See [CDK context variables](#cdk-context-variables) for the full list, or
+[`../docs/deployment.md`](../docs/deployment.md) for the canonical walkthrough.
 
 ### Step 4: Verify
 
@@ -210,6 +230,8 @@ All values come from `.env`. The CDK code reads them at deploy time.
 | `OIDC_CLIENT_SECRET` | OAuth client secret from your IdP app registration |
 | `ALLOWED_EMAIL_DOMAINS` | Only users with these email domains can sign in |
 | `BEDROCK_REGION` | Region for Bedrock API calls |
+| `CERT_ARN` | Imported ACM cert ARN for `GATEWAY_HOSTNAME` (required; `deploy.sh` maps it to the `certArn` context) |
+| `INGRESS_CIDR` | VPN/corp **client** CIDR developers connect from — **not** the VPC CIDR (required; maps to `ingressCidr`) |
 
 ### CDK context variables
 
@@ -233,14 +255,24 @@ pass 2 (default) deploys the full stack.
 
 ## Before going to production
 
-This stack is designed for quick testing and proof-of-concept. Before using it with real workloads:
+This stack is a worked example — it already ships the security-relevant defaults
+(internal IPv4-only ALB, `desiredCount: 2`, ECS tasks in private subnets, the OIDC
+client secret and DB credentials pulled from Secrets Manager). What it trades for
+easy teardown is data durability. Before using it with real workloads, edit
+`claude-gateway-stack.ts` to:
 
-- Change the ALB from `internetFacing: true` to `internetFacing: false` in `claude-gateway-stack.ts`. Developers must access it through VPN.
-- Enable `deletionProtection: true` on the RDS instance so it's not accidentally deleted.
-- Move the OIDC client secret to AWS Secrets Manager instead of passing it as an environment variable.
-- Increase `desiredCount` from 0 to 2+ for high availability.
-- Use private subnets for ECS tasks and remove `assignPublicIp: true`.
-- Set up a VPN or Direct Connect so developers on the corporate network can reach the internal ALB.
+- **Protect the database.** The RDS instance uses `deletionProtection: false`,
+  `removalPolicy: DESTROY`, `multiAz: false`, and `backupRetention: 1 day` for clean
+  teardown. Flip to `deletionProtection: true`, `removalPolicy: RETAIN`,
+  `multiAz: true`, and a longer backup window.
+- **Retain the other stateful resources.** The ECR repository (`emptyOnDelete: true`)
+  and the log group set `removalPolicy: DESTROY`, and the secrets default to it. Switch
+  them to `RETAIN` so a `cdk destroy` can't wipe images, credentials, or audit logs.
+- **Populate the OIDC client secret.** The stack creates it in Secrets Manager with a
+  placeholder — set the real value from your IdP before developers sign in.
+- **Set up VPN or Direct Connect** so developers on the corporate network can reach the
+  internal ALB (its hostname must resolve to private IPs only, which is why the ALB is
+  internal in the first place).
 
 ## Testing without a VPN (local workaround)
 

--- a/claude-apps-gateway/cdk/README.md
+++ b/claude-apps-gateway/cdk/README.md
@@ -221,7 +221,7 @@ All values come from `.env`. The CDK code reads them at deploy time.
 
 | Variable | What it is |
 |----------|-----------|
-| `GATEWAY_NAME` | Prefix for all resource names (cluster, service, ALB, RDS, etc.) |
+| `GATEWAY_NAME` | Prefix for the stack's named resources (repo, cluster, service, secrets, log group); `deploy.sh` passes it to the `gatewayName` context so the stack matches |
 | `GATEWAY_HOSTNAME` | The full DNS name developers connect to |
 | `HOSTED_ZONE_ID` | Route53 zone ID where the DNS record is created (optional if managing DNS externally) |
 | `HOSTED_ZONE_NAME` | Route53 zone name (optional if managing DNS externally) |
@@ -232,6 +232,8 @@ All values come from `.env`. The CDK code reads them at deploy time.
 | `BEDROCK_REGION` | Region for Bedrock API calls |
 | `CERT_ARN` | Imported ACM cert ARN for `GATEWAY_HOSTNAME` (required; `deploy.sh` maps it to the `certArn` context) |
 | `INGRESS_CIDR` | VPN/corp **client** CIDR developers connect from — **not** the VPC CIDR (required; maps to `ingressCidr`) |
+| `VPC_ID` | Optional. Reuse an existing VPC (e.g. to keep a Client VPN association intact) instead of creating one; maps to `vpcId` |
+| `CREATE_VPC_ENDPOINTS` | Optional. Set `false` with `VPC_ID` when the reused VPC already has the interface endpoints; maps to `createVpcEndpoints` |
 
 ### CDK context variables
 

--- a/claude-apps-gateway/cdk/bin/app.ts
+++ b/claude-apps-gateway/cdk/bin/app.ts
@@ -16,6 +16,7 @@ import { GatewayStack } from '../lib/claude-gateway-stack';
  * Context vars (pass with -c key=value, or set in cdk.json / cdk.context.json):
  *   RUNTIME / INFRA (consumed by the stack):
  *     region          AWS region (default: CDK_DEFAULT_REGION or us-east-1)
+ *     gatewayName     name prefix for repo/cluster/service/secrets/log group (default: claude-gateway)
  *     publicUrl       internal ALB https origin, e.g. https://claude-gateway.example.com   (required)
  *     imageTag        ECR image tag (default: the claudeVersion below)
  *     certArn         ACM cert ARN for publicUrl's hostname — IMPORTED   (required for pass 2)
@@ -40,6 +41,7 @@ const claudeVersion = ctx('claudeVersion') ?? '2.1.199';
 new GatewayStack(app, 'ClaudeGatewayStack', {
   env: { account: process.env.CDK_DEFAULT_ACCOUNT, region },
   description: 'Claude apps gateway on ECS Fargate with Amazon Bedrock (worked example)',
+  gatewayName: ctx('gatewayName'),
   publicUrl: ctx('publicUrl'),
   imageTag: ctx('imageTag') ?? claudeVersion,
   certArn: ctx('certArn'),

--- a/claude-apps-gateway/cdk/lib/claude-gateway-stack.ts
+++ b/claude-apps-gateway/cdk/lib/claude-gateway-stack.ts
@@ -37,6 +37,12 @@ export interface GatewayStackProps extends cdk.StackProps {
    * is the opt-out for that case.
    */
   readonly createVpcEndpoints?: boolean;
+  /**
+   * Name prefix for the stack's named resources (ECR repo, cluster, service,
+   * secrets, log group). Mirrors setup.sh's PROJECT. Defaults to 'claude-gateway'.
+   * deploy.sh passes this through from the .env GATEWAY_NAME.
+   */
+  readonly gatewayName?: string;
   /** false = pass 1 (ECR repo only); true = pass 2 (full stack incl. service). */
   readonly imageReady: boolean;
 }
@@ -51,10 +57,14 @@ export class GatewayStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: GatewayStackProps) {
     super(scope, id, props);
 
+    // Name prefix for the stack's named resources. Mirrors setup.sh's PROJECT so
+    // the two tracks name resources identically; deploy.sh passes it from GATEWAY_NAME.
+    const gatewayName = props.gatewayName ?? 'claude-gateway';
+
     // ── ECR repository (the pass-1 target) ────────────────────────────────────
     // Created first so the image can be built+pushed before the service exists.
     const repo = new ecr.Repository(this, 'Repo', {
-      repositoryName: 'claude-gateway',
+      repositoryName: gatewayName,
       imageScanOnPush: true,
       // Example posture: clean teardown. Harden for production (see README).
       removalPolicy: cdk.RemovalPolicy.DESTROY,
@@ -193,7 +203,7 @@ export class GatewayStack extends cdk.Stack {
 
     // ── Gateway-owned secrets (DB creds come from the RDS-managed secret) ─────
     const jwtSecret = new secretsmanager.Secret(this, 'JwtSecret', {
-      secretName: 'claude-gateway-jwt-secret',
+      secretName: `${gatewayName}-jwt-secret`,
       description: 'Claude gateway JWT signing secret (>=32 bytes)',
       generateSecretString: {
         // >= 32 bytes of entropy; no JSON wrapper — the whole string is the secret.
@@ -202,9 +212,10 @@ export class GatewayStack extends cdk.Stack {
       },
     });
     const oidcSecret = new secretsmanager.Secret(this, 'OidcClientSecret', {
-      secretName: 'claude-gateway-oidc-client-secret',
+      secretName: `${gatewayName}-oidc-client-secret`,
       description: 'Claude gateway OIDC client secret — set the real value after deploy',
-      // Placeholder; replace with the real OIDC client secret:
+      // Placeholder; replace with the real OIDC client secret (secret id is
+      // <gatewayName>-oidc-client-secret):
       //   aws secretsmanager put-secret-value --secret-id claude-gateway-oidc-client-secret \
       //     --secret-string '<your-oidc-client-secret>'
       secretStringValue: cdk.SecretValue.unsafePlainText('REPLACE_ME'),
@@ -212,7 +223,7 @@ export class GatewayStack extends cdk.Stack {
 
     // ── Log group (gateway stderr: audit events + operational logs) ───────────
     const logGroup = new logs.LogGroup(this, 'GatewayLogGroup', {
-      logGroupName: '/claude-gateway/gateway',
+      logGroupName: `/${gatewayName}/gateway`,
       retention: logs.RetentionDays.THREE_MONTHS,
       removalPolicy: cdk.RemovalPolicy.DESTROY,
     });
@@ -220,7 +231,7 @@ export class GatewayStack extends cdk.Stack {
     // ── ECS cluster ───────────────────────────────────────────────────────────
     const cluster = new ecs.Cluster(this, 'Cluster', {
       vpc,
-      clusterName: 'claude-gateway',
+      clusterName: gatewayName,
     });
 
 
@@ -314,7 +325,7 @@ export class GatewayStack extends cdk.Stack {
     const image = ecs.ContainerImage.fromEcrRepository(repo, props.imageTag);
     const fargate = new ecsPatterns.ApplicationLoadBalancedFargateService(this, 'Gateway', {
       cluster,
-      serviceName: 'claude-gateway',
+      serviceName: gatewayName,
       cpu: 512,
       memoryLimitMiB: 1024,
       desiredCount: 2, // zero-downtime rolling deploys + AZ resilience; Postgres is the shared layer

--- a/claude-apps-gateway/cdk/scripts/deploy.sh
+++ b/claude-apps-gateway/cdk/scripts/deploy.sh
@@ -28,21 +28,50 @@ echo "=== Claude Gateway Deploy ==="
 echo "Gateway: https://$GATEWAY_HOSTNAME"
 echo ""
 
-# --- Step 1: CDK Deploy ---
-echo "Step 1/4: Deploying infrastructure (CDK)..."
-npx cdk deploy --require-approval never
-echo "✅ Infrastructure deployed"
+# The stack is parameterized by CDK context (-c), not .env — deploy.sh bridges the
+# two. These are required for the pass-2 (full) deploy; fail early with a clear
+# message rather than letting `cdk synth` throw a cryptic "Missing required context".
+: "${GATEWAY_HOSTNAME:?set GATEWAY_HOSTNAME in .env (e.g. claude-gateway.internal.company.com)}"
+: "${HOSTED_ZONE_NAME:?set HOSTED_ZONE_NAME in .env (your Route53 private zone, e.g. internal.company.com)}"
+: "${CERT_ARN:?set CERT_ARN in .env (imported ACM cert ARN for the GATEWAY_HOSTNAME)}"
+: "${INGRESS_CIDR:?set INGRESS_CIDR in .env (VPN/corp CLIENT CIDR developers connect from — NOT the VPC CIDR)}"
+: "${BEDROCK_REGION:?set BEDROCK_REGION in .env}"
+
+# Map .env → CDK context. deploy.sh builds the image as :latest via CodeBuild, so
+# we pin imageTag=latest to match — otherwise the stack defaults to the pinned
+# claude version tag, which this convenience path never pushes.
+CDK_CTX=(
+  -c "region=${BEDROCK_REGION}"
+  -c "publicUrl=https://${GATEWAY_HOSTNAME}"
+  -c "zoneName=${HOSTED_ZONE_NAME}"
+  -c "ingressCidr=${INGRESS_CIDR}"
+  -c "certArn=${CERT_ARN}"
+  -c "imageTag=latest"
+)
+# zoneId is optional (looked up from zoneName if omitted). Pass it only when the
+# user set a real value, not the .env.example placeholder.
+if [ -n "${HOSTED_ZONE_ID:-}" ] && [ "${HOSTED_ZONE_ID}" != "ZXXXXXXXXXXXXXXXXX" ]; then
+  CDK_CTX+=(-c "zoneId=${HOSTED_ZONE_ID}")
+fi
+
+# --- Step 1: CDK pass 1 — ECR repository only ---
+# The ECS service can't start until its image exists, so the stack splits the
+# deploy in two: pass 1 creates just the ECR repo; we build+push; pass 2 (below)
+# brings up the full stack. See cdk/README.md "CDK context variables".
+echo "Step 1/5: Pass 1 — creating the ECR repository (CDK)..."
+npx cdk deploy --require-approval never -c imageReady=false "${CDK_CTX[@]}"
+echo "✅ ECR repository created"
 echo ""
 
 # --- Step 2: Get outputs ---
-echo "Step 2/4: Reading stack outputs..."
+echo "Step 2/5: Reading stack outputs..."
 ECR_URI=$(aws cloudformation describe-stacks --stack-name ClaudeGatewayStack \
   --query "Stacks[0].Outputs[?OutputKey=='EcrRepositoryUri'].OutputValue" --output text)
 echo "   ECR: $ECR_URI"
 echo ""
 
 # --- Step 3: Build and push image ---
-echo "Step 3/4: Building and pushing gateway image..."
+echo "Step 3/5: Building and pushing gateway image..."
 
 # Check if CodeBuild project exists, create if not
 if ! aws codebuild batch-get-projects --names claude-gateway-build --query "projects[0].name" --output text 2>/dev/null | grep -q claude-gateway-build; then
@@ -161,20 +190,22 @@ while true; do
 done
 echo ""
 
-# --- Step 4: Start the service ---
-echo "Step 4/4: Starting ECS service..."
-aws ecs update-service --cluster "$GATEWAY_NAME" --service "${GATEWAY_NAME}-svc" \
-  --desired-count 1 --force-new-deployment --query "service.desiredCount" --output text >/dev/null
+# --- Step 4: CDK pass 2 — full stack incl. the Fargate service ---
+# The image now exists in ECR, so pass 2 brings up the service (desiredCount 2)
+# behind the internal ALB. cdk deploy blocks until the service is stable, so no
+# manual `update-service` scale-up is needed.
+echo "Step 4/5: Pass 2 — deploying the full stack (CDK)..."
+npx cdk deploy --require-approval never -c imageReady=true "${CDK_CTX[@]}"
+echo "✅ Full stack deployed"
+echo ""
 
-echo "   Waiting for service to stabilize..."
-sleep 60
-
-# Verify
+# --- Step 5: Verify ---
+echo "Step 5/5: Verifying the gateway..."
 RESPONSE=$(curl -s "https://${GATEWAY_HOSTNAME}/.well-known/oauth-authorization-server" 2>/dev/null || echo "")
 if echo "$RESPONSE" | grep -q "device_authorization_endpoint"; then
   echo "✅ Gateway is live at https://${GATEWAY_HOSTNAME}"
 else
-  echo "⚠️  Gateway may still be starting. Check in a minute with:"
+  echo "⚠️  Gateway may still be starting (or unreachable without VPN). Check with:"
   echo "   curl https://${GATEWAY_HOSTNAME}/.well-known/oauth-authorization-server"
 fi
 

--- a/claude-apps-gateway/cdk/scripts/deploy.sh
+++ b/claude-apps-gateway/cdk/scripts/deploy.sh
@@ -4,7 +4,8 @@
 #
 # Prerequisites:
 #   1. .env file configured (cp .env.example .env)
-#   2. linux-x64/claude binary available (from the gateway tarball)
+#   2. claude linux-x64 binary staged (from the gateway tarball) as either
+#      linux-x64/claude or ./claude — the latter is where the tracked CDK Dockerfile expects it
 #   3. AWS CLI configured
 #   4. npm install already run
 #
@@ -115,14 +116,20 @@ if ! aws codebuild batch-get-projects --names claude-gateway-build --query "proj
     --service-role "arn:aws:iam::${ACCOUNT_ID}:role/claude-gateway-codebuild" >/dev/null
 fi
 
-# Find the linux binary
+# Find the linux binary. Accept the tarball's linux-x64/ layout OR the location the
+# tracked CDK Dockerfile uses (cdk/claude, i.e. ./claude relative to cdk/), so the
+# two documented build paths agree on where the binary lives.
 LINUX_BINARY=""
 if [ -f "../linux-x64/claude" ]; then
   LINUX_BINARY="../linux-x64/claude"
 elif [ -f "./linux-x64/claude" ]; then
   LINUX_BINARY="./linux-x64/claude"
+elif [ -f "./claude" ]; then
+  LINUX_BINARY="./claude"
+elif [ -f "../claude" ]; then
+  LINUX_BINARY="../claude"
 else
-  echo "❌ linux-x64/claude binary not found. Extract it from the gateway tarball."
+  echo "❌ claude binary not found (looked for linux-x64/claude and ./claude). Extract it from the gateway tarball."
   exit 1
 fi
 

--- a/claude-apps-gateway/cdk/scripts/deploy.sh
+++ b/claude-apps-gateway/cdk/scripts/deploy.sh
@@ -33,7 +33,7 @@ echo ""
 # two. These are required for the pass-2 (full) deploy; fail early with a clear
 # message rather than letting `cdk synth` throw a cryptic "Missing required context".
 : "${GATEWAY_HOSTNAME:?set GATEWAY_HOSTNAME in .env (e.g. claude-gateway.internal.company.com)}"
-: "${HOSTED_ZONE_NAME:?set HOSTED_ZONE_NAME in .env (your Route53 private zone, e.g. internal.company.com)}"
+: "${HOSTED_ZONE_NAME:?set HOSTED_ZONE_NAME in .env (your Route53 hosted zone, public or private, e.g. internal.company.com)}"
 : "${CERT_ARN:?set CERT_ARN in .env (imported ACM cert ARN for the GATEWAY_HOSTNAME)}"
 : "${INGRESS_CIDR:?set INGRESS_CIDR in .env (VPN/corp CLIENT CIDR developers connect from — NOT the VPC CIDR)}"
 : "${BEDROCK_REGION:?set BEDROCK_REGION in .env}"

--- a/claude-apps-gateway/cdk/scripts/deploy.sh
+++ b/claude-apps-gateway/cdk/scripts/deploy.sh
@@ -37,11 +37,17 @@ echo ""
 : "${INGRESS_CIDR:?set INGRESS_CIDR in .env (VPN/corp CLIENT CIDR developers connect from — NOT the VPC CIDR)}"
 : "${BEDROCK_REGION:?set BEDROCK_REGION in .env}"
 
+# GATEWAY_NAME is the name prefix for the stack's resources (repo, cluster, service,
+# secrets, log group). The stack honors it via -c gatewayName, so any value works —
+# but it MUST match what CDK creates, hence we thread the same value everywhere below.
+GATEWAY_NAME="${GATEWAY_NAME:-claude-gateway}"
+
 # Map .env → CDK context. deploy.sh builds the image as :latest via CodeBuild, so
 # we pin imageTag=latest to match — otherwise the stack defaults to the pinned
 # claude version tag, which this convenience path never pushes.
 CDK_CTX=(
   -c "region=${BEDROCK_REGION}"
+  -c "gatewayName=${GATEWAY_NAME}"
   -c "publicUrl=https://${GATEWAY_HOSTNAME}"
   -c "zoneName=${HOSTED_ZONE_NAME}"
   -c "ingressCidr=${INGRESS_CIDR}"
@@ -53,6 +59,11 @@ CDK_CTX=(
 if [ -n "${HOSTED_ZONE_ID:-}" ] && [ "${HOSTED_ZONE_ID}" != "ZXXXXXXXXXXXXXXXXX" ]; then
   CDK_CTX+=(-c "zoneId=${HOSTED_ZONE_ID}")
 fi
+# Optional: reuse an existing VPC (e.g. to keep a Client VPN association intact).
+# If that VPC already has the Bedrock/Secrets Manager/ECR/CloudWatch/S3 endpoints,
+# also set CREATE_VPC_ENDPOINTS=false — the stack refuses to recreate them.
+[ -n "${VPC_ID:-}" ] && CDK_CTX+=(-c "vpcId=${VPC_ID}")
+[ -n "${CREATE_VPC_ENDPOINTS:-}" ] && CDK_CTX+=(-c "createVpcEndpoints=${CREATE_VPC_ENDPOINTS}")
 
 # --- Step 1: CDK pass 1 — ECR repository only ---
 # The ECS service can't start until its image exists, so the stack splits the
@@ -67,11 +78,22 @@ echo ""
 echo "Step 2/5: Reading stack outputs..."
 ECR_URI=$(aws cloudformation describe-stacks --stack-name ClaudeGatewayStack \
   --query "Stacks[0].Outputs[?OutputKey=='EcrRepositoryUri'].OutputValue" --output text)
-echo "   ECR: $ECR_URI"
+# The repo name the stack actually created, taken from the URI — this is what the
+# CodeBuild IAM policy and docker tags must reference (never assume GATEWAY_NAME
+# alone, so a name mismatch with the stack can't break the push).
+REPO_NAME="${ECR_URI##*/}"
+echo "   ECR: $ECR_URI (repo: $REPO_NAME)"
 echo ""
 
 # --- Step 3: Build and push image ---
 echo "Step 3/5: Building and pushing gateway image..."
+
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+BUCKET="claude-gateway-build-${ACCOUNT_ID}"
+# Create the S3 build bucket BEFORE the CodeBuild project, which references it as
+# its source location — create-project fails with "Bucket ... does not exist"
+# otherwise (only bites a first-ever run, where the project doesn't yet exist).
+aws s3 mb "s3://$BUCKET" 2>/dev/null || true
 
 # Check if CodeBuild project exists, create if not
 if ! aws codebuild batch-get-projects --names claude-gateway-build --query "projects[0].name" --output text 2>/dev/null | grep -q claude-gateway-build; then
@@ -81,24 +103,17 @@ if ! aws codebuild batch-get-projects --names claude-gateway-build --query "proj
   aws iam create-role --role-name claude-gateway-codebuild \
     --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"codebuild.amazonaws.com"},"Action":"sts:AssumeRole"}]}' 2>/dev/null || true
 
-  ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
-
   aws iam put-role-policy --role-name claude-gateway-codebuild --policy-name build-perms \
-    --policy-document "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"s3:GetObject\",\"s3:ListBucket\"],\"Resource\":[\"arn:aws:s3:::claude-gateway-build-${ACCOUNT_ID}\",\"arn:aws:s3:::claude-gateway-build-${ACCOUNT_ID}/*\"]},{\"Effect\":\"Allow\",\"Action\":[\"ecr:GetAuthorizationToken\"],\"Resource\":\"*\"},{\"Effect\":\"Allow\",\"Action\":[\"ecr:BatchCheckLayerAvailability\",\"ecr:GetDownloadUrlForLayer\",\"ecr:BatchGetImage\",\"ecr:PutImage\",\"ecr:InitiateLayerUpload\",\"ecr:UploadLayerPart\",\"ecr:CompleteLayerUpload\"],\"Resource\":\"arn:aws:ecr:${BEDROCK_REGION}:${ACCOUNT_ID}:repository/${GATEWAY_NAME}\"},{ \"Effect\":\"Allow\",\"Action\":[\"logs:CreateLogGroup\",\"logs:CreateLogStream\",\"logs:PutLogEvents\"],\"Resource\":\"*\"}]}" 2>/dev/null
+    --policy-document "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"s3:GetObject\",\"s3:ListBucket\"],\"Resource\":[\"arn:aws:s3:::claude-gateway-build-${ACCOUNT_ID}\",\"arn:aws:s3:::claude-gateway-build-${ACCOUNT_ID}/*\"]},{\"Effect\":\"Allow\",\"Action\":[\"ecr:GetAuthorizationToken\"],\"Resource\":\"*\"},{\"Effect\":\"Allow\",\"Action\":[\"ecr:BatchCheckLayerAvailability\",\"ecr:GetDownloadUrlForLayer\",\"ecr:BatchGetImage\",\"ecr:PutImage\",\"ecr:InitiateLayerUpload\",\"ecr:UploadLayerPart\",\"ecr:CompleteLayerUpload\"],\"Resource\":\"arn:aws:ecr:${BEDROCK_REGION}:${ACCOUNT_ID}:repository/${REPO_NAME}\"},{ \"Effect\":\"Allow\",\"Action\":[\"logs:CreateLogGroup\",\"logs:CreateLogStream\",\"logs:PutLogEvents\"],\"Resource\":\"*\"}]}" 2>/dev/null
 
   sleep 10  # Wait for IAM propagation
 
   aws codebuild create-project --name claude-gateway-build \
-    --source "{\"type\":\"S3\",\"location\":\"claude-gateway-build-${ACCOUNT_ID}/\",\"buildspec\":\"buildspec.yml\"}" \
+    --source "{\"type\":\"S3\",\"location\":\"${BUCKET}/\",\"buildspec\":\"buildspec.yml\"}" \
     --artifacts '{"type":"NO_ARTIFACTS"}' \
     --environment '{"type":"LINUX_CONTAINER","image":"aws/codebuild/standard:7.0","computeType":"BUILD_GENERAL1_SMALL","privilegedMode":true}' \
     --service-role "arn:aws:iam::${ACCOUNT_ID}:role/claude-gateway-codebuild" >/dev/null
 fi
-
-# Upload build artifacts to S3
-ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
-BUCKET="claude-gateway-build-${ACCOUNT_ID}"
-aws s3 mb "s3://$BUCKET" 2>/dev/null || true
 
 # Find the linux binary
 LINUX_BINARY=""
@@ -121,8 +136,8 @@ phases:
   build:
     commands:
       - chmod +x claude
-      - docker build -t ${GATEWAY_NAME} .
-      - docker tag ${GATEWAY_NAME}:latest ${ECR_URI}:latest
+      - docker build -t ${REPO_NAME} .
+      - docker tag ${REPO_NAME}:latest ${ECR_URI}:latest
   post_build:
     commands:
       - docker push ${ECR_URI}:latest
@@ -157,7 +172,11 @@ session:
   ttl_hours: 1
 
 store:
-  postgres_url: \${GATEWAY_POSTGRES_URL}
+  # Compose the URL from the env vars the CDK task def actually injects (DB_HOST,
+  # DB_USER, DB_PASSWORD) — matches gateway.yaml.template. The CDK task def never
+  # sets GATEWAY_POSTGRES_URL, so referencing it here left the store unconfigured.
+  postgres_url: postgres://\${DB_HOST}:5432/claude_gateway?sslmode=require
+  username: \${DB_USER}
   password: \${DB_PASSWORD}
 
 upstreams:

--- a/claude-apps-gateway/cdk/scripts/setup.sh
+++ b/claude-apps-gateway/cdk/scripts/setup.sh
@@ -30,7 +30,8 @@
 #     behavior). To skip the prompt, use a PUBLIC ACM cert - DNS validation needs no
 #     public endpoint, so the ALB stays internal. See the "TLS: bring an ACM cert"
 #     section of cdk/README.md.
-#   * A private Route 53 hosted zone (ZONE_ID/ZONE_NAME) for the gateway A-record,
+#   * A Route 53 hosted zone (ZONE_ID/ZONE_NAME) for the gateway A-record — public
+#     or private; see the two topologies in docs/deployment.md prerequisite 3 —
 #     plus a network path + private-DNS resolution from developer laptops to the
 #     internal ALB (VPN/DX/TGW). See docs/connectivity.md - the #1 "internal ALB
 #     doesn't work from my laptop" failure.
@@ -164,8 +165,8 @@ ALLOWED_EMAIL_DOMAINS="${ALLOWED_EMAIL_DOMAINS:?required: comma-separated, e.g. 
 # Imported ACM cert for PUBLIC_URL's hostname. The CLI pins its SHA-256 fingerprint
 # on first /login; use a PUBLIC ACM cert to skip the prompt (see the header).
 CERT_ARN="${CERT_ARN:?required: ACM cert ARN for the PUBLIC_URL hostname}"
-ZONE_ID="${ZONE_ID:?required: Route 53 PRIVATE hosted zone id for the gateway A-record}"
-ZONE_NAME="${ZONE_NAME:?required: Route 53 private zone name, e.g. example.com}"
+ZONE_ID="${ZONE_ID:?required: Route 53 hosted zone id for the gateway A-record (public or private; see deployment.md prereq 3)}"
+ZONE_NAME="${ZONE_NAME:?required: Route 53 zone name, e.g. example.com}"
 # The VPN/corp CLIENT CIDR developer traffic arrives from — NOT the VPC CIDR.
 # A wrong guess is either wide-open or fully-closed, so we refuse to default it.
 INGRESS_CIDR="${INGRESS_CIDR:?required: the VPN/corp client CIDR developers connect from}"

--- a/claude-apps-gateway/cdk/test/gateway-stack.test.ts
+++ b/claude-apps-gateway/cdk/test/gateway-stack.test.ts
@@ -160,3 +160,21 @@ describe('createVpcEndpoints opt-out (VPC reuse)', () => {
     template.resourceCountIs('AWS::EC2::VPCEndpoint', 7);
   });
 });
+
+describe('gatewayName parameterization (must match setup.sh PROJECT / deploy.sh GATEWAY_NAME)', () => {
+  test('a custom gatewayName renames the repo, cluster, service, secret, and log group', () => {
+    // Guards the bug where deploy.sh honored GATEWAY_NAME but the stack hardcoded
+    // 'claude-gateway', so a renamed gateway pushed to a repo the IAM policy didn't cover.
+    const t = synth({ ...PASS2, gatewayName: 'claude-gateway2' });
+    t.hasResourceProperties('AWS::ECR::Repository', { RepositoryName: 'claude-gateway2' });
+    t.hasResourceProperties('AWS::ECS::Cluster', { ClusterName: 'claude-gateway2' });
+    t.hasResourceProperties('AWS::ECS::Service', { ServiceName: 'claude-gateway2' });
+    t.hasResourceProperties('AWS::SecretsManager::Secret', { Name: 'claude-gateway2-oidc-client-secret' });
+    t.hasResourceProperties('AWS::Logs::LogGroup', { LogGroupName: '/claude-gateway2/gateway' });
+  });
+
+  test('defaults to claude-gateway when gatewayName is omitted', () => {
+    const t = synth(PASS2);
+    t.hasResourceProperties('AWS::ECR::Repository', { RepositoryName: 'claude-gateway' });
+  });
+});

--- a/claude-apps-gateway/docs/deployment.md
+++ b/claude-apps-gateway/docs/deployment.md
@@ -32,6 +32,15 @@ a common failure:
      --messages '[{"role":"user","content":[{"text":"ping"}]}]' \
      --inference-config '{"maxTokens":5}' >/dev/null && echo model access OK
    ```
+
+   Not every model has a short-alias inference profile. `claude-opus-4-8`,
+   `claude-sonnet-5`, and `claude-fable-5` do, but **Haiku 4.5 exists only as the
+   dated profile** `us.anthropic.claude-haiku-4-5-20251001-v1:0` — the short
+   `us.anthropic.claude-haiku-4-5` is rejected as `ValidationException: invalid`.
+   Run `aws bedrock list-inference-profiles` for the exact IDs. This caveat only
+   affects this manual check; in `gateway.yaml` you still list the **friendly**
+   name (`claude-haiku-4-5`) and the gateway's built-in catalog resolves it to the
+   right profile.
 2. **An ACM cert** for your gateway hostname, passed as `CERT_ARN` / `-c certArn`.
    On first `/login` the CLI pins the cert's SHA-256 fingerprint and prompts the
    developer to confirm it — intended behavior (the CLI pinning the authentic

--- a/claude-apps-gateway/docs/teardown.md
+++ b/claude-apps-gateway/docs/teardown.md
@@ -19,7 +19,7 @@ automation) and must be cleaned up regardless: the **ACM certificate**, its
 
 ---
 
-## Track A — CDK
+## Track B — CDK
 
 ```bash
 cd cdk
@@ -43,7 +43,7 @@ groups, and VPC endpoints — everything in the stack.
 
 ---
 
-## Track B — `setup.sh` (hand teardown)
+## Track A — `setup.sh` (hand teardown)
 
 `setup.sh` has no `--destroy`. Delete in **reverse dependency order** — services
 before the cluster, listeners/target groups before the ALB, everything network


### PR DESCRIPTION
## What

Fixes the `claude-apps-gateway` **CDK `deploy.sh` convenience path**, which was broken for a first-time user, plus a handful of initial-deployment documentation gaps. The `setup.sh` track is unaffected by the code changes. Functional CDK stack behavior is unchanged except for one deliberate parameterization (`gatewayName`).

Found by live-deploying **both** tracks end-to-end (deploy → browser SSO → Bedrock inference → teardown) in a disposable test account.

## Why

`./scripts/deploy.sh` failed immediately at `cdk synth` (missing required context), and after that was unblocked it hit three more bugs in its CodeBuild image-build path. None of this surfaced before because the alternative `setup.sh` track uses a different (local) build path and the canonical `gateway.yaml` template.

## Changes

**`deploy.sh` context / two-pass (`05167e3`)**
- `deploy.sh` ran a single bare `cdk deploy` with no context; the stack requires `publicUrl`/`zoneName`/`ingressCidr`/`certArn` and a two-pass (`imageReady`) deploy. Now validates the required `.env` vars, maps them to CDK context, and runs the real two-pass flow. Pins `imageTag=latest` to match the pushed image; drops a broken manual `update-service` (pass 2 starts the service).
- `.env.example`: add the required `CERT_ARN` and `INGRESS_CIDR`.

**`deploy.sh` CodeBuild-path bugs (`bffece2`)**
1. **Bucket ordering** — `create-project` referenced the S3 build bucket before `s3 mb` created it (first-run failure). Bucket is now created first.
2. **Name/repo mismatch** — the stack hardcoded `claude-gateway` for repo/cluster/service/secrets/log group while `deploy.sh` scoped the CodeBuild IAM policy to `${GATEWAY_NAME}`, so a renamed gateway got `AccessDenied` on push. Parameterized the stack with a `gatewayName` context (default `claude-gateway`, mirroring `setup.sh`'s `PROJECT`) that `deploy.sh` passes through, and derive `REPO_NAME` from the ECR output so IAM + docker tags always match what the stack created.
3. **Postgres URL** — the inline `gateway.yaml` referenced `${GATEWAY_POSTGRES_URL}` (never set by the task def) and omitted the username. Now composes `postgres://${DB_HOST}:5432/claude_gateway?sslmode=require` + `username: ${DB_USER}`, matching `gateway.yaml.template`.
- Also adds an optional `VPC_ID` / `CREATE_VPC_ENDPOINTS` passthrough so the convenience path can reuse an existing VPC, and tests asserting a custom `gatewayName` renames resources.

**Initial-deployment doc fixes (`12aa0c0`)**
- `deployment.md`: Haiku 4.5 has no short-alias inference profile (only the dated `…-20251001-v1:0`); note it applies to the manual verify command, not `gateway.yaml`.
- `setup.sh`: `ZONE_ID`/`ZONE_NAME` said "PRIVATE hosted zone", contradicting `deployment.md` prereq 3's public-zone topology — reworded to "public or private".
- `teardown.md`: track labels were swapped vs `deployment.md`; aligned so `setup.sh` = Track A, CDK = Track B everywhere.
- `deploy.sh`: also accept the binary at `./claude`/`../claude` (where the tracked CDK Dockerfile stages it), not only `linux-x64/claude`.

## Testing

- `cd cdk && npm test` → **16/16 pass** (incl. new `gatewayName` cases).
- `cdk synth` for both passes (pass 1 = repo only, pass 2 = full) and with a custom `gatewayName`.
- `bash -n` + `shellcheck` on `deploy.sh`/`setup.sh` (only pre-existing infos).
- **Live end-to-end**, disposable account: `setup.sh` track (full browser SSO + Bedrock inference), and the `deploy.sh` track with `GATEWAY_NAME=claude-gateway2` — all three CodeBuild-path bugs confirmed fixed.