### PR TITLE
chore(claude-apps-gateway): bump pinned Claude Code to 2.1.218

### DIFF
--- a/claude-apps-gateway/README.md
+++ b/claude-apps-gateway/README.md
@@ -108,7 +108,7 @@ Both the gateway server (Linux binary) and each developer's Claude Code CLI must
 
 Developers can update with `claude update`. The gateway server uses the same binary, downloaded from the Claude Code release page and packaged into a container image.
 
-Some gateway behaviour is version-gated: v2.1.198 added cross-upstream failover on `404` and the `anthropicAws` (Claude Platform on AWS) provider — earlier gateway builds reject that provider at boot. The worked example in this repo pins **2.1.199** to get both. See [`docs/upstream-watch.md`](docs/upstream-watch.md) for a checklist to stay across gateway releases.
+Some gateway behaviour is version-gated: v2.1.198 added cross-upstream failover on `404` and the `anthropicAws` (Claude Platform on AWS) provider — earlier gateway builds reject that provider at boot. The worked example in this repo pins **2.1.218**, which also fixes gateway spend metering to price Bedrock application-inference-profile ARNs and other config-mapped upstream model IDs at the configured model's rates — directly relevant to this example's `global.anthropic.*` inference profiles. See [`docs/upstream-watch.md`](docs/upstream-watch.md) for a checklist to stay across gateway releases.
 
 ### 5. Device management (for pushing settings to developers)
 

--- a/claude-apps-gateway/cdk/bin/app.ts
+++ b/claude-apps-gateway/cdk/bin/app.ts
@@ -33,7 +33,7 @@ import { GatewayStack } from '../lib/claude-gateway-stack';
  *     imageReady      "false" for pass 1 (repo only), "true"/unset for pass 2
  *   BUILD-TIME (stamped into the image by stamp-config.sh; shown here for parity,
  *   not passed to the running task — changing them means a new image, by design):
- *     claudeVersion   default 2.1.199
+ *     claudeVersion   default 2.1.218
  *     oidcIssuer, oidcClientId, allowedEmailDomains
  */
 const app = new cdk.App();
@@ -45,7 +45,7 @@ const region = ctx('region') ?? process.env.CDK_DEFAULT_REGION ?? 'us-east-1';
 // the inference-profile IAM ARN at a different region. NOTE: cross-region Bedrock
 // also needs the VPC Bedrock interface endpoint reworked — see the stack.
 const bedrockRegion = ctx('bedrockRegion') ?? region;
