### PR TITLE
feat(claude-apps-gateway-bootstrap): resource-stripping OAuth proxy for Entra + AgentCore web search

### DIFF
--- a/claude-apps-gateway-bootstrap/.gitignore
+++ b/claude-apps-gateway-bootstrap/.gitignore
@@ -1,7 +1,13 @@
 # Deployment-specific — copy the .example files
 .env
 bootstrap/config/bootstrap-config.json
+# Live top-level config edited per deployment (real hostnames/tenant/client ids);
+# the committed template is bootstrap/config/bootstrap-config.example.json.
+bootstrap-config.json
 cdk/cdk.context.json
+
+# Local, throwaway smoke-test scratch (not part of the deployable component)
+websearch-proxy/local-test/
 
 # Build artifacts & dependencies
 node_modules/

--- a/claude-apps-gateway-bootstrap/bootstrap/config/bootstrap-config.example.json
+++ b/claude-apps-gateway-bootstrap/bootstrap/config/bootstrap-config.example.json
@@ -37,6 +37,20 @@
       }
     },
     {
+      "name": "agentcore-websearch-entra-via-proxy",
+      "transport": "http",
+      "url": "https://claude-gateway.example.com/websearch/mcp",
+      "oauth": {
+        "clientId": "<entra-public-client-id>",
+        "authorizationServer": [
+          "https://claude-gateway.example.com/websearch"
+        ],
+        "scope": "openid offline_access api://<entra-public-client-id>/mcp.invoke",
+        "callbackHost": "localhost",
+        "callbackPort": 8990
+      }
+    },
+    {
       "name": "example-oauth-server",
       "transport": "http",
       "url": "https://<your-mcp-server>/mcp",

--- a/claude-apps-gateway-bootstrap/cdk/bin/app.ts
+++ b/claude-apps-gateway-bootstrap/cdk/bin/app.ts
@@ -3,6 +3,7 @@ import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
 import { AwsSolutionsChecks } from 'cdk-nag';
 import { BootstrapStack } from '../lib/bootstrap-stack';
+import { WebsearchProxyStack } from '../lib/websearch-proxy-stack';
 
 /**
  * CDK entry point for the BOOTSTRAP ADD-ON to the claude-apps-gateway sample.
@@ -67,5 +68,44 @@ new BootstrapStack(app, 'ClaudeBootstrapStack', {
   requiredRoles: ctx('requiredRoles'),
   imageTag: ctx('imageTag'),
 });
+
+// ── Optional add-on: resource-stripping OAuth proxy (Entra + AgentCore web search) ──
+// Opt-in via `-c enableWebsearchProxy=true`, so the default bootstrap deploy flow is
+// unchanged (the proxy stack is not instantiated unless requested). Same two-pass
+// `imageReady` convention. When deploying it, pass the shared gateway-output context
+// plus the proxy-specific `upstreamMcpUrl`:
+//   Pass 1: cdk deploy ClaudeWebsearchProxyStack -c enableWebsearchProxy=true -c imageReady=false
+//   build + push the websearch-proxy image
+//   Pass 2: cdk deploy ClaudeWebsearchProxyStack -c enableWebsearchProxy=true \
+//             -c publicUrl=... -c listenerArn=... -c albSgId=... -c vpcId=... \
+//             -c entraTenantId=... -c upstreamMcpUrl=... [-c basePath=/websearch] [-c mcpClientId=...]
+if (ctx('enableWebsearchProxy') === 'true') {
+  const reqProxy = (k: string): string => {
+    const v = ctx(k);
+    if (imageReady && !v) {
+      throw new Error(`Missing required pass-2 context for websearch proxy: -c ${k}=...`);
+    }
+    return v ?? '';
+  };
+  new WebsearchProxyStack(app, 'ClaudeWebsearchProxyStack', {
+    env: {
+      account: process.env.CDK_DEFAULT_ACCOUNT,
+      region: ctx('region') ?? process.env.CDK_DEFAULT_REGION,
+    },
+    description:
+      'Resource-stripping OAuth proxy add-on: fronts an AgentCore gateway so Claude Desktop '
+      + 'MCP OAuth works with Microsoft Entra ID (strips the RFC 8707 resource parameter).',
+    imageReady,
+    publicUrl: reqProxy('publicUrl'),
+    listenerArn: reqProxy('listenerArn'),
+    albSgId: reqProxy('albSgId'),
+    vpcId: reqProxy('vpcId'),
+    entraTenantId: reqProxy('entraTenantId'),
+    upstreamMcpUrl: reqProxy('upstreamMcpUrl'),
+    basePath: ctx('basePath'),
+    mcpClientId: ctx('mcpClientId'),
+    imageTag: ctx('proxyImageTag') ?? ctx('imageTag'),
+  });
+}
 
 app.synth();

--- a/claude-apps-gateway-bootstrap/cdk/lib/websearch-proxy-stack.ts
+++ b/claude-apps-gateway-bootstrap/cdk/lib/websearch-proxy-stack.ts
@@ -1,0 +1,207 @@
+import { Stack, StackProps, Duration, CfnOutput, RemovalPolicy } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+import * as ecr from 'aws-cdk-lib/aws-ecr';
+import * as elbv2 from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import * as logs from 'aws-cdk-lib/aws-logs';
+import { ackNag } from './nag';
+
+export interface WebsearchProxyStackProps extends StackProps {
+  /**
+   * The gateway origin — the ClaudeGatewayStack `PublicUrl` output, e.g.
+   * https://claude-gateway.example.com. The proxy attaches to this hostname's
+   * listener and every self-referential OAuth metadata URL is built from it.
+   */
+  readonly publicUrl: string;
+  /** HTTPS :443 listener ARN of the gateway ALB (same lookup as the bootstrap add-on). */
+  readonly listenerArn: string;
+  /** Security group id of the gateway ALB (ingress source for the proxy service). */
+  readonly albSgId: string;
+  /** VPC id the gateway stack deployed into. */
+  readonly vpcId: string;
+  /**
+   * Upstream AgentCore gateway MCP endpoint the proxy reverse-proxies to, e.g.
+   * https://<id>.gateway.bedrock-agentcore.us-east-1.amazonaws.com/mcp
+   */
+  readonly upstreamMcpUrl: string;
+  /** Entra tenant ID — issuer whose OIDC metadata/authorize/token the proxy relays. */
+  readonly entraTenantId: string;
+  /**
+   * Path prefix the ALB routes to the proxy (NOT stripped by the ALB). The proxy
+   * mounts its routes under this and advertises `<publicUrl><basePath>/...`.
+   * Default '/websearch'.
+   */
+  readonly basePath?: string;
+  /**
+   * Optional static client_id returned by the proxy's mock DCR endpoint. Claude
+   * Desktop supplies a static clientId and skips DCR, so this is only for other
+   * MCP clients; safe to omit.
+   */
+  readonly mcpClientId?: string;
+  /** ECR image tag for the proxy image (default 'latest'). */
+  readonly imageTag?: string;
+  /**
+   * Two-pass deploy, same convention as the gateway/bootstrap: pass 1
+   * (imageReady=false) creates only the ECR repo; build+push the image; pass 2
+   * (imageReady=true, the default) deploys the service and listener rule.
+   */
+  readonly imageReady: boolean;
+}
+
+/**
+ * Resource-stripping OAuth proxy add-on: fronts an Amazon Bedrock AgentCore
+ * gateway so Claude Desktop's MCP OAuth flow works with Microsoft Entra ID.
+ *
+ * Entra rejects the RFC 8707 `resource` parameter that spec-compliant MCP clients
+ * send (AADSTS9010010) and there is no client-side knob to suppress it. This proxy
+ * (the documented Microsoft workaround) mediates the OAuth handshake and strips the
+ * parameter before relaying to Entra, then reverse-proxies /mcp to the gateway.
+ *
+ * Deploys BEHIND the gateway's existing internal ALB via one listener rule
+ * (path `<basePath>/*` on the gateway hostname) — the ClaudeGatewayStack is consumed
+ * unmodified, coupled only through its deployed outputs. The gateway's CUSTOM_JWT
+ * authorizer is left as-is: it still validates the Entra token it receives.
+ */
+export class WebsearchProxyStack extends Stack {
+  constructor(scope: Construct, id: string, props: WebsearchProxyStackProps) {
+    super(scope, id, props);
+    const imageTag = props.imageTag ?? 'latest';
+    const basePath = (props.basePath ?? '/websearch').replace(/\/+$/, '');
+    const PORT = 8082;
+
+    // ── ECR repository for the proxy image (built/pushed like the gateway's) ──
+    const repo = new ecr.Repository(this, 'Repo', {
+      imageScanOnPush: true,
+      removalPolicy: RemovalPolicy.DESTROY,
+      emptyOnDelete: true,
+    });
+    new CfnOutput(this, 'EcrRepositoryUri', { value: repo.repositoryUri });
+
+    // Pass 1: repo only. Return BEFORE any environment lookups so
+    // `cdk deploy -c imageReady=false` synthesizes with EMPTY context.
+    if (!props.imageReady) {
+      new CfnOutput(this, 'NextStep', {
+        value:
+          'Build+push the websearch-proxy image to the EcrRepositoryUri above, then '
+          + 're-run: cdk deploy -c imageReady=true with the gateway-output context '
+          + '(publicUrl/listenerArn/albSgId/vpcId/entraTenantId/upstreamMcpUrl).',
+      });
+      return;
+    }
+
+    // Pass 2 inputs — the deployed claude-apps-gateway outputs.
+    const gatewayHost = props.publicUrl.replace(/^https?:\/\//, '');
+    const vpc = ec2.Vpc.fromLookup(this, 'Vpc', { vpcId: props.vpcId });
+    const albSg = ec2.SecurityGroup.fromSecurityGroupId(this, 'AlbSg', props.albSgId);
+    const listener = elbv2.ApplicationListener.fromApplicationListenerAttributes(
+      this, 'HttpsListener', { listenerArn: props.listenerArn, securityGroup: albSg });
+
+    // ── Fargate service (own small cluster; the gateway cluster name is a fixed
+    // physical name inside ClaudeGatewayStack and is not exported) ──
+    const cluster = new ecs.Cluster(this, 'Cluster', {
+      vpc,
+      containerInsightsV2: ecs.ContainerInsights.ENABLED,
+    });
+
+    const taskDef = new ecs.FargateTaskDefinition(this, 'ProxyTask', {
+      cpu: 256,
+      memoryLimitMiB: 512,
+    });
+
+    // The proxy holds NO secrets: token validation is the gateway's job, and the
+    // proxy only relays the public OAuth dance (strip resource) + streams /mcp.
+    taskDef.addContainer('proxy', {
+      image: ecs.ContainerImage.fromEcrRepository(repo, imageTag),
+      logging: ecs.LogDrivers.awsLogs({
+        streamPrefix: 'websearch-proxy',
+        logGroup: new logs.LogGroup(this, 'ServiceLogs', {
+          retention: logs.RetentionDays.ONE_MONTH,
+          removalPolicy: RemovalPolicy.DESTROY,
+        }),
+      }),
+      portMappings: [{ containerPort: PORT }],
+      environment: {
+        PORT: String(PORT),
+        // Externally visible origin (the gateway ALB hostname) + the path prefix the
+        // listener rule routes here; all OAuth metadata is self-referential to these.
+        PUBLIC_ORIGIN: props.publicUrl,
+        BASE_PATH: basePath,
+        UPSTREAM_MCP_URL: props.upstreamMcpUrl,
+        ENTRA_TENANT_ID: props.entraTenantId,
+        ...(props.mcpClientId ? { MCP_CLIENT_ID: props.mcpClientId } : {}),
+      },
+    });
+    ackNag(taskDef,
+      {
+        id: 'AwsSolutions-ECS2',
+        reason:
+          'All environment values are non-sensitive public identifiers by design: gateway '
+          + 'origin/base path, the upstream AgentCore gateway URL, the Entra tenant id, and '
+          + '(optionally) the public client id. The proxy holds no secrets — it relays the '
+          + 'public OAuth dance and validation is done by the gateway authorizer.',
+      },
+      {
+        id: 'AwsSolutions-IAM5[Resource::*]',
+        reason:
+          'CDK-generated execution-role statement: ecr:GetAuthorizationToken (account-scoped, '
+          + 'only valid on *) plus the log-group grant the awslogs driver emits.',
+      },
+    );
+
+    const serviceSg = new ec2.SecurityGroup(this, 'ServiceSg', {
+      vpc,
+      description: `Websearch proxy - ingress ${PORT} from the gateway ALB only`,
+      allowAllOutbound: true, // Entra OIDC/token fetch + upstream AgentCore gateway (via NAT)
+    });
+    serviceSg.addIngressRule(albSg, ec2.Port.tcp(PORT), 'websearch proxy from gateway ALB');
+    // The gateway sample's ALB SG uses RESTRICTED egress, so ALB->target health checks
+    // are dropped unless we author the matching egress rule (owned by THIS stack).
+    new ec2.CfnSecurityGroupEgress(this, 'AlbToProxy', {
+      groupId: props.albSgId,
+      destinationSecurityGroupId: serviceSg.securityGroupId,
+      ipProtocol: 'tcp',
+      fromPort: PORT,
+      toPort: PORT,
+      description: 'gateway ALB to websearch proxy targets',
+    });
+
+    const service = new ecs.FargateService(this, 'ProxyService', {
+      cluster,
+      taskDefinition: taskDef,
+      desiredCount: 1,
+      securityGroups: [serviceSg],
+      vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
+      assignPublicIp: false,
+      minHealthyPercent: 0,
+      circuitBreaker: { rollback: true },
+    });
+
+    // ── Attach to the gateway's existing HTTPS listener: one path-prefix rule. ──
+    const tg = new elbv2.ApplicationTargetGroup(this, 'ProxyTg', {
+      vpc,
+      port: PORT,
+      protocol: elbv2.ApplicationProtocol.HTTP,
+      targets: [service],
+      healthCheck: {
+        path: '/healthz', // served at root by the container, independent of basePath
+        healthyHttpCodes: '200',
+        interval: Duration.seconds(30),
+      },
+      deregistrationDelay: Duration.seconds(10),
+    });
+    new elbv2.ApplicationListenerRule(this, 'ProxyRule', {
+      listener,
+      priority: 6, // bootstrap uses 5; keep distinct
+      conditions: [
+        elbv2.ListenerCondition.hostHeaders([gatewayHost]),
+        elbv2.ListenerCondition.pathPatterns([`${basePath}/*`]),
+      ],
+      action: elbv2.ListenerAction.forward([tg]),
+    });
+
+    // The MCP server URL to put in the bootstrap managedMcpServers entry.
+    new CfnOutput(this, 'WebsearchMcpUrl', { value: `${props.publicUrl}${basePath}/mcp` });
+    new CfnOutput(this, 'WebsearchProxyBaseUrl', { value: `${props.publicUrl}${basePath}` });
+  }
+}

--- a/claude-apps-gateway-bootstrap/websearch-proxy/Dockerfile
+++ b/claude-apps-gateway-bootstrap/websearch-proxy/Dockerfile
@@ -1,0 +1,18 @@
+# Resource-stripping OAuth proxy image (Node/Express). Build with `docker build`/`finch build`
+# and push to ECR (see README) — no standing build infrastructure.
+FROM node:20-slim
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install --omit=dev
+
+COPY server.js ./
+
+ENV PORT=8082
+EXPOSE 8082
+USER node
+CMD ["node", "server.js"]

--- a/claude-apps-gateway-bootstrap/websearch-proxy/README.md
+++ b/claude-apps-gateway-bootstrap/websearch-proxy/README.md
@@ -1,0 +1,224 @@
+# Web search OAuth proxy (Entra ID → AgentCore Gateway)
+
+A tiny **resource-stripping OAuth proxy** that lets Claude Desktop / Cowork use an
+Amazon Bedrock **AgentCore Gateway** MCP server (for example the AgentCore web
+search tool) when your identity provider is **Microsoft Entra ID**.
+
+It exists to work around a concrete incompatibility between the MCP OAuth spec and
+Entra. If your IdP is Amazon Cognito (or another provider that implements RFC 8707),
+you do **not** need this — point the managed MCP entry straight at the gateway.
+
+---
+
+## The problem: `AADSTS9010010`
+
+An AgentCore Gateway presents itself as an MCP **resource server**. A spec-compliant
+MCP client (Claude Desktop's managed-MCP `oauth` flow, `mcp-remote`, Claude Code on
+the 2025-06-18 auth spec) does this on first connect:
+
+1. `POST /mcp` with no token → the gateway answers `401` with a `WWW-Authenticate`
+   header pointing at its **Protected Resource Metadata** (PRM, [RFC 9728]).
+2. The client reads the PRM, learns the authorization server, and — because the MCP
+   auth spec mandates **Resource Indicators** ([RFC 8707]) — adds a `resource`
+   parameter equal to the gateway URL on the `/authorize` and `/token` requests.
+
+Microsoft Entra ID does **not** implement RFC 8707. When it sees that `resource`
+parameter it rejects the token exchange:
+
+```
+AADSTS9010010: The resource parameter provided in the request doesn't match with
+the requested scopes.  (error=invalid_target, HTTP 400 at the token endpoint)
+```
+
+The scope (`api://<clientId>/mcp.invoke`) already identifies the target API, so the
+`resource` parameter is redundant here — but the client sends it and Entra refuses.
+
+### Why you can't just fix it on the client
+
+There is **no configuration knob** to suppress the `resource` parameter:
+
+- Claude Desktop's managed-MCP `oauth` block (`clientId` / `tenantId` /
+  `authorizationServer` / `scope`) always drives the PRM flow and emits `resource`.
+- `mcp-remote` builds the same `resource` parameter from the server URL (verified:
+  it appears verbatim in the `/authorize` URL it opens).
+- Claude Code has the same behaviour — tracked upstream in
+  [anthropics/claude-code#73460][issue-73460] ("allow overriding or omitting the
+  RFC 8707 resource parameter").
+
+So the mismatch is structural: fix it **in front of the resource server**, not in
+the client.
+
+---
+
+## The fix: an OAuth proxy that strips `resource`
+
+This is the pattern Microsoft and the community document for "Entra + MCP": put a
+small proxy in front of the MCP server that mediates the OAuth handshake and removes
+the `resource` parameter before relaying to Entra. See
+[Building Claude-Ready Entra ID-Protected MCP Servers with Azure API Management][ms-apim]
+and the write-up [10 Azure Entra ID incompatibilities with MCP server auth][groff]
+(incompatibility #3 is exactly `AADSTS9010010`; the fix is to strip `resource`).
+AWS's own [auth-code walkthrough for AgentCore Gateway + MCP clients][aws-authcode]
+likewise inserts an "MCP OAuth proxy" to bridge these spec gaps.
+
+For **Claude Desktop specifically**, the proxy can be minimal: Desktop uses a static
+`clientId` and does not attempt Dynamic Client Registration, so the only real
+incompatibility to neutralise is the `resource` parameter (#3). The other items in
+the write-up — mock DCR, RFC 8414 metadata, issuer/audience quirks — are handled for
+completeness but are not the blocker here.
+
+Claude talks **only** to the proxy; the proxy relays to Entra (minus `resource`) and
+reverse-proxies `/mcp` to the gateway. The **AgentCore Gateway is unchanged** — its
+`CUSTOM_JWT` authorizer still validates the Entra token it receives
+([inbound JWT authorizer][agentcore-jwt]).
+
+### Endpoints
+
+| Endpoint | Role |
+|---|---|
+| `GET /.well-known/oauth-protected-resource` | PRM — advertises **this proxy** as the authorization server |
+| `GET /.well-known/oauth-authorization-server`, `/.well-known/openid-configuration` | Entra's OIDC metadata, but with `authorize`/`token`/`register` rewritten to the proxy |
+| `GET /oauth/authorize` | **strips `resource`**, 302 to Entra's real authorize endpoint |
+| `POST /oauth/token` | **strips `resource`**, forwards the form to Entra's real token endpoint |
+| `POST /oauth/register` | mock DCR ([RFC 7591]) — Desktop skips it; kept for other clients |
+| `ALL /mcp` | streaming reverse-proxy to the AgentCore gateway, forwarding `Authorization`; on a missing/invalid token returns `401` with the proxy's own PRM pointer |
+| `GET /healthz` | health check (served at root, for the ALB target group) |
+
+### Flow
+
+```
+Claude Desktop ──POST /mcp (no token)──▶ PROXY ──401 WWW-Authenticate: resource_metadata=PROXY PRM
+   ─GET PRM─▶ PROXY  (authorization_servers = [PROXY])
+   ─GET AS metadata─▶ PROXY  (authorize/token = PROXY)
+   ─browser /oauth/authorize (…&resource=…)─▶ PROXY ─(strip resource)─▶ Entra ─▶ user login
+   Entra ─▶ redirect to http://127.0.0.1:<port>/callback?code=…   (client loopback, unchanged)
+   ─POST /oauth/token (code+PKCE+resource)─▶ PROXY ─(strip resource)─▶ Entra ─▶ access token
+   ─POST /mcp  Authorization: Bearer <token>─▶ PROXY ─▶ AgentCore Gateway ─▶ web search tool
+```
+
+The `redirect_uri` stays the client's own loopback and is passed through untouched,
+so **no new Entra redirect registration is required** beyond the loopback the client
+already uses.
+
+---
+
+## Configuration (env)
+
+| Var | Required | Meaning |
+|---|---|---|
+| `PORT` | no (8082) | listen port |
+| `PUBLIC_ORIGIN` | yes | externally visible origin of the fronting ALB, e.g. `https://claude-gateway.example.com` |
+| `BASE_PATH` | no (`""`) | path prefix the ALB routes here (not stripped by the ALB), e.g. `/websearch` |
+| `UPSTREAM_MCP_URL` | yes | AgentCore gateway MCP URL, e.g. `https://<id>.gateway.bedrock-agentcore.<region>.amazonaws.com/mcp` |
+| `ENTRA_TENANT_ID` | yes | Entra tenant whose OIDC metadata/authorize/token are relayed |
+| `ENTRA_DISCOVERY_URL` | no | override the OIDC discovery URL (defaults from tenant) |
+| `MCP_CLIENT_ID` | no | static client id returned by the mock DCR endpoint |
+
+Self-referential metadata is built from `PUBLIC_ORIGIN + BASE_PATH`.
+
+---
+
+## Deploy (CDK, two-pass)
+
+Hosted behind the **existing internal gateway ALB** (same pattern as the bootstrap
+add-on): a path-prefix listener rule routes `<basePath>/*` to a Fargate service in a
+private subnet; the service reaches the public AgentCore gateway and Entra via NAT.
+The gateway stack is consumed unmodified through its outputs. The stack is opt-in via
+`-c enableWebsearchProxy=true`, so the default bootstrap deploy is unaffected.
+
+First collect the gateway outputs (see the bootstrap README for the same lookups):
+`publicUrl`, the ALB `:443` `listenerArn`, `albSgId`, `vpcId`.
+
+```bash
+# Pass 1 — create the ECR repo only
+cd cdk
+cdk deploy ClaudeWebsearchProxyStack -c enableWebsearchProxy=true -c imageReady=false
+
+# Build + push the image to the EcrRepositoryUri from pass 1 (Fargate = linux/amd64)
+cd ../websearch-proxy
+REPO=<EcrRepositoryUri>
+aws ecr get-login-password --region <region> | finch login --username AWS --password-stdin "${REPO%%/*}"
+finch build --platform linux/amd64 -t "${REPO}:latest" .
+finch push "${REPO}:latest"
+
+# Pass 2 — deploy the service + listener rule
+cd ../cdk
+cdk deploy ClaudeWebsearchProxyStack -c enableWebsearchProxy=true \
+  -c publicUrl=https://claude-gateway.example.com \
+  -c listenerArn=<gateway ALB :443 listener ARN> \
+  -c albSgId=<gateway ALB SG id> -c vpcId=<gateway VPC id> \
+  -c entraTenantId=<tenant> \
+  -c upstreamMcpUrl=https://<id>.gateway.bedrock-agentcore.<region>.amazonaws.com/mcp \
+  -c mcpClientId=<entra public client id> -c basePath=/websearch
+```
+
+Stack outputs `WebsearchMcpUrl` — the URL to put in the bootstrap config.
+
+## Wire the bootstrap config
+
+Add a normal remote `http` + `oauth` entry to `managedMcpServers` pointing at the
+proxy (not the gateway). No change to the bootstrap server is needed — it passes the
+`oauth` block through:
+
+```json
+{
+  "name": "agentcore-websearch",
+  "transport": "http",
+  "url": "https://claude-gateway.example.com/websearch/mcp",
+  "oauth": {
+    "clientId": "<entra public client id>",
+    "authorizationServer": ["https://claude-gateway.example.com/websearch"],
+    "scope": "openid offline_access api://<entra public client id>/mcp.invoke",
+    "callbackHost": "localhost",
+    "callbackPort": 8990
+  }
+}
+```
+
+Also add the gateway host to `coworkEgressAllowedHosts`. The Entra app needs the
+loopback `http://localhost:<callbackPort>/callback` registered under *Mobile and
+desktop applications* and the `api://<clientId>/mcp.invoke` scope exposed
+(`requestedAccessTokenVersion: 2`); the gateway authorizer's `allowedAudience` stays
+the client id.
+
+---
+
+## Security
+
+- Deploy the proxy **internal-only** (behind the VPN'd gateway ALB). It mediates
+  OAuth and relays tokens in transit; it must not be exposed publicly.
+- It holds **no secrets** (public client + PKCE); it never persists tokens and must
+  not log them. TLS end-to-end.
+- It is in the hot path for all web-search MCP traffic — monitor health/availability.
+
+## Local smoke test
+
+`local-test/` (gitignored, throwaway) has a `smoke.sh` that validates the
+resource-stripping and discovery chain without a real Entra login. See the comments
+at the top of that script.
+
+---
+
+## References
+
+- [RFC 8707 — Resource Indicators for OAuth 2.0][RFC 8707]
+- [RFC 9728 — OAuth 2.0 Protected Resource Metadata][RFC 9728]
+- [RFC 8414 — OAuth 2.0 Authorization Server Metadata][RFC 8414]
+- [RFC 7591 — OAuth 2.0 Dynamic Client Registration][RFC 7591]
+- [AgentCore Gateway — inbound JWT authorizer][agentcore-jwt]
+- [Building Claude-Ready Entra ID-Protected MCP Servers with Azure API Management][ms-apim]
+- [10 Azure Entra ID incompatibilities with MCP server authentication][groff]
+- [AWS — secure auth-code flow with AgentCore Gateway and MCP clients][aws-authcode]
+- [anthropics/claude-code#73460 — omit/override the RFC 8707 resource parameter][issue-73460]
+
+Content from external sources above was paraphrased; see each link for the original.
+
+[RFC 8707]: https://datatracker.ietf.org/doc/html/rfc8707
+[RFC 9728]: https://datatracker.ietf.org/doc/html/rfc9728
+[RFC 8414]: https://datatracker.ietf.org/doc/html/rfc8414
+[RFC 7591]: https://datatracker.ietf.org/doc/html/rfc7591
+[agentcore-jwt]: https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/inbound-jwt-authorizer.html
+[ms-apim]: https://developer.microsoft.com/blog/claude-ready-secure-mcp-apim
+[groff]: https://www.groff.dev/blog/azure-entra-id-mcp-server-authentication-incompatibilities
+[aws-authcode]: https://aws.amazon.com/blogs/machine-learning/building-a-secure-auth-code-flow-setup-using-agentcore-gateway-with-mcp-clients/
+[issue-73460]: https://github.com/anthropics/claude-code/issues/73460

--- a/claude-apps-gateway-bootstrap/websearch-proxy/package-lock.json
+++ b/claude-apps-gateway-bootstrap/websearch-proxy/package-lock.json
@@ -1,0 +1,831 @@
+{
+  "name": "claude-websearch-oauth-proxy",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "claude-websearch-oauth-proxy",
+      "version": "0.1.0",
+      "dependencies": {
+        "express": "^4.21.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  }
+}

--- a/claude-apps-gateway-bootstrap/websearch-proxy/package.json
+++ b/claude-apps-gateway-bootstrap/websearch-proxy/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "claude-websearch-oauth-proxy",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Resource-stripping OAuth proxy that fronts an Amazon Bedrock AgentCore gateway so Claude Desktop's MCP OAuth flow works with Microsoft Entra ID (removes the RFC 8707 resource parameter Entra rejects with AADSTS9010010).",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node --test test/"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "dependencies": {
+    "express": "^4.21.2"
+  }
+}

--- a/claude-apps-gateway-bootstrap/websearch-proxy/server.js
+++ b/claude-apps-gateway-bootstrap/websearch-proxy/server.js
@@ -1,0 +1,254 @@
+// Resource-stripping OAuth proxy for Claude Desktop + Microsoft Entra ID + AgentCore Gateway.
+//
+// WHY THIS EXISTS
+// ---------------
+// Amazon Bedrock AgentCore Gateway advertises itself as an MCP resource server. A spec-
+// compliant MCP client (Claude Desktop, mcp-remote, Claude Code >= the 2025-06-18 auth spec)
+// discovers the gateway's Protected Resource Metadata (RFC 9728) and then includes an RFC 8707
+// `resource` parameter (= the gateway URL) in its /authorize and /token requests. Microsoft
+// Entra ID does NOT implement RFC 8707 and rejects that parameter:
+//
+//     AADSTS9010010: The resource parameter provided in the request doesn't match with the
+//     requested scopes.
+//
+// There is no client-side config knob to suppress the parameter (confirmed against Claude
+// Desktop's managed-MCP `oauth` block and mcp-remote). The documented fix (Microsoft / the
+// widely-cited "10 Entra + MCP incompatibilities" write-up) is an OAuth proxy that sits in
+// front of the resource server and STRIPS the `resource` parameter before relaying to Entra.
+// The scope (api://<clientId>/mcp.invoke) already encodes the target, so stripping is safe.
+//
+// WHAT IT DOES
+// ------------
+// Claude talks ONLY to this proxy. The proxy:
+//   * /.well-known/oauth-protected-resource  -> points the client at THIS proxy as the AS
+//   * /.well-known/oauth-authorization-server -> Entra's OIDC metadata, but with authorize/
+//                                                token endpoints rewritten to this proxy
+//   * /oauth/authorize                        -> strip `resource`, 302 to Entra authorize
+//   * /oauth/token                            -> strip `resource`, forward to Entra token
+//   * /oauth/register                         -> mock DCR (Desktop uses a static clientId and
+//                                                normally skips this; kept for other clients)
+//   * /mcp                                    -> reverse-proxy (streaming) to the AgentCore
+//                                                gateway, forwarding the Authorization header
+//
+// The AgentCore gateway is left unchanged: it still validates the Entra JWT it receives
+// (discoveryUrl = Entra, allowedAudience = the client id). The redirect_uri stays the client's
+// own loopback (the proxy passes it through), so Entra redirect registration is unchanged.
+//
+// DEPLOYMENT SHAPE
+// ----------------
+// Hosted internally behind the claude-apps-gateway ALB (same pattern as the bootstrap add-on),
+// reached by the laptop over the VPN and reaching the public AgentCore gateway via NAT egress.
+// The ALB routes a path prefix (e.g. /websearch/*) here WITHOUT stripping it, so the functional
+// routes are mounted under BASE_PATH and every self-referencing URL uses PUBLIC_BASE_URL.
+
+import express from 'express';
+import https from 'node:https';
+import http from 'node:http';
+
+const PORT = parseInt(process.env.PORT || '8082', 10);
+
+// Externally visible origin of the fronting ALB, e.g. https://claude-gateway.example.com
+const PUBLIC_ORIGIN = (process.env.PUBLIC_ORIGIN || '').replace(/\/+$/, '');
+// Path prefix the ALB forwards to this service (NOT stripped by the ALB), e.g. /websearch.
+// Empty string mounts at root (dedicated-host deployments).
+const BASE_PATH = (process.env.BASE_PATH || '').replace(/\/+$/, '');
+// The full externally visible base URL of this proxy; all metadata is self-referential to it.
+const PUBLIC_BASE_URL = `${PUBLIC_ORIGIN}${BASE_PATH}`;
+
+// Upstream AgentCore gateway MCP endpoint, e.g.
+// https://<id>.gateway.bedrock-agentcore.us-east-1.amazonaws.com/mcp
+const UPSTREAM_MCP_URL = process.env.UPSTREAM_MCP_URL || '';
+
+// Entra tenant issuer discovery.
+const ENTRA_TENANT_ID = process.env.ENTRA_TENANT_ID || '';
+const ENTRA_DISCOVERY_URL =
+  process.env.ENTRA_DISCOVERY_URL ||
+  `https://login.microsoftonline.com/${ENTRA_TENANT_ID}/v2.0/.well-known/openid-configuration`;
+
+// Optional static client_id returned by the mock DCR endpoint (only for clients that attempt
+// RFC 7591 dynamic registration; Claude Desktop supplies a static clientId and skips it).
+const MCP_CLIENT_ID = process.env.MCP_CLIENT_ID || '';
+
+if (!PUBLIC_ORIGIN || !UPSTREAM_MCP_URL || !ENTRA_TENANT_ID) {
+  console.error(
+    '[websearch-proxy] required env missing: PUBLIC_ORIGIN, UPSTREAM_MCP_URL, ENTRA_TENANT_ID',
+  );
+  process.exit(1);
+}
+
+const upstream = new URL(UPSTREAM_MCP_URL);
+const PRM_URL = `${PUBLIC_BASE_URL}/.well-known/oauth-protected-resource`;
+
+// ── Entra OIDC metadata (cached 1h) ──────────────────────────────────────────
+let oidcMeta = null;
+let oidcMetaAt = 0;
+async function getEntraMeta() {
+  if (oidcMeta && Date.now() - oidcMetaAt < 3600_000) return oidcMeta;
+  const r = await fetch(ENTRA_DISCOVERY_URL);
+  if (!r.ok) throw new Error(`OIDC discovery ${r.status}`);
+  oidcMeta = await r.json();
+  oidcMetaAt = Date.now();
+  return oidcMeta;
+}
+
+const app = express();
+app.disable('x-powered-by');
+
+// Root health check — the ALB target group probes the container directly (independent of the
+// listener path rule), so this stays at root regardless of BASE_PATH.
+app.get('/healthz', (_req, res) => res.status(200).send('ok'));
+
+// Everything functional is mounted under BASE_PATH because the ALB does not strip the prefix.
+const r = express.Router();
+
+// Health check under the prefix too (lets the TG health check path match the listener rule).
+r.get('/healthz', (_req, res) => res.status(200).send('ok'));
+
+// RFC 9728 Protected Resource Metadata: advertise THIS proxy as the authorization server so
+// the client drives the OAuth dance through us (where the resource parameter is stripped).
+r.get('/.well-known/oauth-protected-resource', (_req, res) => {
+  res.json({
+    resource: `${PUBLIC_BASE_URL}/mcp`,
+    authorization_servers: [PUBLIC_BASE_URL],
+    bearer_methods_supported: ['header'],
+  });
+});
+
+// RFC 8414 Authorization Server Metadata: relay Entra's real metadata but override the
+// endpoints the client will call so authorize/token/register route through this proxy.
+async function authServerMetadata(_req, res) {
+  try {
+    const m = await getEntraMeta();
+    res.json({
+      ...m,
+      issuer: PUBLIC_BASE_URL,
+      authorization_endpoint: `${PUBLIC_BASE_URL}/oauth/authorize`,
+      token_endpoint: `${PUBLIC_BASE_URL}/oauth/token`,
+      registration_endpoint: `${PUBLIC_BASE_URL}/oauth/register`,
+      code_challenge_methods_supported: ['S256'],
+    });
+  } catch (e) {
+    res.status(502).json({ error: 'metadata_unavailable', detail: String(e.message) });
+  }
+}
+r.get('/.well-known/oauth-authorization-server', authServerMetadata);
+// Some clients probe the OIDC discovery path directly; serve the same shape.
+r.get('/.well-known/openid-configuration', authServerMetadata);
+
+// Authorize: strip `resource`, 302 to Entra's real authorization endpoint with all other
+// params (client_id, redirect_uri, scope, state, PKCE challenge, prompt, ...) untouched.
+r.get('/oauth/authorize', async (req, res) => {
+  try {
+    const m = await getEntraMeta();
+    const url = new URL(m.authorization_endpoint);
+    for (const [k, v] of Object.entries(req.query)) {
+      if (k === 'resource') continue; // ← the whole point
+      url.searchParams.set(k, Array.isArray(v) ? String(v[0]) : String(v));
+    }
+    res.redirect(302, url.toString());
+  } catch (e) {
+    res.status(502).send(`authorize proxy error: ${e.message}`);
+  }
+});
+
+// Token: strip `resource`, forward the form-encoded body to Entra's real token endpoint,
+// return the token response verbatim. Public client + PKCE → no client secret to add.
+r.post('/oauth/token', express.urlencoded({ extended: false }), async (req, res) => {
+  try {
+    const m = await getEntraMeta();
+    const params = new URLSearchParams();
+    for (const [k, v] of Object.entries(req.body || {})) {
+      if (k === 'resource') continue; // ← the whole point
+      params.set(k, String(v));
+    }
+    const upstreamResp = await fetch(m.token_endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+      },
+      body: params.toString(),
+    });
+    const body = await upstreamResp.text();
+    res
+      .status(upstreamResp.status)
+      .set('Content-Type', upstreamResp.headers.get('content-type') || 'application/json')
+      .send(body);
+  } catch (e) {
+    res.status(502).json({ error: 'token_proxy_error', detail: String(e.message) });
+  }
+});
+
+// Mock Dynamic Client Registration (RFC 7591). Entra has no DCR; Claude Desktop supplies a
+// static clientId and does not call this. Kept for spec-completeness / other MCP clients.
+r.post('/oauth/register', express.json(), (req, res) => {
+  const requested = req.body || {};
+  res.status(201).json({
+    client_id: MCP_CLIENT_ID || requested.client_id || '',
+    client_id_issued_at: Math.floor(Date.now() / 1000),
+    client_secret_expires_at: 0,
+    token_endpoint_auth_method: 'none',
+    grant_types: Array.isArray(requested.grant_types)
+      ? requested.grant_types
+      : ['authorization_code', 'refresh_token'],
+    response_types: Array.isArray(requested.response_types) ? requested.response_types : ['code'],
+    redirect_uris: Array.isArray(requested.redirect_uris)
+      ? requested.redirect_uris
+      : ['http://127.0.0.1/callback'],
+    scope: requested.scope,
+  });
+});
+
+// Reverse-proxy /mcp to the upstream AgentCore gateway, streaming both directions (MCP uses
+// Streamable HTTP: a POST may return JSON or a long-lived SSE stream). No body parsing here —
+// the raw request is piped straight through.
+r.all('/mcp', (req, res) => {
+  // No token yet → return OUR 401 so the client discovers THIS proxy's PRM (not the gateway's).
+  if (!req.headers.authorization) {
+    res.set('WWW-Authenticate', `Bearer resource_metadata="${PRM_URL}"`);
+    return res
+      .status(401)
+      .json({ jsonrpc: '2.0', id: 0, error: { code: -32001, message: 'Missing Bearer token' } });
+  }
+  const mod = upstream.protocol === 'https:' ? https : http;
+  const headers = { ...req.headers, host: upstream.host };
+  delete headers['content-length']; // recomputed by the pipe / chunked
+  const proxyReq = mod.request(
+    {
+      method: req.method,
+      hostname: upstream.hostname,
+      port: upstream.port || (upstream.protocol === 'https:' ? 443 : 80),
+      path: upstream.pathname + (upstream.search || ''),
+      headers,
+    },
+    (proxyRes) => {
+      // If the gateway itself challenges, rewrite its resource_metadata pointer to ours so the
+      // client re-discovers through the proxy rather than hitting the gateway's PRM directly.
+      const wa = proxyRes.headers['www-authenticate'];
+      if (wa) {
+        proxyRes.headers['www-authenticate'] = wa.replace(
+          /resource_metadata="[^"]*"/,
+          `resource_metadata="${PRM_URL}"`,
+        );
+      }
+      res.writeHead(proxyRes.statusCode || 502, proxyRes.headers);
+      proxyRes.pipe(res);
+    },
+  );
+  proxyReq.on('error', (e) => {
+    if (!res.headersSent) {
+      res.status(502).json({ error: 'upstream_error', detail: String(e.message) });
+    } else {
+      res.end();
+    }
+  });
+  req.pipe(proxyReq);
+});
+
+app.use(BASE_PATH || '/', r);
+
+app.listen(PORT, '0.0.0.0', () => {
+  console.log(
+    `[websearch-proxy] listening on 0.0.0.0:${PORT} — base=${PUBLIC_BASE_URL || '(root)'} upstream=${UPSTREAM_MCP_URL}`,
+  );
+});


### PR DESCRIPTION
## Problem

Claude Desktop / Cowork (and any spec-compliant MCP client) can't use an Amazon Bedrock **AgentCore Gateway** MCP server — e.g. the AgentCore web search tool — when the identity provider is **Microsoft Entra ID**.

On first connect the client discovers the gateway's Protected Resource Metadata (RFC 9728) and, per the MCP auth spec, adds an RFC 8707 `resource` parameter (the gateway URL) to the `/authorize` and `/token` requests. Entra does not implement RFC 8707 and rejects it:

```
AADSTS9010010: The resource parameter provided in the request doesn't match with the requested scopes.
```

There is no client-side configuration to suppress the parameter — Claude Desktop's managed-MCP `oauth` block, `mcp-remote`, and Claude Code all emit it (tracked in anthropics/claude-code#73460). With Amazon Cognito this "just works"; with Entra it is blocked.

## Solution

An **optional resource-stripping OAuth proxy** that fronts the gateway — the documented Microsoft/community workaround. Claude talks only to the proxy; the proxy mediates the OAuth handshake, **strips the `resource` parameter** before relaying to Entra, and reverse-proxies `/mcp` to the gateway. The gateway's `CUSTOM_JWT` authorizer is unchanged.

It deploys behind the **existing internal gateway ALB** (same pattern as the bootstrap add-on) via a path-prefix listener rule, and is **opt-in** (`-c enableWebsearchProxy=true`) so the default bootstrap deploy is unaffected.

## What's included

- `websearch-proxy/` — small Node/Express service + Dockerfile + README (problem, fix, architecture, endpoints, two-pass deploy)
- `cdk/lib/websearch-proxy-stack.ts` — `WebsearchProxyStack` (Fargate + target group + listener rule + SG rules), wired opt-in in `cdk/bin/app.ts`
- an example `managedMcpServers` entry in `bootstrap/config/bootstrap-config.example.json`

## How it was tested

Deployed to a test account (eu-south-1) behind the gateway's internal ALB and validated end-to-end through the real ALB:

- `/oauth/authorize` → 302 to Entra **without** `resource=`
- `/mcp` without a token → 401 carrying the proxy's own `resource_metadata`
- `/mcp` with a token → forwarded to the AgentCore gateway (gateway `x-amzn-requestid` returned)
- interactive Entra login on Claude Desktop → the web search MCP connects and tool calls succeed

## Notes

- The gateway's inbound authorizer is untouched (still validates the Entra token; `allowedAudience` stays the client id).
- For Claude Desktop the proxy only needs to strip `resource` (Desktop uses a static `clientId` and skips Dynamic Client Registration); the mock DCR / RFC 8414 endpoints are included for completeness / other clients.
- References (problem and fix): RFC 8707 / 9728 / 8414 / 7591, the Microsoft "Claude-ready Entra-protected MCP servers with APIM" guidance, and the "10 Entra + MCP incompatibilities" write-up — see the component README.
