### PR TITLE
docs(claude-apps-gateway): document CloudWatch Coding Agent Insights

### DIFF
--- a/claude-apps-gateway/docs/deployment.md
+++ b/claude-apps-gateway/docs/deployment.md
@@ -265,6 +265,57 @@ traces need additional ADOT pipeline configuration and are out of scope here. Se
 [`workshop/03-telemetry/README.md`](../workshop/03-telemetry/README.md) and
 [`gotchas.md`](gotchas.md) §1 for more.
 
+### CloudWatch Coding Agent Insights
+
+Because the sidecar forwards to CloudWatch's **native OTLP metrics endpoint**
+(`monitoring.<region>.amazonaws.com/v1/metrics`), these metrics also populate
+**[Coding Agent Insights](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/coding-agents-insights.html)** —
+ready-made dashboards under the console's **GenAI Observability → Coding Agent
+Insights** (Claude Code tab). No extra wiring beyond the telemetry setup above; the
+dashboards appear automatically and populate from metrics in the expected OTel shape.
+AWS's [gateway setup guide](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/coding-agents-claude-code-gateway.html)
+describes this path, and our ADOT config mirrors AWS's recommended metrics-collector
+config (same `otlphttp`→`monitoring/v1/metrics` exporter, `sigv4auth` service
+`monitoring`, `cloudwatch:PutMetricData` via the task role). These native-OTLP metrics
+are queryable with PromQL and live in the GenAI Observability store — they do **not**
+appear under classic CloudWatch `list-metrics`.
+
+**What populates automatically.** The gateway stamps each export with the signed-in
+developer's identity as OTel *resource* attributes — `user.email`, `user.id`,
+`identity.source` — and Claude Code adds `model` and token `type`. So the per-user,
+per-model, and per-token-type views work with no developer- or admin-side config.
+
+**By team / department / cost center is *not* automatic.** The gateway's identity
+stamping is user-level only; it does not emit `team.id`, `department`, `cost_center`,
+or `organization`. It does stamp `user.groups` when your IdP emits them, but that lands
+as a *comma-separated string* of all group memberships — it is not one of the
+dashboards' grouping dimensions and does not become `team.id`/`department` on its own.
+To drive the team/department/cost-center segments, push them as resource attributes via
+[`OTEL_RESOURCE_ATTRIBUTES`](https://code.claude.com/docs/en/monitoring-usage) (a
+standard OpenTelemetry variable the CLI honors) through a group-scoped
+[managed policy](https://code.claude.com/docs/en/claude-apps-gateway-config#managed)'s
+`env` block:
+
+```yaml
+managed:
+  policies:
+    - match: { groups: [team-payments] }
+      cli:
+        env:
+          OTEL_RESOURCE_ATTRIBUTES: "team.id=payments,department=engineering,cost_center=CC-1234"
+```
+
+The CLI stamps these into the OTLP resource block, the gateway relays them verbatim,
+and CloudWatch retains them so the by-team/department/cost-center dashboard segments
+populate. The values are static per policy, so you map one policy per team/group rather
+than deriving attributes from a directory. `OTEL_RESOURCE_ATTRIBUTES` isn't on the CLI's `env` safe list, so it rides
+the same one-time managed-settings approval dialog the pushed OTLP endpoint already
+triggers.
+
+**Availability.** Coding Agent Insights is in all commercial regions except Middle
+East (UAE), Middle East (Bahrain), and Israel (Tel Aviv). Standard CloudWatch OTLP
+metric-ingestion pricing applies.
+
 ## Cost expectations
 
 A live deploy of this example idles at roughly **US$5–7/day** (us-east-1,

--- a/claude-apps-gateway/workshop/03-telemetry/README.md
+++ b/claude-apps-gateway/workshop/03-telemetry/README.md
@@ -53,10 +53,47 @@ See [`docs/deployment.md`](../../docs/deployment.md#telemetry) for deployment de
 
 ### What gets stamped on each metric
 
-The CLI automatically includes these attributes on every OTLP export:
+The CLI automatically includes these attributes on every OTLP export, in the OTel
+**resource block** (and, by default, mirrored as datapoint labels):
 - `user.id`: the OIDC `sub` claim (stable user identifier)
 - `user.email`: the user's email from the id_token
-- `user.groups`: the user's IdP groups
+- `user.groups`: the user's IdP groups (only when your IdP emits them)
+- `identity.source`: `gateway-oidc` on gateway sessions
+
+Placing identity in the resource block is what lets CloudWatch **Coding Agent
+Insights** (below) slice usage by developer.
+
+### CloudWatch Coding Agent Insights
+
+When the CloudWatch destination is used, these metrics land in the console's **GenAI
+Observability → Coding Agent Insights** dashboards (Claude Code tab) — no dashboards
+to build. Out of the box you get **per-user** (`user.email`), **per-model**, and
+**per-token-type** breakdowns for adoption and spend.
+
+The dashboards also segment by `team.id`, `department`, `cost_center`, and
+`organization`, but the gateway does **not** emit those — they're not part of its
+identity stamping. (`user.groups` *is* stamped when your IdP sends it, but it's a
+comma-separated string of all groups, not a dashboard grouping dimension, so it doesn't
+segment usage on its own.) To populate the team/department segments, push them as
+resource attributes via
+[`OTEL_RESOURCE_ATTRIBUTES`](https://code.claude.com/docs/en/monitoring-usage) from a
+group-scoped managed policy's `env` block:
+
+```yaml
+managed:
+  policies:
+    - match: { groups: [team-payments] }
+      cli:
+        env:
+          OTEL_RESOURCE_ATTRIBUTES: "team.id=payments,department=engineering,cost_center=CC-1234"
+```
+
+The CLI stamps those as resource attributes, the gateway relays them verbatim, and
+CloudWatch retains them so the by-team/department/cost-center views populate. Values
+are static per policy — one policy per group. See
+[`docs/deployment.md`](../../docs/deployment.md#cloudwatch-coding-agent-insights) for
+the full write-up, and note Coding Agent Insights isn't available in every region
+(excludes UAE, Bahrain, Tel Aviv).
 
 ### Sensitivity levels
 


### PR DESCRIPTION
## What

Documents how this gateway example's telemetry surfaces in **CloudWatch Coding Agent Insights** (GenAI Observability dashboards), scoped precisely to what actually populates.

The ADOT sidecar already forwards OTLP metrics to CloudWatch's native OTLP endpoint (`monitoring.<region>.amazonaws.com/v1/metrics`) — which is exactly what powers Coding Agent Insights. This adds the "why" without changing any infra.

## Details

- **Per-user / per-model / per-token-type** views work out of the box — the gateway stamps `user.email`/`user.id`/`identity.source` as OTel **resource** attributes and the CLI adds `model` + token `type`.
- **By-team / department / cost_center is NOT automatic.** The gateway emits user-level identity only (`user.groups` is a comma-separated string, not a dashboard dimension). To drive those segments, push `team.id`/`department`/`cost_center` as resource attributes via a group-scoped managed policy's `env.OTEL_RESOURCE_ATTRIBUTES`.
- Clarifies identity is stamped in the OTLP **resource block** (what Insights keys on), fixing looser "stamped on each metric" wording.
- Notes region availability (excludes UAE, Bahrain, Tel Aviv).

## Files

- `claude-apps-gateway/docs/deployment.md` — new "CloudWatch Coding Agent Insights" subsection under Telemetry.
- `claude-apps-gateway/workshop/03-telemetry/README.md` — matching section + resource-block clarification.

## Verification

Verified end to end against a live deploy: managed-policy `env` → CLI resource attributes → gateway relay → ADOT sidecar → native OTLP endpoint → the Coding Agent Insights dashboard segmenting by the pushed `team.id`/`department`/`cost_center`. Also confirmed the example's ADOT config + `cloudwatch:PutMetricData` IAM match AWS's documented metrics-collector setup.

Docs-only; no code or infra changes.