### PR TITLE
fix(claude-apps-gateway): deploy.sh stamps config from template so telemetry works

### DIFF
--- a/claude-apps-gateway/cdk/README.md
+++ b/claude-apps-gateway/cdk/README.md
@@ -24,6 +24,7 @@ This CDK stack creates all the AWS infrastructure needed to run it:
 | **Security groups** | Network rules: ALB accepts HTTPS (443), ECS accepts traffic from ALB only (8080), RDS accepts traffic from ECS only (5432). |
 | **Route53 A record** | Points your gateway hostname at the ALB so developers can reach it by name. |
 | **CloudWatch log group** | Gateway logs go here. Boot messages, auth events, errors. |
+| **ADOT collector sidecar** | Runs *in the same Fargate task* as the gateway (not a separate service, no extra ALB listener). Receives per-user usage telemetry (OTLP) from the gateway on `localhost:4318` and forwards it to CloudWatch metrics (namespace `ClaudeGateway`) via SigV4 on the task role. The gateway container sets `CLAUDE_GATEWAY_ALLOW_LOOPBACK=1` so it can push to the loopback sidecar past its SSRF guard. See "Telemetry" below. |
 
 ## How traffic flows
 
@@ -42,6 +43,15 @@ This CDK stack creates all the AWS infrastructure needed to run it:
 3. Gateway validates the token, checks the developer's model access policy
 4. Gateway calls Amazon Bedrock using the ECS task role
 5. Amazon Bedrock streams the response back through the gateway to the developer
