### PR TITLE
feat(claude-apps-gateway): offer Claude Opus 5 in the model catalog

### DIFF
--- a/claude-apps-gateway/README.md
+++ b/claude-apps-gateway/README.md
@@ -240,9 +240,9 @@ upstreams:
 # region-agnostic. (For data residency, swap global. for a geo prefix: us./eu./apac.)
 auto_include_builtin_models: false
 models:
-  - id: claude-opus-4-8
-    label: Claude Opus 4.8
-    upstream_model: { bedrock: global.anthropic.claude-opus-4-8 }
+  - id: claude-opus-5
+    label: Claude Opus 5
+    upstream_model: { bedrock: global.anthropic.claude-opus-5 }
   - id: claude-haiku-4-5
     label: Claude Haiku 4.5   # no short alias — dated profile id
     upstream_model: { bedrock: global.anthropic.claude-haiku-4-5-20251001-v1:0 }

--- a/claude-apps-gateway/cdk/README.md
+++ b/claude-apps-gateway/cdk/README.md
@@ -312,7 +312,7 @@ inference confined to a specific geography, switch the catalog off global:
 - A geo (or in-region) profile only routes within that geography, so pick a
   `BEDROCK_REGION` the profile actually spans.
 
-**Default model set.** The shipped catalog is Claude Opus 4.8, Sonnet 5, and Haiku 4.5
+**Default model set.** The shipped catalog is Claude Opus 5, Sonnet 5, and Haiku 4.5
 — all three invoke via their global profiles from any region. **Claude Fable 5 is
 opt-in**: on Bedrock it requires a non-default data-retention mode that isn't enabled
 in every region, so it returns `ValidationException: data retention mode 'default' is
@@ -422,9 +422,9 @@ upstreams:
 # Global inference profiles → region-agnostic (see "Regions & data residency")
 auto_include_builtin_models: false
 models:
-  - id: claude-opus-4-8
-    label: Claude Opus 4.8
-    upstream_model: { bedrock: global.anthropic.claude-opus-4-8 }
+  - id: claude-opus-5
+    label: Claude Opus 5
+    upstream_model: { bedrock: global.anthropic.claude-opus-5 }
 ```
 
 **5. Trust the self-signed cert:**

--- a/claude-apps-gateway/cdk/gateway.yaml.example
+++ b/claude-apps-gateway/cdk/gateway.yaml.example
@@ -160,7 +160,7 @@ managed:
     - match: {}
       cli:
         availableModels:
-          - claude-opus-4-8
+          - claude-opus-5
           - claude-sonnet-5
           - claude-haiku-4-5
           # - claude-fable-5   # opt-in — see the models: block note below
@@ -190,10 +190,10 @@ managed:
 # enable the retention prereq for your region, uncomment it in availableModels above,
 # and uncomment the entry below.
 models:
-  - id: claude-opus-4-8
-    label: Claude Opus 4.8
+  - id: claude-opus-5
+    label: Claude Opus 5
     upstream_model:
-      bedrock: global.anthropic.claude-opus-4-8
+      bedrock: global.anthropic.claude-opus-5
   - id: claude-sonnet-5
     label: Claude Sonnet 5
     upstream_model:

--- a/claude-apps-gateway/cdk/gateway.yaml.template
+++ b/claude-apps-gateway/cdk/gateway.yaml.template
@@ -167,7 +167,7 @@ managed:
     - match: {}
       cli:
         availableModels:
-          - claude-opus-4-8
+          - claude-opus-5
           - claude-sonnet-5
           - claude-haiku-4-5
           # - claude-fable-5   # opt-in — see the models: block note below
@@ -197,10 +197,10 @@ managed:
 # enable the retention prereq for your region, uncomment it in availableModels above,
 # and uncomment the entry below.
 models:
-  - id: claude-opus-4-8
-    label: Claude Opus 4.8
+  - id: claude-opus-5
+    label: Claude Opus 5
     upstream_model:
-      bedrock: global.anthropic.claude-opus-4-8
+      bedrock: global.anthropic.claude-opus-5
   - id: claude-sonnet-5
     label: Claude Sonnet 5
     upstream_model:

--- a/claude-apps-gateway/docs/deployment.md
+++ b/claude-apps-gateway/docs/deployment.md
@@ -34,7 +34,7 @@ a common failure:
      --inference-config '{"maxTokens":5}' >/dev/null && echo model access OK
    ```
 
-   Not every model has a short-alias inference profile. `claude-opus-4-8`,
+   Not every model has a short-alias inference profile. `claude-opus-5`,
    `claude-sonnet-5`, and `claude-fable-5` do, but **Haiku 4.5 exists only as the
    dated profile** `global.anthropic.claude-haiku-4-5-20251001-v1:0` — the short
    `global.anthropic.claude-haiku-4-5` is rejected as `ValidationException: invalid`.


### PR DESCRIPTION
## What

Adds **Claude Opus 5** (`claude-opus-5`) to the example's model catalog, replacing Claude Opus 4.8. Opus 5 is now the recommended model for agentic coding / enterprise work and is available on Amazon Bedrock; Opus 4.8 has moved to Anthropic's legacy tier.

## Changes

- **`cdk/gateway.yaml.template` + `cdk/gateway.yaml.example`** — replace `claude-opus-4-8` with `claude-opus-5` in both the `managed.policies.availableModels` picker allowlist and the `models:` catalog. The catalog entry maps to `global.anthropic.claude-opus-5`, matching the dateless global-inference-profile pattern the `claude-sonnet-5` entry already uses.
- **Docs** (`cdk/README.md`, `README.md`, `docs/deployment.md`) — update the "shipped catalog" statement and the catalog / short-alias examples that mirror it.

## Why no IAM or version change

- **No IAM/CDK change:** the task role already grants `bedrock:InvokeModel*` on the wildcards `inference-profile/global.anthropic.*` and `foundation-model/anthropic.*`, which cover Opus 5. The CDK tests assert those wildcards (not specific model IDs), so nothing breaks.
- **No pinned-CLI bump:** the gateway resolves operator-defined model IDs straight to Bedrock inference profiles (`auto_include_builtin_models: false`), so a new model id is neither a new gateway subcommand nor a new managed-settings key. `CLAUDE_VERSION` stays at 2.1.218.
- **Operator prerequisite unchanged:** enable Bedrock model access for the model you list (already documented). Confirm the exact global profile id with `aws bedrock list-inference-profiles` per the template's existing caveat.

Deliberately left as-is: illustrative policy/failover snippets that already show non-shipped models (e.g. `sonnet-4-6`, on-demand profiles), workshop teaching material, and the `LESSONS.md` live-deploy log (historical record).

## Verification

`gateway.yaml.example` parses; the `stamp-config` suite stamps the edited template to valid YAML (9); `setup-helpers` (14); `cdk synth` + jest (17) all pass. No live AWS account exercised (per repo convention).