### PR TITLE
fix(claude-apps-gateway): document how to enable the admin API / spend caps

### DIFF
--- a/claude-apps-gateway/README.md
+++ b/claude-apps-gateway/README.md
@@ -296,9 +296,37 @@ models:
 
 **What it does:** Set daily, weekly, or monthly spend limits per user, group, or organization. When a developer exceeds their cap, the gateway returns 429 and blocks further requests until the period resets or an admin raises the limit.
 
-**How it's configured:**
+**Why it's off by default:** the admin API is disabled in the shipped config
+because enabling it turns Postgres into the durable system of record for spend
+counters, an audit log, and per-developer PII. The example's RDS is deliberately
+disposable (`removalPolicy: DESTROY`, `deletionProtection: false`, 1-day backups,
+single-AZ), so turning this on is a conscious opt-in, not a default.
 
-First, enable the admin API in `gateway.yaml`:
+**How to enable it** — three steps:
+
+**1. Mint the admin keys as secrets** (≥32 chars each), the same way the JWT/OIDC
+secrets are created:
+
+```bash
+aws secretsmanager create-secret --name claude-gateway-admin-write-key \
+  --secret-string "$(openssl rand -base64 32)" --region "$AWS_REGION"
+aws secretsmanager create-secret --name claude-gateway-admin-read-key \
+  --secret-string "$(openssl rand -base64 32)" --region "$AWS_REGION"
+```
+
+**2. Inject them into the container**, alongside `GATEWAY_JWT_SECRET` /
+`OIDC_CLIENT_SECRET`:
+
+- **CDK** — add to the `secrets:` map in `cdk/lib/claude-gateway-stack.ts` and grant
+  the task role `secretsmanager:GetSecretValue` on the two new ARNs:
+  ```ts
+  GATEWAY_ADMIN_WRITE_KEY: ecs.Secret.fromSecretsManager(adminWriteSecret),
+  GATEWAY_ADMIN_READ_KEY:  ecs.Secret.fromSecretsManager(adminReadSecret),
+  ```
+- **setup.sh** — add matching entries to the container `secrets` array and the IAM
+  secrets policy.
+
+**3. Uncomment the `admin:` block** in `gateway.yaml` and redeploy:
 
 ```yaml
 admin:
@@ -308,6 +336,11 @@ admin:
     - { id: reporting, key: "${GATEWAY_ADMIN_READ_KEY}" }
   blocked_message: "Contact platform-team@company.com to request a higher limit."
 ```
+
+> ⚠️ **Harden RDS before relying on this.** Enabling admin makes Postgres hold
+> durable spend + audit + PII. The shipped database is disposable — enable deletion
+> protection, a longer backup window, and multi-AZ first. See
+> [cdk/README.md → "Before going to production"](cdk/README.md#before-going-to-production).
 
 Then set caps via the admin API (not in YAML):
 

--- a/claude-apps-gateway/cdk/gateway.yaml.example
+++ b/claude-apps-gateway/cdk/gateway.yaml.example
@@ -170,7 +170,9 @@ managed:
 #
 # admin:        # enables /v1/organizations/spend_limits + per-developer spend caps
 #   write_keys:
-#     - { id: terraform, key: "${GATEWAY_ADMIN_WRITE_KEY_TF}" }
+#     - { id: terraform, key: "${GATEWAY_ADMIN_WRITE_KEY}" }
+#   read_keys:
+#     - { id: reporting, key: "${GATEWAY_ADMIN_READ_KEY}" }
 #   admin_groups: [platform-finops]
 #   # NOTE: enabling admin makes Postgres hold durable spend + audit + PII. Harden
 #   # RDS (backups, deletion protection, multi-AZ) — see the README "Productionising".

--- a/claude-apps-gateway/cdk/gateway.yaml.template
+++ b/claude-apps-gateway/cdk/gateway.yaml.template
@@ -177,7 +177,9 @@ managed:
 #
 # admin:        # enables /v1/organizations/spend_limits + per-developer spend caps
 #   write_keys:
-#     - { id: terraform, key: "${GATEWAY_ADMIN_WRITE_KEY_TF}" }
+#     - { id: terraform, key: "${GATEWAY_ADMIN_WRITE_KEY}" }
+#   read_keys:
+#     - { id: reporting, key: "${GATEWAY_ADMIN_READ_KEY}" }
 #   admin_groups: [platform-finops]
 #   # NOTE: enabling admin makes Postgres hold durable spend + audit + PII. Harden
 #   # RDS (backups, deletion protection, multi-AZ) — see the README "Productionising".

--- a/claude-apps-gateway/workshop/05-spend-caps/README.md
+++ b/claude-apps-gateway/workshop/05-spend-caps/README.md
@@ -16,6 +16,10 @@ The gateway can set daily, weekly, or monthly spend limits per user, group, or o
 
 ### Enable the admin API in gateway.yaml
 
+> **Prerequisite:** the admin API is off by default. Mint `GATEWAY_ADMIN_WRITE_KEY`
+> / `GATEWAY_ADMIN_READ_KEY` as secrets and inject them into the task definition
+> first — see the "How to enable it" steps in the main [README §5](../../README.md#5-spend-caps-per-user-budget-enforcement).
+
 ```yaml
 admin:
   write_keys:


### PR DESCRIPTION
## What

The README's spend-caps section (§5) presents the `admin:` YAML block as though enabling spend caps is just an uncomment-and-go step. It isn't: the admin write/read keys have to be minted as secrets and injected into the task definition, and — unlike `GATEWAY_JWT_SECRET` / `OIDC_CLIENT_SECRET` / the DB creds — **nothing in the CDK stack or `setup.sh` provisions them**. Following §5 verbatim yields a gateway where `${GATEWAY_ADMIN_WRITE_KEY}` expands to nothing.

The variable names also disagreed across the repo: the config templates used `GATEWAY_ADMIN_WRITE_KEY_TF` (write-only), while the README and the spend-caps workshop already used `GATEWAY_ADMIN_WRITE_KEY` / `GATEWAY_ADMIN_READ_KEY`.

## Why it's a docs fix, not a code fix

The admin API being off by default is intentional and correct: enabling it turns Postgres into the durable system of record for spend counters, an audit log, and per-developer PII — on top of an RDS that the example deliberately keeps disposable (`removalPolicy: DESTROY`, `deletionProtection: false`, 1-day backups, single-AZ). So this keeps the opt-in manual and just documents it honestly.

## Changes

- **README §5** — add a short "why it's off by default" rationale, the three concrete opt-in steps (mint secrets → inject into the container → uncomment + redeploy), and an RDS-hardening prerequisite that links to `cdk/README.md` → "Before going to production".
- **`cdk/gateway.yaml.{template,example}`** — align the commented `admin:` block to the variable names the README and workshop already use (drop the stale `_TF` suffix; add the `read_keys` entry).
- **`workshop/05-spend-caps/README.md`** — add a one-line prerequisite pointing at the README steps.

Docs + commented-template only; no behavior change.

## Testing

- `cd cdk && npm test` → 17/17 pass (unchanged).
- `python3 -c 'import yaml; yaml.safe_load(open("cdk/gateway.yaml.example"))'` → parses OK.

## Out of scope (noted for a follow-up)

The templates and a couple of docs (`docs/teardown.md`, `docs/connectivity.md`) still reference a README "Productionising" section that doesn't exist; the real guidance lives in `cdk/README.md` → "Before going to production", which this PR links to. Reconciling that phantom reference repo-wide is left for a separate change.