### PR TITLE
fix(claude-apps-gateway): bound deploy.sh gateway probe; generalize VPN-only wording

### DIFF
--- a/claude-apps-gateway/cdk/README.md
+++ b/claude-apps-gateway/cdk/README.md
@@ -353,9 +353,9 @@ easy teardown is data durability. Before using it with real workloads, edit
   internal ALB (its hostname must resolve to private IPs only, which is why the ALB is
   internal in the first place).
 
-## Testing without a VPN (local workaround)
+## Testing without VPC network access (local workaround)
 
-In production, the gateway runs behind an internal ALB and developers access it through VPN. But for testing on your own laptop without VPN access to the VPC, you can run the gateway locally.
+In production, the gateway runs behind an internal ALB and developers reach it over a private network path to the VPC (VPN, Direct Connect, Transit Gateway, etc.). But for testing on your own laptop without that access, you can run the gateway locally.
 
 This works because the Claude Code CLI accepts `127.0.0.1` (loopback) as a valid private address.
 
@@ -465,7 +465,7 @@ You should see the Cloud gateway screen. Press Enter, complete browser SSO, and 
 - Your local machine needs AWS credentials configured (`~/.aws/credentials` or env vars) for Amazon Bedrock access
 - `.dev` domains have HSTS preloaded in browsers, so avoid them for the hostname (self-signed certs won't work in the browser)
 - The Claude Code binary must be v2.1.195+. If your standard install is older, replace it with the gateway binary
-- This is for testing only. Customers with VPN access do not need any of this.
+- This is for testing only. Customers with a private network path to the VPC (VPN, Direct Connect, etc.) do not need any of this.
 
 ---
 

--- a/claude-apps-gateway/cdk/scripts/deploy.sh
+++ b/claude-apps-gateway/cdk/scripts/deploy.sh
@@ -253,13 +253,24 @@ echo "✅ OIDC client secret seeded and service redeployed"
 echo ""
 
 # --- Step 5: Verify ---
+# The gateway sits behind an INTERNAL ALB (private IPs by design), so this probe
+# only succeeds from a host with a private network path to the VPC (in-VPC, VPN,
+# Direct Connect, peering, Transit Gateway, etc.). Bound the curl with an explicit
+# --connect-timeout/--max-time: without them it hangs on the TCP connect when run
+# from a host that can't route to the private ALB, making an already-finished
+# deploy look stuck. A failure here is EXPECTED when there is no network path and
+# does NOT mean the deploy failed — the stack/service are already up by this point.
 echo "Step 5/5: Verifying the gateway..."
-RESPONSE=$(curl -s "https://${GATEWAY_HOSTNAME}/.well-known/oauth-authorization-server" 2>/dev/null || echo "")
+RESPONSE=$(curl -s --connect-timeout 5 --max-time 15 \
+  "https://${GATEWAY_HOSTNAME}/.well-known/oauth-authorization-server" 2>/dev/null || echo "")
 if echo "$RESPONSE" | grep -q "device_authorization_endpoint"; then
   echo "✅ Gateway is live at https://${GATEWAY_HOSTNAME}"
 else
-  echo "⚠️  Gateway may still be starting (or unreachable without VPN). Check with:"
-  echo "   curl https://${GATEWAY_HOSTNAME}/.well-known/oauth-authorization-server"
+  echo "ℹ️  Could not reach the gateway from here within the timeout — this is EXPECTED"
+  echo "    when this host has no private network path to the VPC (VPN, Direct Connect,"
+  echo "    in-VPC, etc.); the ALB is internal (private IPs only). The deploy itself is"
+  echo "    complete. Verify from a host with a network path to the VPC with:"
+  echo "      curl https://${GATEWAY_HOSTNAME}/.well-known/oauth-authorization-server"
 fi
 
 echo ""


### PR DESCRIPTION
## What

Two small robustness/clarity fixes for the claude-apps-gateway worked example, found while running a live deploy.

### 1. Bound `deploy.sh`'s Step 5 verify curl

The final step curls `/.well-known/oauth-authorization-server` to confirm the gateway is live. The gateway sits behind an **internal** ALB (private IPs by design), and the curl had **no timeout** — so when `deploy.sh` runs from a host with no network path to the VPC, it hangs on the TCP connect, making an already-finished deploy look stuck.

- Add `--connect-timeout 5 --max-time 15` so it fails fast.
- Reword the guidance so a miss reads as **expected off-network** and does not imply the deploy failed (the stack/service are already up by that point).

### 2. Generalize "VPN-only" doc wording

A few spots in `cdk/README.md` framed VPN as the *only* way to reach the internal ALB. Reworded to "private network path to the VPC (VPN / Direct Connect / Transit Gateway)", matching the convention already used in `cdk/scripts/setup.sh` and `docs/deployment.md`. Legitimately VPN-specific content (the Client VPN appendix in `docs/connectivity.md`, teardown steps, `INGRESS_CIDR` client-CIDR notes) was left unchanged.

## Verification

- `bash -n cdk/scripts/deploy.sh` clean; `shellcheck` clean (only the pre-existing SC1091 info on the sourced `.env`).
- Docs-only for the wording change.