+
+**Telemetry (fire-and-forget, alongside every request):**
+
+1. After each request the gateway exports OTLP metrics — stamped with the developer's identity — to `telemetry.forward_to` in `gateway.yaml`
+2. That target is `http://localhost:4318`, the ADOT collector sidecar in the same task
+3. The sidecar forwards the metrics to CloudWatch (namespace `ClaudeGateway`) via SigV4 on the task role — for per-user cost and usage dashboards
+4. This leg is fire-and-forget: if the sidecar is down, inference is unaffected
+
+> The gateway only forwards telemetry when **both** `telemetry.forward_to` and `listen.public_url` are set. Both deploy paths (`setup.sh` and `deploy.sh`) stamp `gateway.yaml` from [`gateway.yaml.template`](gateway.yaml.template), whose `telemetry:` block points `forward_to` at the localhost sidecar — so telemetry is on by default and metrics-only (no prompt/tool-input content). To send to your *own* external collector (Datadog, Splunk, etc.) instead, edit that block (swap `url` for an `https://` endpoint and add `headers` if needed). To turn telemetry off, delete the block; the sidecar then just receives nothing (it shares the gateway task, so there's no separate service to remove).
 
 ## What you need before deploying
 
@@ -473,10 +483,12 @@ This deletes the ECS service, ALB, RDS database, ECR repository, IAM roles, secu
 
 | Resource | Monthly cost |
 |----------|-------------|
-| ECS Fargate (0.25 vCPU, 1 GB) | ~$9 |
+| ECS Fargate (0.5 vCPU, 1 GB — gateway + ADOT sidecar) | ~$9 |
 | RDS db.t4g.micro | ~$12 |
 | Application Load Balancer | ~$16 |
 | ACM certificate | Free |
 | **Total** | **~$37** |
+
+The ADOT collector runs as a sidecar inside the gateway's Fargate task (a small memory reservation), so per-user usage telemetry adds no separate service cost. Turning telemetry off (deleting the `telemetry:` block — see "Telemetry" under "How traffic flows") saves nothing here, since there's no idle task to remove.
 
 No license or per-seat fee from Anthropic. Amazon Bedrock inference costs are separate and the same as calling Amazon Bedrock directly without the gateway.

--- a/claude-apps-gateway/cdk/scripts/deploy.sh
+++ b/claude-apps-gateway/cdk/scripts/deploy.sh
@@ -158,7 +158,33 @@ else
   exit 1
 fi
 
-# Create build files
+# Stamp gateway.yaml from the COMMITTED template via stamp-config.sh — the SAME
+# path setup.sh uses (setup.sh Step 2a) — instead of maintaining a second inline
+# copy of the config here. This is what wires telemetry: the template's
+# `telemetry.forward_to: http://localhost:4318` block (the gateway's own ADOT
+# collector sidecar, which relays to CloudWatch via SigV4 on the task role) only
+# reaches the image through this stamp. The old inline heredoc omitted it, so
+# telemetry forwarding was silently off even though the CDK task runs the sidecar.
+# The sidecar + `CLAUDE_GATEWAY_ALLOW_LOOPBACK=1` (needed to push to localhost past
+# the SSRF guard) come from the CDK stack this script deploys, so no extra wiring is
+# needed here. Stamping also keeps the model catalog + store wiring in lockstep with
+# the template, so a template change can't skip this convenience path.
+# AWS_REGION here is the Bedrock endpoint region (the upstream `region:` the
+# template bakes); DB_NAME defaults inside stamp-config.sh to match the stack.
+echo "   Stamping gateway.yaml from gateway.yaml.template..."
+PUBLIC_URL="https://${GATEWAY_HOSTNAME}" \
+AWS_REGION="${BEDROCK_REGION}" \
+OIDC_ISSUER="${OIDC_ISSUER}" \
+OIDC_CLIENT_ID="${OIDC_CLIENT_ID}" \
+ALLOWED_EMAIL_DOMAINS="${ALLOWED_EMAIL_DOMAINS}" \
+TEMPLATE="${PROJECT_DIR}/gateway.yaml.template" \
+OUT="/tmp/gw-gateway.yaml" \
+  "${SCRIPT_DIR}/stamp-config.sh"
+
+# Build via the COMMITTED distroless Dockerfile (cdk/Dockerfile), not a second
+# inline copy. It expects ./claude and ./gateway.yaml in the build context and must
+# be built --platform=linux/amd64 --provenance=false (the binary is linux/amd64;
+# buildx OCI image indexes are rejected by some runtimes). Mirrors setup.sh's build.
 cat > /tmp/gw-buildspec.yml <<EOF
 version: 0.2
 phases:
@@ -167,89 +193,15 @@ phases:
       - aws ecr get-login-password --region ${DEPLOY_REGION} | docker login --username AWS --password-stdin ${ECR_URI}
   build:
     commands:
-      - chmod +x claude
-      - docker build -t ${REPO_NAME} .
+      - docker build --platform=linux/amd64 --provenance=false -t ${REPO_NAME} .
       - docker tag ${REPO_NAME}:latest ${ECR_URI}:latest
   post_build:
     commands:
       - docker push ${ECR_URI}:latest
 EOF
 
-cat > /tmp/gw-Dockerfile <<EOF
-FROM public.ecr.aws/debian/debian:bookworm-slim
-RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
-COPY claude /usr/local/bin/claude
-COPY gateway.yaml /etc/claude/gateway.yaml
-RUN chmod +x /usr/local/bin/claude
-ENV CLAUDE_CONFIG_DIR=/tmp/.claude
-EXPOSE 8080
-ENTRYPOINT ["claude", "gateway", "--config", "/etc/claude/gateway.yaml"]
-EOF
-
-cat > /tmp/gw-gateway.yaml <<EOF
-listen:
-  host: 0.0.0.0
-  port: 8080
-  public_url: https://${GATEWAY_HOSTNAME}
-
-oidc:
-  issuer: ${OIDC_ISSUER}
-  client_id: ${OIDC_CLIENT_ID}
-  client_secret: \${OIDC_CLIENT_SECRET}
-  allowed_email_domains: [$(echo $ALLOWED_EMAIL_DOMAINS | tr ',' ', ')]
-  userinfo_fallback: true
-
-session:
-  jwt_secret: \${GATEWAY_JWT_SECRET}
-  ttl_hours: 1
-
-store:
-  # Compose the URL from the env vars the CDK task def actually injects (DB_HOST,
-  # DB_USER, DB_PASSWORD) — matches gateway.yaml.template. The CDK task def never
-  # sets GATEWAY_POSTGRES_URL, so referencing it here left the store unconfigured.
-  postgres_url: postgres://\${DB_HOST}:5432/claude_gateway?sslmode=require
-  username: \${DB_USER}
-  password: \${DB_PASSWORD}
-
-upstreams:
-  - provider: bedrock
-    region: ${BEDROCK_REGION}
-    auth: {}
-
-# Curated model list mapped to GLOBAL cross-region inference profiles
-# (global.anthropic.*). Global profiles are region-agnostic — the same IDs resolve
-# from any Bedrock region — so this config deploys unchanged regardless of
-# BEDROCK_REGION, and the built-in catalog's region-specific us.* defaults are not
-# used (auto_include_builtin_models: false). NOTE: global profiles route inference
-# to any commercial AWS region; if you need data residency, swap global. for a geo
-# profile (us./eu./apac.) and see cdk/README "Regions & data residency". Claude
-# Haiku 4.5 has no short profile alias — it must use the dated ID.
-#
-# Claude Fable 5 is intentionally omitted: on Bedrock it requires a non-default data
-# retention mode that isn't enabled in every region, so it 400s ("data retention mode
-# 'default' is not available for this model") where the default set works everywhere.
-# To add it, enable the retention prereq for your region and append:
-#   - id: claude-fable-5
-#     label: Claude Fable 5
-#     upstream_model: { bedrock: global.anthropic.claude-fable-5 }
-auto_include_builtin_models: false
-models:
-  - id: claude-opus-4-8
-    label: Claude Opus 4.8
-    upstream_model:
-      bedrock: global.anthropic.claude-opus-4-8
-  - id: claude-sonnet-5
-    label: Claude Sonnet 5
-    upstream_model:
-      bedrock: global.anthropic.claude-sonnet-5
-  - id: claude-haiku-4-5
-    label: Claude Haiku 4.5
-    upstream_model:
-      bedrock: global.anthropic.claude-haiku-4-5-20251001-v1:0
-EOF
-
 aws s3 cp /tmp/gw-buildspec.yml "s3://$BUCKET/buildspec.yml" --quiet
-aws s3 cp /tmp/gw-Dockerfile "s3://$BUCKET/Dockerfile" --quiet
+aws s3 cp "${PROJECT_DIR}/Dockerfile" "s3://$BUCKET/Dockerfile" --quiet
 aws s3 cp /tmp/gw-gateway.yaml "s3://$BUCKET/gateway.yaml" --quiet
 aws s3 cp "$LINUX_BINARY" "s3://$BUCKET/claude" --quiet
 


### PR DESCRIPTION
## Problem

The recommended `deploy.sh` convenience path **silently disabled telemetry forwarding** by forking its own config.

- `deploy.sh` forked its own inline `gateway.yaml` (heredoc) instead of reusing `stamp-config.sh` + the tracked `cdk/Dockerfile`. That inline config had **no `telemetry:` block**, so the gateway never set `forward_to` and — per its own rule ("telemetry turns on only when `forward_to` AND `public_url` are both set") — never forwarded anything.
- The CDK task runs an **ADOT collector sidecar** (added in #243) ready to receive OTLP on `localhost:4318` and relay to CloudWatch, but with `forward_to` unset nothing ever reached it.

## Fix

**Align `deploy.sh` with `setup.sh`.** It now stamps `gateway.yaml` from the committed `gateway.yaml.template` via `stamp-config.sh` (which carries the `telemetry.forward_to: http://localhost:4318` sidecar block) and builds via the tracked distroless `cdk/Dockerfile`. Removes ~80 lines of duplicated config and closes the drift class where a template change could skip this path.

The sidecar and `CLAUDE_GATEWAY_ALLOW_LOOPBACK=1` (needed to push to the loopback receiver past the gateway's SSRF guard) both come from the CDK stack `deploy.sh` already deploys, so no extra task wiring is needed on this path.

**Refresh the docs** in `cdk/README.md` to the sidecar model: the resource table, the "How traffic flows" Telemetry leg, and the Cost table now describe one Fargate task running the gateway + ADOT sidecar — no separate service, no `:4318` ALB listener, no extra service cost.

## Verification (static)

- `bash -n` on `deploy.sh` + `setup.sh`
- `stamp-config.test.sh` (9) + `setup-helpers.test.sh` (14)
- `cdk` `npm test` (17) + `cdk synth` — sidecar image, `CLAUDE_GATEWAY_ALLOW_LOOPBACK`, and `cloudwatch:PutMetricData` all present in the synthesized template
- End-to-end stamp → valid YAML with `forward_to=http://localhost:4318` and `public_url` set, `${VAR}` secrets preserved, no `REPLACE_ME`/`@@` placeholders left

## Notes

- **Rebased onto `main` after #243** (standalone collector → sidecar). The README.md telemetry-section conflict was resolved in favor of #243's sidecar copy; this PR no longer edits the root README.
- The tracked Dockerfile pulls `debian:12-slim` + `gcr.io/distroless/...`; anonymous CodeBuild pulls can hit Docker Hub rate limits.
- Out of scope (found during earlier live testing, not fixed here): deploy.sh's CodeBuild IAM role scopes ECR push to the first run's `GATEWAY_NAME` and isn't re-scoped on a later name change.