-const claudeVersion = ctx('claudeVersion') ?? '2.1.199';
+const claudeVersion = ctx('claudeVersion') ?? '2.1.218';
 
 new GatewayStack(app, 'ClaudeGatewayStack', {
   env: { account: process.env.CDK_DEFAULT_ACCOUNT, region },

--- a/claude-apps-gateway/cdk/scripts/setup.sh
+++ b/claude-apps-gateway/cdk/scripts/setup.sh
@@ -121,7 +121,7 @@ PROJECT="${PROJECT:-claude-gateway}"
 # anthropicAws (Claude Platform on AWS) provider, both referenced in
 # gateway.yaml.template; keep this >= 2.1.198 if you rely on either. See the README
 # "Version coupling" note.
-CLAUDE_VERSION="${CLAUDE_VERSION:-2.1.199}"
+CLAUDE_VERSION="${CLAUDE_VERSION:-2.1.218}"
 RELEASES_URL="${RELEASES_URL:-https://downloads.claude.ai/claude-code-releases}"
 KEYS_URL="${KEYS_URL:-https://downloads.claude.ai/keys/claude-code.asc}"
 # Anthropic Claude Code release signing key fingerprint (verify the imported key).

--- a/claude-apps-gateway/cdk/test/gateway-stack.test.ts
+++ b/claude-apps-gateway/cdk/test/gateway-stack.test.ts
@@ -21,7 +21,7 @@ const REGION = 'us-east-1';
 const PASS2: GatewayStackProps = {
   env: { account: ACCOUNT, region: REGION },
   imageReady: true,
-  imageTag: '2.1.199',
+  imageTag: '2.1.218',
   publicUrl: 'https://claude-gateway.example.com',
   certArn: `arn:aws:acm:${REGION}:${ACCOUNT}:certificate/abc-123`,
   zoneName: 'example.com',
@@ -36,7 +36,7 @@ function synth(props: GatewayStackProps): Template {
 }
 
 describe('pass 1 (imageReady: false) — ECR repo only', () => {
-  const template = synth({ env: PASS2.env, imageReady: false, imageTag: '2.1.199' });
+  const template = synth({ env: PASS2.env, imageReady: false, imageTag: '2.1.218' });
 
   test('creates the ECR repository', () => {
     template.resourceCountIs('AWS::ECR::Repository', 1);

--- a/claude-apps-gateway/docs/deployment.md
+++ b/claude-apps-gateway/docs/deployment.md
@@ -152,7 +152,7 @@ ALLOWED_EMAIL_DOMAINS=example.com \
 # Download the pinned linux-x64 binary and verify it (versions must match the
 # claudeVersion pin in bin/app.ts). setup.sh's phase 2 shows the full
 # GPG-signed-manifest verification; the abbreviated form:
-CLAUDE_VERSION=2.1.199
+CLAUDE_VERSION=2.1.218
 curl -fL -o claude "https://downloads.claude.ai/claude-code-releases/${CLAUDE_VERSION}/linux-x64/claude"
 curl -fsSL "https://downloads.claude.ai/claude-code-releases/${CLAUDE_VERSION}/manifest.json" \
   | jq -r '.platforms["linux-x64"].checksum' | xargs -I{} sh -c 'echo "{}  claude" | shasum -a 256 -c'

--- a/claude-apps-gateway/docs/upstream-watch.md
+++ b/claude-apps-gateway/docs/upstream-watch.md
@@ -10,8 +10,8 @@ Run it **before each version bump** and **when a gateway release ships**.
 
 ## Current pin
 
-- **Pinned version:** `2.1.199` (see `CLAUDE_VERSION` in `cdk/scripts/setup.sh` and `claudeVersion` in `cdk/bin/app.ts`)
-- **Validated on:** `2.1.199`
+- **Pinned version:** `2.1.218` (see `CLAUDE_VERSION` in `cdk/scripts/setup.sh` and `claudeVersion` in `cdk/bin/app.ts`)
+- **Validated on:** `2.1.218` (live end-to-end: deploy + SSO sign-in + Bedrock inference)
 - **Floor:** `2.1.195` (the `gateway` subcommand floor)
 
 Update the "Pinned version" line here whenever `CLAUDE_VERSION` changes.


### PR DESCRIPTION
## What

Bumps the pinned Claude Code version for the claude-apps-gateway worked example from **2.1.199 → 2.1.218**.

## Why

2.1.218 ships a gateway change directly relevant to this example, whose upstream is Amazon Bedrock via **global** cross-region inference profiles (`global.anthropic.*`). From the [Claude Code CHANGELOG (2.1.218)](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md):

> Fixed gateway spend metering to price Bedrock application-inference-profile ARNs and other config-mapped upstream model IDs at the configured model's rates

Since this example maps upstream model IDs through `gateway.yaml` and uses inference-profile ARNs, correct spend metering is exactly the behaviour it exercises — so the pin should move to the release that fixes it.

## Changes

- `cdk/scripts/setup.sh` — `CLAUDE_VERSION` default → `2.1.218`
- `cdk/bin/app.ts` — `claudeVersion` default → `2.1.218`
- `cdk/test/gateway-stack.test.ts` — `imageTag` expectations → `2.1.218`
- `README.md`, `docs/deployment.md`, `docs/upstream-watch.md` — version notes, including **"Validated on" → `2.1.218`**

## Verification

- **Live end-to-end validation on 2.1.218**: deployed the full Fargate stack, completed corporate-SSO sign-in through the gateway, and ran Bedrock inference successfully.
- `cd cdk && npm test` → 17/17 pass
- `bash -n cdk/scripts/setup.sh` clean
- Ran the repo's upstream-watch changelog review across `2.1.199 → 2.1.218`: no new required config keys or version tripwires.