### PR TITLE
fix(claude-apps-gateway): bootstrap CDK with imageReady=false to avoid pass-2 synth guard

### DIFF
--- a/claude-apps-gateway/cdk/README.md
+++ b/claude-apps-gateway/cdk/README.md
@@ -168,7 +168,7 @@ outputs; then pass 2 brings up the full stack (the service starts automatically
 at `desiredCount 2` — no manual scale-up):
 
 ```bash
-npx cdk bootstrap    # first time only
+npx cdk bootstrap -c imageReady=false    # first time only
 
 # Pass 1: ECR repo only
 npx cdk deploy -c imageReady=false \

--- a/claude-apps-gateway/docs/deployment.md
+++ b/claude-apps-gateway/docs/deployment.md
@@ -134,7 +134,7 @@ ECS service needs the image to exist first.
 ```bash
 cd cdk
 npm install
-npx cdk bootstrap        # first time in the account/region only
+npx cdk bootstrap -c imageReady=false    # first time in the account/region only
 npx cdk deploy -c imageReady=false
 ```
 


### PR DESCRIPTION
## What

The gateway CDK docs tell first-time users to run `npx cdk bootstrap` with no context. But `cdk bootstrap` synthesizes the app before bootstrapping, and synth defaults to **pass 2** — which requires `publicUrl`/`zoneName`/`ingressCidr`/`certArn` and throws without them:

```
Error: Missing required context "publicUrl". For pass 2 deploy with: -c publicUrl=... ...
Or set imageReady=false for the pass-1 ECR-repo-only deploy.
```

## Fix

Add `-c imageReady=false` to the `cdk bootstrap` command in both places it appears, so synth short-circuits to the ECR-repo-only stack that needs none of that context:

- `claude-apps-gateway/cdk/README.md` (Option B — drive CDK yourself)
- `claude-apps-gateway/docs/deployment.md` (Track B — Pass 1)

Docs-only change. This matches the flag already used for the pass-1 `cdk deploy` that immediately follows.