### PR TITLE
docs(claude-apps-gateway): clarify Bedrock model-access prereq + Marketplace 403

### DIFF
--- a/claude-apps-gateway/README.md
+++ b/claude-apps-gateway/README.md
@@ -84,6 +84,7 @@ You need an AWS account where they can create the following resources:
 - **Database**: An RDS PostgreSQL instance (db.t4g.micro is sufficient; the gateway stores only a few KB of sign-in state)
 - **Networking**: A VPC with private subnets, an internal ALB, and an imported ACM TLS certificate (use a public ACM cert to skip the first-login fingerprint prompt — see [`cdk/README.md`](cdk/README.md))
 - **IAM role**: The gateway's task role needs `bedrock:InvokeModel` and `bedrock:InvokeModelWithResponseStream` permissions on inference-profile and foundation-model ARNs
+- **Model access**: A **one-time, account-level** enablement of each Claude model you list — a Bedrock *console/admin* action, **not** an IAM grant or a gateway responsibility. On Bedrock, Anthropic's models are AWS Marketplace offerings, so first use requires a subscription. Until it's done, invokes return a `403` (often naming `aws-marketplace:ViewSubscriptions` / `aws-marketplace:Subscribe`) even though the IAM policy above is correct. Enable it once as an admin; **do not** add Marketplace permissions to the task role (see [`docs/gotchas.md`](docs/gotchas.md) §8 for why). This is the single most common Bedrock-through-gateway failure.
 
 The IAM policy for the task role looks like:
 ```json

--- a/claude-apps-gateway/docs/gotchas.md
+++ b/claude-apps-gateway/docs/gotchas.md
@@ -183,17 +183,33 @@ deploy: the internal IPv4 ALB resolved to `10.0.x.x` only, with **no AAAA record
 
 ## 8. Bedrock model access is a separate, non-IAM prerequisite
 
-**Symptom:** invoke returns `AccessDeniedException` even though the IAM policy is
-correct.
+**Symptom:** invoke returns `AccessDeniedException` — or a `403` naming
+`aws-marketplace:ViewSubscriptions` / `aws-marketplace:Subscribe` — even though the
+`bedrock:InvokeModel*` IAM policy is correct.
 
-**Why:** Bedrock model access is an **account/console-level** grant, separate from
-IAM. And for cross-region inference profiles (`global.anthropic.*`), it must be enabled
-in the source region and any region the profile may route to (global spans all
-commercial regions), not just your endpoint region.
+**Why:** on Bedrock, Anthropic's models are AWS Marketplace offerings, so the first
+use of a model in an account requires a one-time, **account/console-level**
+model-access grant (a subscription), separate from IAM. For cross-region inference
+profiles (`global.anthropic.*`) it must be enabled in the source region and any
+region the profile may route to (global spans all commercial regions), not just your
+endpoint region.
 
-**Fix:** in the Bedrock console, per region, request + enable access for each Claude
-model you list in `availableModels`. This is the **#1 Bedrock-through-gateway
-failure** and it's easy to miss because IAM looks correct.
+**Fix:** as an account admin, enable model access **once** — Bedrock console →
+*Model access* (or the API) — for each Claude model you list in `availableModels`,
+per region global may route to. After that the 403 is gone permanently and the task
+role only ever needs `bedrock:InvokeModel` / `bedrock:InvokeModelWithResponseStream`.
+This is the **#1 Bedrock-through-gateway failure** and it's easy to miss because IAM
+looks correct.
+
+> **Do NOT fix this by adding `aws-marketplace:Subscribe` to the task role.** It makes
+> the error disappear — the task self-subscribes on first call — but it's the wrong
+> posture: (1) it grants a *one-time provisioning* action as a **standing** permission
+> on a long-lived, network-exposed runtime identity; (2) `Subscribe` is account-wide,
+> so a compromised container could subscribe the account to arbitrary paid Marketplace
+> products and accept their EULAs — well outside an inference proxy's blast radius;
+> (3) procuring models is an account-governance decision, not a data-plane one. Enable
+> access out-of-band as an admin instead — which is exactly why the CDK doesn't
+> provision these permissions.
 
 ---
 


### PR DESCRIPTION
## What

Makes the **Bedrock model-access prerequisite** discoverable and documents the AWS Marketplace `403` that a correct IAM setup still hits.

Addresses #251, where a customer deployed the gateway with a correct `bedrock:InvokeModel*` task-role policy and still got:

```
403 – Model access is denied due to IAM user or service role is not authorized to perform
the required AWS Marketplace actions (aws-marketplace:ViewSubscriptions, aws-marketplace:Subscribe)
```

## Why it's a docs fix, not a code fix

On Bedrock, Anthropic's models are AWS Marketplace offerings, so first use in an account requires a **one-time, account-level model-access grant (subscription)** — separate from IAM. This is a documented prerequisite (README prereq #3, `docs/deployment.md`, `docs/gotchas.md` §8), but none of those named the Marketplace `403` symptom, so it wasn't obvious that this error maps to the model-access step.

The tempting workaround — adding `aws-marketplace:Subscribe` to the ECS task role — makes the error disappear (the task self-subscribes on first call) but is a security anti-pattern:

- it grants a **one-time provisioning** action as a **standing** permission on a long-lived, network-exposed runtime identity;
- `Subscribe` is **account-wide** — a compromised container could subscribe the account to arbitrary paid Marketplace products and accept their EULAs, well outside an inference proxy's blast radius;
- procuring models is an **account-governance** decision, not a data-plane one.

That separation is exactly why model enablement is an out-of-band admin prereq the CDK deliberately does not automate. The right fix is the one-time console/API enablement; the task role then only needs `bedrock:InvokeModel*`.

## Changes

- **README prereq #3** — add a prominent **Model access** bullet: one-time account/admin action (not IAM, not a gateway responsibility), the `403`/Marketplace symptom, and an explicit "do not add Marketplace permissions to the task role" note.
- **`docs/gotchas.md` §8** — add the `aws-marketplace:*` `403` as an explicit symptom, the one-time admin fix, and a callout explaining why granting the task role `Subscribe` is the wrong posture (standing privilege, account-wide blast radius, separation of duties).

Docs-only; no behavior change.

## Testing

- `cd cdk && npm test` → 17/17 pass (unchanged).
- `python3 -c 'import yaml; yaml.safe_load(open("cdk/gateway.yaml.example"))'` → parses OK.