### PR TITLE
fix(claude-apps-gateway): make VPC reuse and repeat deploys safe

### DIFF
--- a/claude-apps-gateway/CLAUDE.md
+++ b/claude-apps-gateway/CLAUDE.md
@@ -92,9 +92,11 @@ No live AWS account is wired up here, so verification is local/static:
   synthesized template — dual-ARN Bedrock policy, IPv4 internal ALB, `/healthz` probe,
   ADOT telemetry sidecar, `createVpcEndpoints` opt-out, imported-cert TLS),
   `./test/stamp-config.test.sh`
-  (dependency-free bash: placeholder guard + Google scope auto-injection), and
+  (dependency-free bash: placeholder guard + Google scope auto-injection),
   `./test/setup-helpers.test.sh` (setup.sh's sourceable helpers — container-tool
-  detection / `--provenance` gating + the OIDC-secret preflight). None
+  detection / `--provenance` gating + the OIDC-secret preflight), and
+  `./test/deploy-helpers.test.sh` (deploy.sh's pass-1 gate — the destructive branch's
+  status allowlist, fail-closed status query, early bail on a wedged stack). None
   needs an AWS account. CDK tests pass `-c zoneId` to skip the `fromLookup` credential call.
 - Config: `python3 -c 'import yaml; yaml.safe_load(open("gateway.yaml.example"))'` (the `${...}`
   placeholders are plain strings to YAML).

--- a/claude-apps-gateway/cdk/README.md
+++ b/claude-apps-gateway/cdk/README.md
@@ -185,7 +185,8 @@ at `desiredCount 2` — no manual scale-up):
 ```bash
 npx cdk bootstrap -c imageReady=false    # first time only
 
-# Pass 1: ECR repo only
+# Pass 1: ECR repo only — FIRST DEPLOY ONLY (re-running it over a pass-2 stack
+# deletes the RDS instance and everything else; update via pass 2 alone).
 npx cdk deploy -c imageReady=false \
   -c publicUrl=https://claude-gateway.internal.company.com \
   -c zoneName=internal.company.com -c ingressCidr=10.0.0.0/8 \
@@ -249,7 +250,7 @@ All values come from `.env`. The CDK code reads them at deploy time.
 
 | Variable | What it is |
 |----------|-----------|
-| `GATEWAY_NAME` | Prefix for the stack's named resources (repo, cluster, service, secrets, log group); `deploy.sh` passes it to the `gatewayName` context so the stack matches |
+| `GATEWAY_NAME` | Prefix for the stack's named resources (repo, cluster, service, secrets, log group); `deploy.sh` passes it to the `gatewayName` context so the stack matches. **Fixed once deployed** — changing it replaces the ECR repo, so `deploy.sh` refuses; to rename, tear down and deploy fresh |
 | `GATEWAY_HOSTNAME` | The full DNS name developers connect to |
 | `HOSTED_ZONE_ID` | Route53 zone ID where the DNS record is created (optional if managing DNS externally) |
 | `HOSTED_ZONE_NAME` | Route53 zone name (optional if managing DNS externally) |
@@ -258,11 +259,11 @@ All values come from `.env`. The CDK code reads them at deploy time.
 | `OIDC_CLIENT_SECRET` | OAuth client secret from your IdP app registration; `deploy.sh` seeds it into Secrets Manager (never baked into the image) and refuses to deploy while it's still the placeholder |
 | `ALLOWED_EMAIL_DOMAINS` | Only users with these email domains can sign in |
 | `BEDROCK_REGION` | Region whose Bedrock endpoint the gateway calls (the upstream `region:` + the inference-profile IAM ARN). Any region works — the gateway uses global inference profiles. See [Regions & data residency](#regions--data-residency) |
-| `DEPLOY_REGION` | Optional. Region the **stack** deploys into (VPC/ALB/RDS/ECR/ECS/CodeBuild). Defaults to `BEDROCK_REGION`; `deploy.sh` exports it as `AWS_REGION`/`AWS_DEFAULT_REGION` so every `aws` call and CDK agree. See [Regions](#regions) |
+| `DEPLOY_REGION` | Optional. Region the **stack** deploys into (VPC/ALB/RDS/ECR/ECS/CodeBuild). Defaults to `BEDROCK_REGION`; `deploy.sh` exports it as `AWS_REGION`/`AWS_DEFAULT_REGION` so every `aws` call and CDK agree. `deploy.sh` targets **one active region per account** (see the scope note at its Step 3). See [Regions](#regions) |
 | `CERT_ARN` | Imported ACM cert ARN for `GATEWAY_HOSTNAME` (required; `deploy.sh` maps it to the `certArn` context) |
 | `INGRESS_CIDR` | VPN/corp **client** CIDR developers connect from — **not** the VPC CIDR (required; maps to `ingressCidr`) |
 | `VPC_ID` | Optional. Reuse an existing VPC (e.g. to keep a Client VPN association intact) instead of creating one; maps to `vpcId` |
-| `CREATE_VPC_ENDPOINTS` | Optional. Set `false` with `VPC_ID` when the reused VPC already has the interface endpoints; maps to `createVpcEndpoints` |
+| `CREATE_VPC_ENDPOINTS` | Optional. Set `false` with `VPC_ID` when the reused VPC already has the interface endpoints; maps to `createVpcEndpoints`. You must then authorize 443 from the task SG on those endpoints yourself — see [Reusing an existing VPC](../docs/deployment.md#reusing-an-existing-vpc) |
 
 ### CDK context variables
 
@@ -283,7 +284,7 @@ pass 2 (default) deploys the full stack.
 | `zoneId` | 2 | no | Hosted-zone id (looked up from `zoneName` if omitted) |
 | `ingressCidr` | 2 | **yes** | VPN/corp **client** CIDR developers connect from — **not** the VPC CIDR |
 | `vpcId` | 2 | no | Import an existing VPC instead of creating one |
-| `createVpcEndpoints` | 2 | no | Default `true`. Set `false` **only** when reusing a `vpcId` that already has the Bedrock/Secrets Manager/ECR/CloudWatch/S3 endpoints — AWS allows one private-DNS endpoint per service per VPC, so recreating them fails the deploy |
+| `createVpcEndpoints` | 2 | no | Default `true`. Set `false` **only** when reusing a `vpcId` that already has the Bedrock/Secrets Manager/ECR/CloudWatch interface endpoints (+ the S3 gateway endpoint) — AWS allows one private-DNS endpoint per service per VPC, so recreating them fails the deploy. Then authorize 443 yourself: [Reusing an existing VPC](../docs/deployment.md#reusing-an-existing-vpc) |
 
 ### Regions & data residency
 

--- a/claude-apps-gateway/cdk/README.md
+++ b/claude-apps-gateway/cdk/README.md
@@ -115,10 +115,13 @@ validation never needs the hostname to be publicly resolvable.
 > by the [context variables below](#cdk-context-variables), with the image built
 > from the tracked distroless `Dockerfile` and SHA-verified binary. The
 > `.env` + `deploy.sh` flow in the steps below is a convenience path: `deploy.sh`
-> builds the image via CodeBuild using its own inline Dockerfile and config, and
-> maps your `.env` values onto the CDK context (`-c`) the stack requires, running
-> both deploy passes for you. Driving `npx cdk deploy` directly (Option B below)
-> means supplying that context yourself.
+> maps your `.env` values onto the CDK context (`-c`) the stack requires and runs both
+> deploy passes for you, building the image in CodeBuild (from this directory's tracked
+> `Dockerfile` and `stamp-config.sh`) so no local Docker is needed. It does not
+> download or SHA-verify the binary — stage that yourself, per
+> [prerequisite 5](#5-the-claude-code-linux-x64-binary) — and it pushes `:latest`.
+> Driving `npx cdk deploy` directly (Option B below) means supplying that context
+> yourself.
 
 ### Step 1: Configure
 
@@ -259,7 +262,7 @@ All values come from `.env`. The CDK code reads them at deploy time.
 | `OIDC_CLIENT_SECRET` | OAuth client secret from your IdP app registration; `deploy.sh` seeds it into Secrets Manager (never baked into the image) and refuses to deploy while it's still the placeholder |
 | `ALLOWED_EMAIL_DOMAINS` | Only users with these email domains can sign in |
 | `BEDROCK_REGION` | Region whose Bedrock endpoint the gateway calls (the upstream `region:` + the inference-profile IAM ARN). Any region works — the gateway uses global inference profiles. See [Regions & data residency](#regions--data-residency) |
-| `DEPLOY_REGION` | Optional. Region the **stack** deploys into (VPC/ALB/RDS/ECR/ECS/CodeBuild). Defaults to `BEDROCK_REGION`; `deploy.sh` exports it as `AWS_REGION`/`AWS_DEFAULT_REGION` so every `aws` call and CDK agree. `deploy.sh` targets **one active region per account** (see the scope note at its Step 3). See [Regions](#regions) |
+| `DEPLOY_REGION` | Optional. Region the **stack** deploys into (VPC/ALB/RDS/ECR/ECS/CodeBuild). Defaults to `BEDROCK_REGION`; `deploy.sh` exports it as `AWS_REGION`/`AWS_DEFAULT_REGION` so every `aws` call and CDK agree. `deploy.sh` targets **one active region per account** (see the scope note at its Step 3). See [Regions & data residency](#regions--data-residency) |
 | `CERT_ARN` | Imported ACM cert ARN for `GATEWAY_HOSTNAME` (required; `deploy.sh` maps it to the `certArn` context) |
 | `INGRESS_CIDR` | VPN/corp **client** CIDR developers connect from — **not** the VPC CIDR (required; maps to `ingressCidr`) |
 | `VPC_ID` | Optional. Reuse an existing VPC (e.g. to keep a Client VPN association intact) instead of creating one; maps to `vpcId` |
@@ -317,8 +320,8 @@ region, and prompts/outputs may be processed or stored outside `BEDROCK_REGION` 
 may retain inputs/outputs in the destination region for abuse detection). If you need
 inference confined to a specific geography, switch the catalog off global:
 
-- Edit the `models:` block (in `deploy.sh`'s inline `gateway.yaml`, or your stamped
-  `gateway.yaml` on the hardened path) — replace each `global.` prefix with a geo
+- Edit the `models:` block in [`gateway.yaml.template`](gateway.yaml.template) (both
+  deploy paths stamp from it) — replace each `global.` prefix with a geo
   profile (`us.` / `eu.` / `au.`, and `jp.` for some models — geo coverage varies per
   model, so it isn't uniform across the catalog). Confirm the exact id per model with
   `aws bedrock list-inference-profiles --region <your-region>` — they're not a clean
@@ -334,8 +337,7 @@ opt-in**: on Bedrock it requires a non-default data-retention mode that isn't en
 in every region, so it returns `ValidationException: data retention mode 'default' is
 not available for this model` where the default three work. To add it, enable that
 prereq for your region, then uncomment `claude-fable-5` in both `availableModels` and
-the `models:` block (`gateway.yaml.template` / `.example`, or `deploy.sh`'s inline
-`gateway.yaml`).
+the `models:` block of `gateway.yaml.template` (or `.example`).
 
 > **Driving CDK by hand (Option B)?** The two-pass `cdk deploy` creates the OIDC
 > client secret with a generated placeholder — it does **not** seed your real
@@ -493,7 +495,7 @@ Remove everything the stack created:
 npx cdk destroy
 ```
 
-This deletes the ECS service, ALB, RDS database, ECR repository, IAM roles, security groups, DNS record, and log group. The S3 bucket and CodeBuild project used for image builds (if created by `deploy.sh`) are separate and may need manual cleanup.
+This deletes the ECS service, ALB, RDS database, ECR repository, IAM roles, security groups, DNS record, and log group. The S3 bucket, CodeBuild project, and build role (if created by `deploy.sh`) sit outside the stack — see [CodeBuild build artifacts](../docs/teardown.md#codebuild-build-artifacts-only-if-you-deployed-with-deploysh) for the commands.
 
 ## Cost
 

--- a/claude-apps-gateway/cdk/README.md
+++ b/claude-apps-gateway/cdk/README.md
@@ -180,7 +180,8 @@ at `desiredCount 2` — no manual scale-up):
 ```bash
 npx cdk bootstrap -c imageReady=false    # first time only
 
-# Pass 1: ECR repo only
+# Pass 1: ECR repo only — FIRST DEPLOY ONLY (re-running it over a pass-2 stack
+# deletes the RDS instance and everything else; update via pass 2 alone).
 npx cdk deploy -c imageReady=false \
   -c publicUrl=https://claude-gateway.internal.company.com \
   -c zoneName=internal.company.com -c ingressCidr=10.0.0.0/8 \
@@ -235,7 +236,7 @@ All values come from `.env`. The CDK code reads them at deploy time.
 
 | Variable | What it is |
 |----------|-----------|
-| `GATEWAY_NAME` | Prefix for the stack's named resources (repo, cluster, service, secrets, log group); `deploy.sh` passes it to the `gatewayName` context so the stack matches |
+| `GATEWAY_NAME` | Prefix for the stack's named resources (repo, cluster, service, secrets, log group); `deploy.sh` passes it to the `gatewayName` context so the stack matches. **Fixed once deployed** — changing it replaces the ECR repo, so `deploy.sh` refuses; to rename, tear down and deploy fresh |
 | `GATEWAY_HOSTNAME` | The full DNS name developers connect to |
 | `HOSTED_ZONE_ID` | Route53 zone ID where the DNS record is created (optional if managing DNS externally) |
 | `HOSTED_ZONE_NAME` | Route53 zone name (optional if managing DNS externally) |
@@ -244,11 +245,11 @@ All values come from `.env`. The CDK code reads them at deploy time.
 | `OIDC_CLIENT_SECRET` | OAuth client secret from your IdP app registration; `deploy.sh` seeds it into Secrets Manager (never baked into the image) and refuses to deploy while it's still the placeholder |
 | `ALLOWED_EMAIL_DOMAINS` | Only users with these email domains can sign in |
 | `BEDROCK_REGION` | Region whose Bedrock endpoint the gateway calls (the upstream `region:` + the inference-profile IAM ARN). Any region works — the gateway uses global inference profiles. See [Regions & data residency](#regions--data-residency) |
-| `DEPLOY_REGION` | Optional. Region the **stack** deploys into (VPC/ALB/RDS/ECR/ECS/CodeBuild). Defaults to `BEDROCK_REGION`; `deploy.sh` exports it as `AWS_REGION`/`AWS_DEFAULT_REGION` so every `aws` call and CDK agree. See [Regions](#regions) |
+| `DEPLOY_REGION` | Optional. Region the **stack** deploys into (VPC/ALB/RDS/ECR/ECS/CodeBuild). Defaults to `BEDROCK_REGION`; `deploy.sh` exports it as `AWS_REGION`/`AWS_DEFAULT_REGION` so every `aws` call and CDK agree. `deploy.sh` targets **one active region per account** (see the scope note at its Step 3). See [Regions](#regions) |
 | `CERT_ARN` | Imported ACM cert ARN for `GATEWAY_HOSTNAME` (required; `deploy.sh` maps it to the `certArn` context) |
 | `INGRESS_CIDR` | VPN/corp **client** CIDR developers connect from — **not** the VPC CIDR (required; maps to `ingressCidr`) |
 | `VPC_ID` | Optional. Reuse an existing VPC (e.g. to keep a Client VPN association intact) instead of creating one; maps to `vpcId` |
-| `CREATE_VPC_ENDPOINTS` | Optional. Set `false` with `VPC_ID` when the reused VPC already has the interface endpoints; maps to `createVpcEndpoints` |
+| `CREATE_VPC_ENDPOINTS` | Optional. Set `false` with `VPC_ID` when the reused VPC already has the interface endpoints; maps to `createVpcEndpoints`. You must then authorize 443 from the task SG on those endpoints yourself — see [Reusing an existing VPC](../docs/deployment.md#reusing-an-existing-vpc) |
 
 ### CDK context variables
 
@@ -269,7 +270,7 @@ pass 2 (default) deploys the full stack.
 | `zoneId` | 2 | no | Hosted-zone id (looked up from `zoneName` if omitted) |
 | `ingressCidr` | 2 | **yes** | VPN/corp **client** CIDR developers connect from — **not** the VPC CIDR |
 | `vpcId` | 2 | no | Import an existing VPC instead of creating one |
-| `createVpcEndpoints` | 2 | no | Default `true`. Set `false` **only** when reusing a `vpcId` that already has the Bedrock/Secrets Manager/ECR/CloudWatch/S3 endpoints — AWS allows one private-DNS endpoint per service per VPC, so recreating them fails the deploy |
+| `createVpcEndpoints` | 2 | no | Default `true`. Set `false` **only** when reusing a `vpcId` that already has the Bedrock/Secrets Manager/ECR/CloudWatch interface endpoints (+ the S3 gateway endpoint) — AWS allows one private-DNS endpoint per service per VPC, so recreating them fails the deploy. Then authorize 443 yourself: [Reusing an existing VPC](../docs/deployment.md#reusing-an-existing-vpc) |
 
 ### Regions & data residency
 

--- a/claude-apps-gateway/cdk/scripts/deploy.sh
+++ b/claude-apps-gateway/cdk/scripts/deploy.sh
@@ -95,9 +95,59 @@ fi
 # The ECS service can't start until its image exists, so the stack splits the
 # deploy in two: pass 1 creates just the ECR repo; we build+push; pass 2 (below)
 # brings up the full stack. See cdk/README.md "CDK context variables".
-echo "Step 1/5: Pass 1 — creating the ECR repository (CDK)..."
-npx cdk deploy --require-approval never -c imageReady=false "${CDK_CTX[@]}"
-echo "✅ ECR repository created"
+#
+# Pass 1 is FIRST-DEPLOY ONLY. Its template holds exactly one resource (the ECR
+# repo), so deploying it over a stack that already reached pass 2 makes
+# CloudFormation delete the ~50 resources absent from it: the RDS instance
+# (deletionProtection false + RemovalPolicy.DESTROY + 1-day backups, so the
+# gateway's store is gone), the ALB, the ECS service, the secrets, the log group,
+# the VPC. Re-running deploy.sh must therefore go straight to build + pass 2,
+# which is also what preserves TaskSg and any 443 rules you authorized on reused
+# interface endpoints (see NO_ROLLBACK below).
+#
+# The status query itself is a safety control, so it must not fail open: a
+# throttle, expired credential, or network blip would yield an empty status, look
+# like "no stack yet", and run the destructive pass against a live one. Treat ONLY
+# an explicit not-found as absent, and abort on anything else.
+set +e
+STACK_QUERY=$(aws cloudformation describe-stacks --stack-name ClaudeGatewayStack \
+  --query 'Stacks[0].StackStatus' --output text 2>&1)
+STACK_RC=$?
+set -e
+if [ "$STACK_RC" -eq 0 ]; then
+  STACK_STATUS="$STACK_QUERY"
+else
+  case "$STACK_QUERY" in
+    *ValidationError*"does not exist"*)
+      STACK_STATUS=""   # genuinely absent → first deploy
+      ;;
+    *)
+      echo "❌ Could not determine the ClaudeGatewayStack status, so deploy.sh cannot"
+      echo "   tell a first deploy from an existing one — refusing to continue, because"
+      echo "   guessing wrong runs a repo-only deploy that would delete the RDS instance"
+      echo "   and the rest of the running stack. Fix the AWS call and re-run:"
+      echo "   $STACK_QUERY"
+      exit 1
+      ;;
+  esac
+fi
+# Running pass 1 is the destructive branch, so IT gets the narrow allowlist: only a
+# stack that is absent or provably holds nothing. Every other status skips to pass 2,
+# which is always the safe default — if the stack is mid-operation or wedged, `cdk
+# deploy` says so itself instead of us enumerating CloudFormation's status list.
+case "$STACK_STATUS" in
+  # No stack, or one holding no resources. ROLLBACK_COMPLETE is a failed FIRST create
+  # (nothing provisioned); CDK deletes and recreates it. REVIEW_IN_PROGRESS is a
+  # change-set-only stack.
+  ""|ROLLBACK_COMPLETE|REVIEW_IN_PROGRESS|DELETE_COMPLETE)
+    echo "Step 1/5: Pass 1 — creating the ECR repository (CDK)..."
+    npx cdk deploy --require-approval never -c imageReady=false "${CDK_CTX[@]}"
+    echo "✅ ECR repository created"
+    ;;
+  *)
+    echo "Step 1/5: stack exists ($STACK_STATUS) — skipping pass 1 (a repo-only deploy would delete the ALB/RDS/service)."
+    ;;
+esac
 echo ""
 
 # --- Step 2: Get outputs ---
@@ -109,35 +159,72 @@ ECR_URI=$(aws cloudformation describe-stacks --stack-name ClaudeGatewayStack \
 # alone, so a name mismatch with the stack can't break the push).
 REPO_NAME="${ECR_URI##*/}"
 echo "   ECR: $ECR_URI (repo: $REPO_NAME)"
+
+# Renaming a deployed gateway in place isn't supported: pass 2 would replace the ECR
+# repo, leaving the service pulling from an empty one. Fail here rather than at a
+# confusing ECS pull error. See cdk/README.md (GATEWAY_NAME).
+if [ "$REPO_NAME" != "$GATEWAY_NAME" ]; then
+  echo "❌ GATEWAY_NAME is '$GATEWAY_NAME' but this stack's repo is '$REPO_NAME'. Set it"
+  echo "   back, or tear down (docs/teardown.md) and deploy fresh under the new name."
+  exit 1
+fi
 echo ""
 
 # --- Step 3: Build and push image ---
 echo "Step 3/5: Building and pushing gateway image..."
 
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
-BUCKET="claude-gateway-build-${ACCOUNT_ID}"
+# Region-suffixed: CodeBuild requires its S3 source bucket in the PROJECT's region,
+# so the bucket name must vary by region (an account-global name would leave the
+# bucket in the first region and fail a build in any other). See the single-region
+# scope note below.
+BUCKET="claude-gateway-build-${ACCOUNT_ID}-${DEPLOY_REGION}"
 # Create the S3 build bucket BEFORE the CodeBuild project, which references it as
 # its source location — create-project fails with "Bucket ... does not exist"
 # otherwise (only bites a first-ever run, where the project doesn't yet exist).
-aws s3 mb "s3://$BUCKET" 2>/dev/null || true
+aws s3 mb "s3://$BUCKET" --region "$DEPLOY_REGION" 2>/dev/null || true
 
-# Check if CodeBuild project exists, create if not
+# CodeBuild role + policy. The project has a FIXED name (CodeBuild projects are
+# region-scoped, so the same name in another region is a separate project); the
+# role has a FIXED name and IAM is global. The inline policy is scoped to THIS
+# deploy's ECR repo + region, so re-assert it on EVERY run (idempotent overwrite)
+# instead of only at first project creation — otherwise redeploying with a
+# different gatewayName leaves the role authorized for the previous repo and the
+# build fails with an opaque ECR AccessDenied.
+#
+# SCOPE: deploy.sh targets ONE active region per account. The shared global role
+# means concurrent deployments in multiple regions (or under different gateway
+# names) overwrite each other's policy — give the role + project per-region/-name
+# suffixes if you truly need them side by side. See cdk/README.md (DEPLOY_REGION).
+aws iam create-role --role-name claude-gateway-codebuild \
+  --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"codebuild.amazonaws.com"},"Action":"sts:AssumeRole"}]}' 2>/dev/null || true
+
+aws iam put-role-policy --role-name claude-gateway-codebuild --policy-name build-perms \
+  --policy-document "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"s3:GetObject\",\"s3:ListBucket\"],\"Resource\":[\"arn:aws:s3:::${BUCKET}\",\"arn:aws:s3:::${BUCKET}/*\"]},{\"Effect\":\"Allow\",\"Action\":[\"ecr:GetAuthorizationToken\"],\"Resource\":\"*\"},{\"Effect\":\"Allow\",\"Action\":[\"ecr:BatchCheckLayerAvailability\",\"ecr:GetDownloadUrlForLayer\",\"ecr:BatchGetImage\",\"ecr:PutImage\",\"ecr:InitiateLayerUpload\",\"ecr:UploadLayerPart\",\"ecr:CompleteLayerUpload\"],\"Resource\":\"arn:aws:ecr:${DEPLOY_REGION}:${ACCOUNT_ID}:repository/${REPO_NAME}\"},{ \"Effect\":\"Allow\",\"Action\":[\"logs:CreateLogGroup\",\"logs:CreateLogStream\",\"logs:PutLogEvents\"],\"Resource\":\"*\"}]}" 2>/dev/null
+
+# IAM is eventually consistent, so wait AFTER (re)asserting the policy — every run,
+# not only at project creation. A prior fix ran this sleep only when the project
+# was first created, so a policy change on an existing project (new repo/region)
+# could hit the build before it propagated → intermittent ECR AccessDenied.
+sleep 10  # IAM propagation for the (re)asserted role policy
+
+# The project's S3 source must track $BUCKET, so assert it on EVERY run — create it
+# on a first deploy, else UPDATE an existing project's source. A project created by
+# an earlier version of this script points at the old unsuffixed
+# claude-gateway-build-${ACCOUNT_ID} bucket; since we now upload to the
+# region-suffixed bucket and the role policy above grants only that one, leaving the
+# stale source in place makes start-build fail while downloading its source.
+CB_SOURCE="{\"type\":\"S3\",\"location\":\"${BUCKET}/\",\"buildspec\":\"buildspec.yml\"}"
 if ! aws codebuild batch-get-projects --names claude-gateway-build --query "projects[0].name" --output text 2>/dev/null | grep -q claude-gateway-build; then
   echo "   Creating CodeBuild project..."
-
-  # Create IAM role for CodeBuild
-  aws iam create-role --role-name claude-gateway-codebuild \
-    --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"codebuild.amazonaws.com"},"Action":"sts:AssumeRole"}]}' 2>/dev/null || true
-
-  aws iam put-role-policy --role-name claude-gateway-codebuild --policy-name build-perms \
-    --policy-document "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"s3:GetObject\",\"s3:ListBucket\"],\"Resource\":[\"arn:aws:s3:::claude-gateway-build-${ACCOUNT_ID}\",\"arn:aws:s3:::claude-gateway-build-${ACCOUNT_ID}/*\"]},{\"Effect\":\"Allow\",\"Action\":[\"ecr:GetAuthorizationToken\"],\"Resource\":\"*\"},{\"Effect\":\"Allow\",\"Action\":[\"ecr:BatchCheckLayerAvailability\",\"ecr:GetDownloadUrlForLayer\",\"ecr:BatchGetImage\",\"ecr:PutImage\",\"ecr:InitiateLayerUpload\",\"ecr:UploadLayerPart\",\"ecr:CompleteLayerUpload\"],\"Resource\":\"arn:aws:ecr:${DEPLOY_REGION}:${ACCOUNT_ID}:repository/${REPO_NAME}\"},{ \"Effect\":\"Allow\",\"Action\":[\"logs:CreateLogGroup\",\"logs:CreateLogStream\",\"logs:PutLogEvents\"],\"Resource\":\"*\"}]}" 2>/dev/null
-
-  sleep 10  # Wait for IAM propagation
-
   aws codebuild create-project --name claude-gateway-build \
-    --source "{\"type\":\"S3\",\"location\":\"${BUCKET}/\",\"buildspec\":\"buildspec.yml\"}" \
+    --source "$CB_SOURCE" \
     --artifacts '{"type":"NO_ARTIFACTS"}' \
     --environment '{"type":"LINUX_CONTAINER","image":"aws/codebuild/standard:7.0","computeType":"BUILD_GENERAL1_SMALL","privilegedMode":true}' \
+    --service-role "arn:aws:iam::${ACCOUNT_ID}:role/claude-gateway-codebuild" >/dev/null
+else
+  aws codebuild update-project --name claude-gateway-build \
+    --source "$CB_SOURCE" \
     --service-role "arn:aws:iam::${ACCOUNT_ID}:role/claude-gateway-codebuild" >/dev/null
 fi
 
@@ -226,8 +313,19 @@ echo ""
 # The image now exists in ECR, so pass 2 brings up the service (desiredCount 2)
 # behind the internal ALB. cdk deploy blocks until the service is stable, so no
 # manual `update-service` scale-up is needed.
+#
+# NO_ROLLBACK=1 adds --no-rollback (CloudFormation DisableRollback). Needed when
+# reusing a VPC whose interface endpoints don't yet allow 443 from the task SG: the
+# service can't stabilize, and the default rollback deletes the just-created TaskSg
+# — the very SG you have to authorize on those endpoints. Retaining it makes the
+# documented deploy → authorize → redeploy sequence possible. Off by default: the
+# failure leaves the stack in UPDATE_FAILED, which you then have to either retry or
+# abandon by hand (`npx cdk rollback` / `aws cloudformation rollback-stack` —
+# continue-update-rollback does NOT apply, it only takes UPDATE_ROLLBACK_FAILED).
+CDK_DEPLOY_FLAGS=(--require-approval never)
+[ "${NO_ROLLBACK:-0}" = "1" ] && CDK_DEPLOY_FLAGS+=(--no-rollback)
 echo "Step 4/5: Pass 2 — deploying the full stack (CDK)..."
-npx cdk deploy --require-approval never -c imageReady=true "${CDK_CTX[@]}"
+npx cdk deploy "${CDK_DEPLOY_FLAGS[@]}" -c imageReady=true "${CDK_CTX[@]}"
 echo "✅ Full stack deployed"
 echo ""
 

--- a/claude-apps-gateway/cdk/scripts/deploy.sh
+++ b/claude-apps-gateway/cdk/scripts/deploy.sh
@@ -18,6 +18,61 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 cd "$PROJECT_DIR"
 
+# ──────────────────────────────────────────────────────────────────────────────
+# Helpers for the pass-1 safety gate (Step 1). Defined up here, before any config
+# or AWS call, so tests can source them in isolation — see the DEPLOY_SH_LIB_ONLY
+# gate below and test/deploy-helpers.test.sh. The gate decides whether to run a
+# deploy that DELETES a live data plane, so its string→branch logic is tested
+# rather than reasoned about.
+# ──────────────────────────────────────────────────────────────────────────────
+
+# classify_stack_query — turn a `describe-stacks` result into a stack status.
+# Prints the status on success, prints NOTHING when the stack is genuinely absent,
+# and returns non-zero when the query failed for any OTHER reason — callers must
+# abort on that. This query is itself a safety control, so it must not fail open: a
+# throttle, an expired credential, or a network blip would otherwise look like "no
+# stack yet" and run the destructive pass against a live stack.
+#
+# stdout and stderr are passed in SEPARATELY on purpose. The CLI can print a
+# warning to stderr while still succeeding (urllib3's NotOpenSSLWarning on some
+# macOS Pythons); folding stderr into stdout would prepend that text to the status,
+# and a recoverable ROLLBACK_COMPLETE stack would then read as an unknown status and
+# skip the pass 1 it needs.
+classify_stack_query() {
+  local rc="$1" out="$2" err="$3"
+  if [ "$rc" -eq 0 ]; then
+    printf '%s' "$out"
+    return 0
+  fi
+  case "$err" in
+    *ValidationError*"does not exist"*) return 0 ;;  # genuinely absent → first deploy
+    *) return 1 ;;
+  esac
+}
+
+# needs_pass_one — should the ECR-repo-only pass 1 run for this stack status?
+# Running pass 1 is the DESTRUCTIVE branch, so it gets the narrow allowlist: only a
+# stack that is absent or provably holds nothing. Every other status — including one
+# neither this script nor today's CloudFormation knows about — skips to pass 2,
+# which is always the safe default.
+needs_pass_one() {
+  case "$1" in
+    # "" is no stack at all. ROLLBACK_COMPLETE is a failed FIRST create (nothing
+    # provisioned); CDK deletes and recreates it. REVIEW_IN_PROGRESS is a
+    # change-set-only stack. DELETE_COMPLETE is listed because it belongs in the
+    # "holds nothing" set, but nothing relies on it: describe-stacks by NAME never
+    # returns a deleted stack (that needs the stack ID), so the arm is unreachable
+    # from the call site below.
+    ""|ROLLBACK_COMPLETE|REVIEW_IN_PROGRESS|DELETE_COMPLETE) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Test hook: `DEPLOY_SH_LIB_ONLY=1 source deploy.sh` loads only the helpers above
+# (see test/deploy-helpers.test.sh) — no .env, no required env, no AWS calls.
+# shellcheck disable=SC2317  # the exit is the executed-not-sourced fallback
+if [ "${DEPLOY_SH_LIB_ONLY:-}" = "1" ]; then return 0 2>/dev/null || exit 0; fi
+
 # Load .env
 if [ ! -f .env ]; then
   echo "❌ .env file not found. Run: cp .env.example .env and fill in your values."
@@ -105,55 +160,69 @@ fi
 # which is also what preserves TaskSg and any 443 rules you authorized on reused
 # interface endpoints (see NO_ROLLBACK below).
 #
-# The status query itself is a safety control, so it must not fail open: a
-# throttle, expired credential, or network blip would yield an empty status, look
-# like "no stack yet", and run the destructive pass against a live one. Treat ONLY
-# an explicit not-found as absent, and abort on anything else.
+# Read the current status, keeping stderr out of the value (see classify_stack_query).
+STACK_ERR_FILE="$(mktemp)"
 set +e
-STACK_QUERY=$(aws cloudformation describe-stacks --stack-name ClaudeGatewayStack \
-  --query 'Stacks[0].StackStatus' --output text 2>&1)
+STACK_OUT="$(aws cloudformation describe-stacks --stack-name ClaudeGatewayStack \
+  --query 'Stacks[0].StackStatus' --output text 2>"$STACK_ERR_FILE")"
 STACK_RC=$?
 set -e
-if [ "$STACK_RC" -eq 0 ]; then
-  STACK_STATUS="$STACK_QUERY"
+STACK_ERR="$(cat "$STACK_ERR_FILE")"
+rm -f "$STACK_ERR_FILE"
+
+STACK_STATUS="$(classify_stack_query "$STACK_RC" "$STACK_OUT" "$STACK_ERR")" || {
+  echo "❌ Could not determine the ClaudeGatewayStack status, so deploy.sh cannot"
+  echo "   tell a first deploy from an existing one — refusing to continue, because"
+  echo "   guessing wrong runs a repo-only deploy that would delete the RDS instance"
+  echo "   and the rest of the running stack. Fix the AWS call and re-run:"
+  echo "   $STACK_ERR"
+  exit 1
+}
+
+# Only the pass-1 decision is made here. Every other status is CDK's to report — this
+# script does not re-implement CloudFormation's status list. What that means in
+# practice, read off the pinned CDK (2.1129) rather than assumed:
+#   * *_IN_PROGRESS — cdk WAITS for the operation to settle, then deploys. Bailing
+#     here would turn a case that heals itself into a hard failure.
+#   * ROLLBACK_COMPLETE / ROLLBACK_FAILED — a failed FIRST create, so cdk deletes the
+#     stack and recreates it (StackStatus.isCreationFailure). ROLLBACK_COMPLETE is in
+#     the pass-1 allowlist above; ROLLBACK_FAILED is not, deliberately — its rollback
+#     failed, so resources may be orphaned, and it is rare enough not to justify
+#     widening the destructive branch. It stops with a clear message at the
+#     EcrRepositoryUri check in Step 2 instead.
+#   * CREATE_FAILED / UPDATE_FAILED / UPDATE_ROLLBACK_FAILED — cdk calls these
+#     "fail-paused" and ASKS to roll back before deploying. `--require-approval never`
+#     does NOT cover that prompt (it only waives security-group/IAM approval); only
+#     `--force` does. So an interactive run stops for a y/n and a non-TTY run fails
+#     with TtyNotAttached — in both cases AFTER the ~10-minute image build. Roll back
+#     first (`npx cdk rollback`) if you land there. NO_ROLLBACK=1 side-steps it for
+#     UPDATE_FAILED, which is the state that flag's retry path exists for.
+if needs_pass_one "$STACK_STATUS"; then
+  echo "Step 1/5: Pass 1 — creating the ECR repository (CDK)..."
+  npx cdk deploy --require-approval never -c imageReady=false "${CDK_CTX[@]}"
+  echo "✅ ECR repository created"
 else
-  case "$STACK_QUERY" in
-    *ValidationError*"does not exist"*)
-      STACK_STATUS=""   # genuinely absent → first deploy
-      ;;
-    *)
-      echo "❌ Could not determine the ClaudeGatewayStack status, so deploy.sh cannot"
-      echo "   tell a first deploy from an existing one — refusing to continue, because"
-      echo "   guessing wrong runs a repo-only deploy that would delete the RDS instance"
-      echo "   and the rest of the running stack. Fix the AWS call and re-run:"
-      echo "   $STACK_QUERY"
-      exit 1
-      ;;
-  esac
+  echo "Step 1/5: stack exists ($STACK_STATUS) — skipping pass 1 (a repo-only deploy would delete the ALB/RDS/service)."
 fi
-# Running pass 1 is the destructive branch, so IT gets the narrow allowlist: only a
-# stack that is absent or provably holds nothing. Every other status skips to pass 2,
-# which is always the safe default — if the stack is mid-operation or wedged, `cdk
-# deploy` says so itself instead of us enumerating CloudFormation's status list.
-case "$STACK_STATUS" in
-  # No stack, or one holding no resources. ROLLBACK_COMPLETE is a failed FIRST create
-  # (nothing provisioned); CDK deletes and recreates it. REVIEW_IN_PROGRESS is a
-  # change-set-only stack.
-  ""|ROLLBACK_COMPLETE|REVIEW_IN_PROGRESS|DELETE_COMPLETE)
-    echo "Step 1/5: Pass 1 — creating the ECR repository (CDK)..."
-    npx cdk deploy --require-approval never -c imageReady=false "${CDK_CTX[@]}"
-    echo "✅ ECR repository created"
-    ;;
-  *)
-    echo "Step 1/5: stack exists ($STACK_STATUS) — skipping pass 1 (a repo-only deploy would delete the ALB/RDS/service)."
-    ;;
-esac
 echo ""
 
 # --- Step 2: Get outputs ---
 echo "Step 2/5: Reading stack outputs..."
 ECR_URI=$(aws cloudformation describe-stacks --stack-name ClaudeGatewayStack \
   --query "Stacks[0].Outputs[?OutputKey=='EcrRepositoryUri'].OutputValue" --output text)
+# Now that pass 1 can be skipped, this can run against a stack that has no
+# EcrRepositoryUri output at all — and `--output text` prints the literal string
+# "None" for a query that matched nothing. Catch that here: left alone it flows into
+# REPO_NAME and the rename guard below blames a GATEWAY_NAME change that never
+# happened.
+if [ -z "$ECR_URI" ] || [ "$ECR_URI" = "None" ]; then
+  echo "❌ ClaudeGatewayStack has no EcrRepositoryUri output, so there is nowhere to"
+  echo "   push the image. This is NOT a GATEWAY_NAME problem: either the stack predates"
+  echo "   that output, or its pass 1 never completed. (Status before this run:"
+  echo "   ${STACK_STATUS:-absent}.) Deploy pass 2 by hand (docs/deployment.md, Track B)"
+  echo "   or tear down and deploy fresh (docs/teardown.md)."
+  exit 1
+fi
 # The repo name the stack actually created, taken from the URI — this is what the
 # CodeBuild IAM policy and docker tags must reference (never assume GATEWAY_NAME
 # alone, so a name mismatch with the stack can't break the push).
@@ -196,16 +265,34 @@ aws s3 mb "s3://$BUCKET" --region "$DEPLOY_REGION" 2>/dev/null || true
 # means concurrent deployments in multiple regions (or under different gateway
 # names) overwrite each other's policy — give the role + project per-region/-name
 # suffixes if you truly need them side by side. See cdk/README.md (DEPLOY_REGION).
+# A bare `|| true` here would also swallow "you may not create roles", which then
+# resurfaces as a baffling put-role-policy failure below. Tolerate ONLY "the role is
+# already there"; anything else aborts with the API's own message.
+ROLE_ERR_FILE="$(mktemp)"
+set +e
 aws iam create-role --role-name claude-gateway-codebuild \
-  --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"codebuild.amazonaws.com"},"Action":"sts:AssumeRole"}]}' 2>/dev/null || true
+  --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"codebuild.amazonaws.com"},"Action":"sts:AssumeRole"}]}' \
+  >/dev/null 2>"$ROLE_ERR_FILE"
+ROLE_RC=$?
+set -e
+if [ "$ROLE_RC" -ne 0 ] && ! grep -q 'EntityAlreadyExists' "$ROLE_ERR_FILE"; then
+  echo "❌ Could not create the CodeBuild role claude-gateway-codebuild:"
+  sed 's/^/   /' "$ROLE_ERR_FILE"
+  rm -f "$ROLE_ERR_FILE"
+  exit 1
+fi
+rm -f "$ROLE_ERR_FILE"
 
+# No 2>/dev/null: put-role-policy is quiet on success, and this now runs on EVERY
+# deploy — silencing it would turn a real IAM failure into the script dying right
+# after "Step 3/5" with nothing printed (set -e, no `|| true`).
 aws iam put-role-policy --role-name claude-gateway-codebuild --policy-name build-perms \
-  --policy-document "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"s3:GetObject\",\"s3:ListBucket\"],\"Resource\":[\"arn:aws:s3:::${BUCKET}\",\"arn:aws:s3:::${BUCKET}/*\"]},{\"Effect\":\"Allow\",\"Action\":[\"ecr:GetAuthorizationToken\"],\"Resource\":\"*\"},{\"Effect\":\"Allow\",\"Action\":[\"ecr:BatchCheckLayerAvailability\",\"ecr:GetDownloadUrlForLayer\",\"ecr:BatchGetImage\",\"ecr:PutImage\",\"ecr:InitiateLayerUpload\",\"ecr:UploadLayerPart\",\"ecr:CompleteLayerUpload\"],\"Resource\":\"arn:aws:ecr:${DEPLOY_REGION}:${ACCOUNT_ID}:repository/${REPO_NAME}\"},{ \"Effect\":\"Allow\",\"Action\":[\"logs:CreateLogGroup\",\"logs:CreateLogStream\",\"logs:PutLogEvents\"],\"Resource\":\"*\"}]}" 2>/dev/null
+  --policy-document "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"s3:GetObject\",\"s3:ListBucket\"],\"Resource\":[\"arn:aws:s3:::${BUCKET}\",\"arn:aws:s3:::${BUCKET}/*\"]},{\"Effect\":\"Allow\",\"Action\":[\"ecr:GetAuthorizationToken\"],\"Resource\":\"*\"},{\"Effect\":\"Allow\",\"Action\":[\"ecr:BatchCheckLayerAvailability\",\"ecr:GetDownloadUrlForLayer\",\"ecr:BatchGetImage\",\"ecr:PutImage\",\"ecr:InitiateLayerUpload\",\"ecr:UploadLayerPart\",\"ecr:CompleteLayerUpload\"],\"Resource\":\"arn:aws:ecr:${DEPLOY_REGION}:${ACCOUNT_ID}:repository/${REPO_NAME}\"},{ \"Effect\":\"Allow\",\"Action\":[\"logs:CreateLogGroup\",\"logs:CreateLogStream\",\"logs:PutLogEvents\"],\"Resource\":\"*\"}]}"
 
-# IAM is eventually consistent, so wait AFTER (re)asserting the policy — every run,
-# not only at project creation. A prior fix ran this sleep only when the project
-# was first created, so a policy change on an existing project (new repo/region)
-# could hit the build before it propagated → intermittent ECR AccessDenied.
+# IAM is eventually consistent, and the policy above is scoped to THIS deploy's ECR
+# repo and region — so any repo/region change rewrites it, on a run where the project
+# already exists. Wait after every (re)assertion, not only at project creation, or a
+# build can start against a policy that hasn't propagated → ECR AccessDenied.
 sleep 10  # IAM propagation for the (re)asserted role policy
 
 # The project's S3 source must track $BUCKET, so assert it on EVERY run — create it
@@ -322,6 +409,11 @@ echo ""
 # failure leaves the stack in UPDATE_FAILED, which you then have to either retry or
 # abandon by hand (`npx cdk rollback` / `aws cloudformation rollback-stack` —
 # continue-update-rollback does NOT apply, it only takes UPDATE_ROLLBACK_FAILED).
+#
+# Set it per-run (`NO_ROLLBACK=1 ./scripts/deploy.sh`), not exported in your shell or
+# .env: CloudFormation REFUSES an update that requires replacing a resource while
+# rollback is disabled, so a leftover NO_ROLLBACK=1 makes an unrelated later change
+# fail for a reason that has nothing to do with the change.
 CDK_DEPLOY_FLAGS=(--require-approval never)
 [ "${NO_ROLLBACK:-0}" = "1" ] && CDK_DEPLOY_FLAGS+=(--no-rollback)
 echo "Step 4/5: Pass 2 — deploying the full stack (CDK)..."

--- a/claude-apps-gateway/cdk/scripts/setup.sh
+++ b/claude-apps-gateway/cdk/scripts/setup.sh
@@ -440,6 +440,7 @@ ensure_interface_endpoint() {
   aws ec2 create-vpc-endpoint --vpc-id "${VPC_ID}" --vpc-endpoint-type Interface \
     --service-name "${sname}" --subnet-ids ${PRIVATE_SUBNETS} \
     --security-group-ids "${VPCE_SG}" --private-dns-enabled \
+    --tag-specifications "ResourceType=vpc-endpoint,Tags=[{Key=Project,Value=${PROJECT}}]" \
     --region "${AWS_REGION}" >/dev/null
   info "created vpc endpoint ${svc}"
 }
@@ -454,6 +455,7 @@ if [[ "$(aws_q ec2 describe-vpc-endpoints \
 else
   aws ec2 create-vpc-endpoint --vpc-id "${VPC_ID}" --vpc-endpoint-type Gateway \
     --service-name "com.amazonaws.${AWS_REGION}.s3" --route-table-ids "${PRI_RT}" \
+    --tag-specifications "ResourceType=vpc-endpoint,Tags=[{Key=Project,Value=${PROJECT}}]" \
     --region "${AWS_REGION}" >/dev/null
   info "created vpc endpoint s3 (gateway)"
 fi

--- a/claude-apps-gateway/cdk/scripts/setup.sh
+++ b/claude-apps-gateway/cdk/scripts/setup.sh
@@ -481,6 +481,7 @@ ensure_interface_endpoint() {
   aws ec2 create-vpc-endpoint --vpc-id "${VPC_ID}" --vpc-endpoint-type Interface \
     --service-name "${sname}" --subnet-ids ${PRIVATE_SUBNETS} \
     --security-group-ids "${VPCE_SG}" --private-dns-enabled \
+    --tag-specifications "ResourceType=vpc-endpoint,Tags=[{Key=Project,Value=${PROJECT}}]" \
     --region "${AWS_REGION}" >/dev/null
   info "created vpc endpoint ${svc}"
 }
@@ -495,6 +496,7 @@ if [[ "$(aws_q ec2 describe-vpc-endpoints \
 else
   aws ec2 create-vpc-endpoint --vpc-id "${VPC_ID}" --vpc-endpoint-type Gateway \
     --service-name "com.amazonaws.${AWS_REGION}.s3" --route-table-ids "${PRI_RT}" \
+    --tag-specifications "ResourceType=vpc-endpoint,Tags=[{Key=Project,Value=${PROJECT}}]" \
     --region "${AWS_REGION}" >/dev/null
   info "created vpc endpoint s3 (gateway)"
 fi

--- a/claude-apps-gateway/docs/deployment.md
+++ b/claude-apps-gateway/docs/deployment.md
@@ -123,13 +123,17 @@ the cert SHA-256 fingerprint to publish to developers.
 Optional flags: `VPC_ID=vpc-...` (reuse an existing VPC). The full list with
 defaults is at the top of [`setup.sh`](../cdk/scripts/setup.sh).
 
+> Reusing a VPC with `VPC_ID` has constraints — fixed subnet CIDRs, and endpoint
+> security groups you must authorize yourself. See
+> [Reusing an existing VPC](#reusing-an-existing-vpc).
+
 ## Track B — CDK (two-pass)
 
 The stack is parameterized by **CDK context** (`-c key=value`); the full table is in
 [`../cdk/README.md`](../cdk/README.md#cdk-context-variables). Two passes because the
 ECS service needs the image to exist first.
 
-**Pass 1 — create the ECR repo:**
+**Pass 1 — create the ECR repo** (first deploy only):
 
 ```bash
 cd cdk
@@ -137,6 +141,13 @@ npm install
 npx cdk bootstrap -c imageReady=false    # first time in the account/region only
 npx cdk deploy -c imageReady=false
 ```
+
+> [!CAUTION]
+> Run pass 1 **only on a first deploy**. Its template holds one resource, so
+> deploying it over a stack that already reached pass 2 tells CloudFormation to
+> delete everything else — the RDS instance and its data included. To update an
+> existing deployment, build the image and run **pass 2 only**. (`deploy.sh` skips
+> pass 1 automatically when the stack exists.)
 
 **Between passes — build and push the image** to the ECR URI from the pass-1
 output. The stamped config and verified binary must sit next to the `Dockerfile` in
@@ -175,8 +186,10 @@ npx cdk deploy \
   -c ingressCidr=10.100.0.0/16
 ```
 
-> Reusing a VPC: `-c vpcId=vpc-...` and, if it already has the
-> service endpoints, `-c createVpcEndpoints=false`.
+> Reusing a VPC: `-c vpcId=vpc-...` and, if it already has the service endpoints,
+> `-c createVpcEndpoints=false`. Read
+> [Reusing an existing VPC](#reusing-an-existing-vpc) first — the endpoint SGs need
+> authorizing by hand, and the ordering is fiddly.
 
 The stack creates `claude-gateway-oidc-client-secret` with a CDK-**generated**
 placeholder (a real secret can't ride in CDK context — it would land in
@@ -200,6 +213,49 @@ To roll a new image later: push a new tag, then re-run pass 2 with
 > hardened build path above (distroless image, SHA-verified binary, placeholder
 > guard) and does not pass CDK context, so this guide — not that script — is the
 > supported route.
+
+## Reusing an existing VPC
+
+Both tracks can deploy into a VPC you already have — `VPC_ID=vpc-...` for `setup.sh`,
+`-c vpcId=vpc-...` for CDK — typically to keep an existing Client VPN association
+intact. Three things to know.
+
+**CIDR.** `setup.sh` creates subnets at fixed CIDRs (`10.20.0.0/24`, `10.20.1.0/24`,
+`10.20.10.0/24`, `10.20.11.0/24`), so the VPC must be `10.20.0.0/16` or a superset
+with those four ranges free; anything else fails at `create-subnet`. The CDK track
+imports the VPC's existing subnets instead, so any CIDR works.
+
+**Endpoint security groups.** If the VPC already has the Bedrock / Secrets Manager /
+ECR / CloudWatch **interface** endpoints, set `CREATE_VPC_ENDPOINTS=false` (or
+`-c createVpcEndpoints=false`) — AWS allows one private-DNS endpoint per service per
+VPC. Neither track then touches those endpoints' security groups, so **you** must
+allow 443 from the gateway task SG on each, or tasks time out fetching secrets,
+images, and logs. S3 is a *gateway* endpoint: no SG, no 443 — it just needs an
+association with the tasks' private route table.
+
+**Ordering, which differs by track.** `setup.sh` creates its task SG (`$P-task-sg`)
+before tasks start: authorize it, then re-run. CDK's `TaskSg` exists only in pass 2,
+so it can't be preauthorized — and a pass 2 that can't stabilize normally rolls back
+and *deletes* the SG you were about to authorize. Deploy that pass with rollback
+disabled so it survives:
+
+```bash
+npx cdk deploy --no-rollback ...   # by hand
+NO_ROLLBACK=1 ./scripts/deploy.sh  # or via deploy.sh
+```
+
+Then authorize 443 from `TaskSg` on the interface endpoints' SGs and deploy **pass 2
+only** — never re-run pass 1 (see the caution under [Track B](#track-b--cdk-two-pass));
+`deploy.sh` skips it for you.
+
+A `--no-rollback` failure leaves the stack in `UPDATE_FAILED`. From there, either
+retry the update (that redeploy) or abandon it with `npx cdk rollback` /
+`aws cloudformation rollback-stack`. `continue-update-rollback` does **not** apply —
+it only accepts `UPDATE_ROLLBACK_FAILED`. Having to make that call by hand is why
+neither path disables rollback by default.
+
+Tearing down a reused VPC needs care too — see
+[Reused VPC](teardown.md#reused-vpc) in the teardown guide.
 
 ## Verify
 

--- a/claude-apps-gateway/docs/deployment.md
+++ b/claude-apps-gateway/docs/deployment.md
@@ -232,11 +232,15 @@ To roll a new image later: push a new tag, then re-run pass 2 with
 > ```
 
 > [!NOTE]
-> `cdk/scripts/deploy.sh` is a separate convenience script that builds the image
-> via CodeBuild using its own inline Dockerfile and config. It does **not** use the
-> hardened build path above (distroless image, SHA-verified binary, placeholder
-> guard) and does not pass CDK context, so this guide — not that script — is the
-> supported route.
+> `cdk/scripts/deploy.sh` is a separate convenience script that runs both passes
+> from `.env`: it maps your values onto the CDK context above and builds the image in
+> CodeBuild, so no local Docker is needed. It shares this track's tracked
+> `Dockerfile` and `stamp-config.sh` (distroless image, placeholder guard) and builds
+> the same `--platform=linux/amd64 --provenance=false` image. Two differences from the
+> walkthrough above: it uses whatever `claude` binary you have already staged rather
+> than downloading and SHA-verifying one itself, and it pushes `:latest` rather than a
+> config-hashed tag — so re-read the config-tag box above before treating `:latest` as
+> a record of what is deployed.
 
 ## Reusing an existing VPC
 
@@ -250,9 +254,11 @@ with those four ranges free; anything else fails at `create-subnet`. The CDK tra
 imports the VPC's existing subnets instead, so any CIDR works.
 
 **Endpoint security groups.** If the VPC already has the Bedrock / Secrets Manager /
-ECR / CloudWatch **interface** endpoints, set `CREATE_VPC_ENDPOINTS=false` (or
-`-c createVpcEndpoints=false`) — AWS allows one private-DNS endpoint per service per
-VPC. Neither track then touches those endpoints' security groups, so **you** must
+ECR / CloudWatch **interface** endpoints, tell the CDK track not to recreate them with
+`CREATE_VPC_ENDPOINTS=false` (`deploy.sh`) or `-c createVpcEndpoints=false` (by hand)
+— AWS allows one private-DNS endpoint per service per VPC. `setup.sh` has no such
+flag and needs none: it describes before creating, so it adopts endpoints already in
+the VPC. Neither track then touches those endpoints' security groups, so **you** must
 allow 443 from the gateway task SG on each, or tasks time out fetching secrets,
 images, and logs. S3 is a *gateway* endpoint: no SG, no 443 — it just needs an
 association with the tasks' private route table.
@@ -277,6 +283,11 @@ retry the update (that redeploy) or abandon it with `npx cdk rollback` /
 `aws cloudformation rollback-stack`. `continue-update-rollback` does **not** apply —
 it only accepts `UPDATE_ROLLBACK_FAILED`. Having to make that call by hand is why
 neither path disables rollback by default.
+
+Set `NO_ROLLBACK=1` **per run**, as above — don't export it or put it in `.env`.
+CloudFormation refuses an update that requires *replacing* a resource while rollback
+is disabled, so a leftover `NO_ROLLBACK=1` makes some unrelated later change fail for
+a reason that has nothing to do with the change.
 
 Tearing down a reused VPC needs care too — see
 [Reused VPC](teardown.md#reused-vpc) in the teardown guide.

--- a/claude-apps-gateway/docs/deployment.md
+++ b/claude-apps-gateway/docs/deployment.md
@@ -124,13 +124,17 @@ the cert SHA-256 fingerprint to publish to developers.
 Optional flags: `VPC_ID=vpc-...` (reuse an existing VPC). The full list with
 defaults is at the top of [`setup.sh`](../cdk/scripts/setup.sh).
 
+> Reusing a VPC with `VPC_ID` has constraints — fixed subnet CIDRs, and endpoint
+> security groups you must authorize yourself. See
+> [Reusing an existing VPC](#reusing-an-existing-vpc).
+
 ## Track B — CDK (two-pass)
 
 The stack is parameterized by **CDK context** (`-c key=value`); the full table is in
 [`../cdk/README.md`](../cdk/README.md#cdk-context-variables). Two passes because the
 ECS service needs the image to exist first.
 
-**Pass 1 — create the ECR repo:**
+**Pass 1 — create the ECR repo** (first deploy only):
 
 ```bash
 cd cdk
@@ -138,6 +142,13 @@ npm install
 npx cdk bootstrap -c imageReady=false    # first time in the account/region only
 npx cdk deploy -c imageReady=false
 ```
+
+> [!CAUTION]
+> Run pass 1 **only on a first deploy**. Its template holds one resource, so
+> deploying it over a stack that already reached pass 2 tells CloudFormation to
+> delete everything else — the RDS instance and its data included. To update an
+> existing deployment, build the image and run **pass 2 only**. (`deploy.sh` skips
+> pass 1 automatically when the stack exists.)
 
 **Between passes — build and push the image** to the ECR URI from the pass-1
 output. The stamped config and verified binary must sit next to the `Dockerfile` in
@@ -176,8 +187,10 @@ npx cdk deploy \
   -c ingressCidr=10.100.0.0/16
 ```
 
-> Reusing a VPC: `-c vpcId=vpc-...` and, if it already has the
-> service endpoints, `-c createVpcEndpoints=false`.
+> Reusing a VPC: `-c vpcId=vpc-...` and, if it already has the service endpoints,
+> `-c createVpcEndpoints=false`. Read
+> [Reusing an existing VPC](#reusing-an-existing-vpc) first — the endpoint SGs need
+> authorizing by hand, and the ordering is fiddly.
 
 The stack creates `claude-gateway-oidc-client-secret` with a CDK-**generated**
 placeholder (a real secret can't ride in CDK context — it would land in
@@ -224,6 +237,49 @@ To roll a new image later: push a new tag, then re-run pass 2 with
 > hardened build path above (distroless image, SHA-verified binary, placeholder
 > guard) and does not pass CDK context, so this guide — not that script — is the
 > supported route.
+
+## Reusing an existing VPC
+
+Both tracks can deploy into a VPC you already have — `VPC_ID=vpc-...` for `setup.sh`,
+`-c vpcId=vpc-...` for CDK — typically to keep an existing Client VPN association
+intact. Three things to know.
+
+**CIDR.** `setup.sh` creates subnets at fixed CIDRs (`10.20.0.0/24`, `10.20.1.0/24`,
+`10.20.10.0/24`, `10.20.11.0/24`), so the VPC must be `10.20.0.0/16` or a superset
+with those four ranges free; anything else fails at `create-subnet`. The CDK track
+imports the VPC's existing subnets instead, so any CIDR works.
+
+**Endpoint security groups.** If the VPC already has the Bedrock / Secrets Manager /
+ECR / CloudWatch **interface** endpoints, set `CREATE_VPC_ENDPOINTS=false` (or
+`-c createVpcEndpoints=false`) — AWS allows one private-DNS endpoint per service per
+VPC. Neither track then touches those endpoints' security groups, so **you** must
+allow 443 from the gateway task SG on each, or tasks time out fetching secrets,
+images, and logs. S3 is a *gateway* endpoint: no SG, no 443 — it just needs an
+association with the tasks' private route table.
+
+**Ordering, which differs by track.** `setup.sh` creates its task SG (`$P-task-sg`)
+before tasks start: authorize it, then re-run. CDK's `TaskSg` exists only in pass 2,
+so it can't be preauthorized — and a pass 2 that can't stabilize normally rolls back
+and *deletes* the SG you were about to authorize. Deploy that pass with rollback
+disabled so it survives:
+
+```bash
+npx cdk deploy --no-rollback ...   # by hand
+NO_ROLLBACK=1 ./scripts/deploy.sh  # or via deploy.sh
+```
+
+Then authorize 443 from `TaskSg` on the interface endpoints' SGs and deploy **pass 2
+only** — never re-run pass 1 (see the caution under [Track B](#track-b--cdk-two-pass));
+`deploy.sh` skips it for you.
+
+A `--no-rollback` failure leaves the stack in `UPDATE_FAILED`. From there, either
+retry the update (that redeploy) or abandon it with `npx cdk rollback` /
+`aws cloudformation rollback-stack`. `continue-update-rollback` does **not** apply —
+it only accepts `UPDATE_ROLLBACK_FAILED`. Having to make that call by hand is why
+neither path disables rollback by default.
+
+Tearing down a reused VPC needs care too — see
+[Reused VPC](teardown.md#reused-vpc) in the teardown guide.
 
 ## Verify
 

--- a/claude-apps-gateway/docs/teardown.md
+++ b/claude-apps-gateway/docs/teardown.md
@@ -40,6 +40,8 @@ groups, and VPC endpoints — everything in the stack.
 - its **Route 53 validation CNAME** and the gateway **A-record** if you created it
   outside the stack
 - any **Client VPN** you stood up for laptop access
+- the **S3 build bucket, CodeBuild project, and build role** if you deployed with
+  `deploy.sh` — it creates them with the CLI, outside the stack
 
 ---
 
@@ -147,8 +149,16 @@ a few minutes to delete; its Elastic IP is only releasable afterward.
 # the VPC is yours to keep, whatever tags it carries. (A pre-existing VPC can legally
 # be tagged Project=claude-gateway — e.g. you built it for this project and put the
 # Client VPN in it — so the tag alone does NOT prove setup.sh created it.)
-VPC_REUSED=0
-[ -n "${VPC_ID:-}" ] && VPC_REUSED=1
+#
+# Decided once, on the FIRST paste, and remembered: the lookup below writes to VPC_ID
+# as well, so re-deriving this from VPC_ID would make a re-paste of this block (the
+# SG-straggler note after it asks for exactly that) read the looked-up id as "you
+# supplied it", conclude reuse, and skip delete-vpc on a VPC setup.sh created. To
+# start over in the same shell: unset VPC_REUSED VPC_ID.
+if [ -z "${VPC_REUSED:-}" ]; then
+  VPC_REUSED=0
+  [ -n "${VPC_ID:-}" ] && VPC_REUSED=1
+fi
 # For a setup.sh-created VPC this finds it by tag. For a REUSED VPC, export
 # VPC_ID=vpc-... yourself first (setup.sh doesn't tag a VPC it didn't create) —
 # the ${VPC_ID:-...} keeps a value you set instead of clobbering it with the lookup.
@@ -244,12 +254,36 @@ A `Project=$P` tag is a hint, not proof: `setup.sh` adopts a pre-existing subnet
 IGW, NAT, or SG that matches what it wants rather than creating one, and tags only
 resources it creates — so anything it adopted still carries your tags. Delete what
 you know you added; leave the rest. The four subnets `setup.sh` creates are
-`$P-public-a/b` and `$P-private-a/b`; its SGs are `$P-alb-sg`, `$P-task-sg`, and
-`$P-rds-sg`.
+`$P-public-a/b` and `$P-private-a/b`; its SGs are `$P-alb-sg`, `$P-task-sg`,
+`$P-rds-sg`, and `$P-vpce-sg` (created even when the endpoints themselves were
+adopted, so it may be unused — delete it either way).
 
 ---
 
 ## Shared cleanup (both tracks)
+
+### CodeBuild build artifacts (only if you deployed with `deploy.sh`)
+
+`cdk destroy` doesn't know about these — `deploy.sh` creates them with the CLI, outside
+the stack. The bucket holds your stamped `gateway.yaml` and the staged `claude` binary,
+so empty it rather than leaving it behind.
+
+```bash
+export AWS_REGION=us-east-1   # the region you deployed into
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+aws codebuild delete-project --name claude-gateway-build --region "$AWS_REGION"
+aws iam delete-role-policy --role-name claude-gateway-codebuild --policy-name build-perms
+aws iam delete-role --role-name claude-gateway-codebuild
+# the region-suffixed build bucket (one per region you deployed into)
+aws s3 rb "s3://claude-gateway-build-${ACCOUNT_ID}-${AWS_REGION}" --force
+```
+
+> The bucket name gained its `-$AWS_REGION` suffix when multi-region support landed
+> (CodeBuild requires its source bucket in the project's region). If you deployed with
+> an earlier `deploy.sh`, an unsuffixed `claude-gateway-build-<account-id>` bucket is
+> still sitting there, unused since your first re-run and still holding that run's
+> stamped config — `aws s3 rb s3://claude-gateway-build-${ACCOUNT_ID} --force` it too.
+> The role and project keep their fixed names across regions, so delete those once.
 
 ### ACM certificate + Route 53 records
 

--- a/claude-apps-gateway/docs/teardown.md
+++ b/claude-apps-gateway/docs/teardown.md
@@ -120,17 +120,53 @@ aws ecr delete-repository --repository-name "$P" --force --region "$AWS_REGION"
 Deleting the VPC last requires every dependency gone first. The NAT gateway takes
 a few minutes to delete; its Elastic IP is only releasable afterward.
 
-```bash
-VPC_ID=$(aws ec2 describe-vpcs --filters "Name=tag:Project,Values=$P" \
-  --query 'Vpcs[0].VpcId' --output text --region "$AWS_REGION")
+> [!WARNING]
+> **The block below is for a VPC `setup.sh` created. If you deployed into a reused
+> VPC (`VPC_ID=...`), don't run it — delete that VPC's resources by hand instead
+> (see [Reused VPC](#reused-vpc) below).**
+>
+> The loops are scoped to the `Project=$P` tag `setup.sh` stamps on what it creates,
+> which is enough to protect a shared VPC only if nothing pre-existing carries that
+> tag — and `setup.sh` can't guarantee that. It adopts a matching subnet, IGW, NAT,
+> or SG when it finds one and tags only what it creates, so an adopted resource keeps
+> whatever tags *you* gave it. Tag a subnet `Project=claude-gateway` yourself and the
+> loops can't tell it from one `setup.sh` made. Ownership isn't inferable, so for a
+> reused VPC we don't pretend otherwise.
+>
+> The final `delete-vpc` is gated twice regardless — it skips whenever you supplied
+> `VPC_ID`, and skips anything not tagged `Project=$P` — so a stray paste can't take
+> the VPC itself.
+>
+> (Endpoint tagging is recent: if you are tearing down a **dedicated** VPC from an
+> older `setup.sh` and `delete-vpc` fails with `DependencyViolation`, that deployment
+> left untagged endpoints — re-run the endpoint loop filtering on `vpc-id` alone,
+> then retry.)
 
-# VPC endpoints (interface + gateway)
-for E in $(aws ec2 describe-vpc-endpoints --filters "Name=vpc-id,Values=$VPC_ID" \
+```bash
+# Record reuse intent BEFORE the lookup fills VPC_ID in: if you set VPC_ID yourself,
+# the VPC is yours to keep, whatever tags it carries. (A pre-existing VPC can legally
+# be tagged Project=claude-gateway — e.g. you built it for this project and put the
+# Client VPN in it — so the tag alone does NOT prove setup.sh created it.)
+VPC_REUSED=0
+[ -n "${VPC_ID:-}" ] && VPC_REUSED=1
+# For a setup.sh-created VPC this finds it by tag. For a REUSED VPC, export
+# VPC_ID=vpc-... yourself first (setup.sh doesn't tag a VPC it didn't create) —
+# the ${VPC_ID:-...} keeps a value you set instead of clobbering it with the lookup.
+VPC_ID="${VPC_ID:-$(aws ec2 describe-vpcs --filters "Name=tag:Project,Values=$P" \
+  --query 'Vpcs[0].VpcId' --output text --region "$AWS_REGION")}"
+if [ -z "$VPC_ID" ] || [ "$VPC_ID" = "None" ]; then
+  echo "⚠  No VPC_ID set and none tagged Project=$P — set VPC_ID=vpc-... and re-run this block."
+fi
+
+# VPC endpoints (interface + gateway) — project-tagged only
+for E in $(aws ec2 describe-vpc-endpoints \
+    --filters "Name=vpc-id,Values=$VPC_ID" "Name=tag:Project,Values=$P" \
     --query 'VpcEndpoints[].VpcEndpointId' --output text --region "$AWS_REGION"); do
   aws ec2 delete-vpc-endpoints --vpc-endpoint-ids "$E" --region "$AWS_REGION"
 done
-# NAT gateway, then release its EIP
-NAT=$(aws ec2 describe-nat-gateways --filter "Name=vpc-id,Values=$VPC_ID" "Name=state,Values=available" \
+# NAT gateway, then release its EIP — project-tagged only
+NAT=$(aws ec2 describe-nat-gateways \
+  --filter "Name=vpc-id,Values=$VPC_ID" "Name=tag:Project,Values=$P" "Name=state,Values=available" \
   --query 'NatGateways[0].NatGatewayId' --output text --region "$AWS_REGION")
 if [ -n "$NAT" ] && [ "$NAT" != "None" ]; then
   EIP=$(aws ec2 describe-nat-gateways --nat-gateway-ids "$NAT" --region "$AWS_REGION" \
@@ -139,35 +175,77 @@ if [ -n "$NAT" ] && [ "$NAT" != "None" ]; then
   aws ec2 wait nat-gateway-deleted --nat-gateway-ids "$NAT" --region "$AWS_REGION"
   [ -n "$EIP" ] && [ "$EIP" != "None" ] && aws ec2 release-address --allocation-id "$EIP" --region "$AWS_REGION"
 fi
-# detach + delete IGW
-IGW=$(aws ec2 describe-internet-gateways --filters "Name=attachment.vpc-id,Values=$VPC_ID" \
+# detach + delete IGW — project-tagged only (a reused VPC's pre-existing IGW is
+# untagged, so it is spared; setup.sh only tags an IGW it created itself)
+IGW=$(aws ec2 describe-internet-gateways \
+  --filters "Name=attachment.vpc-id,Values=$VPC_ID" "Name=tag:Project,Values=$P" \
   --query 'InternetGateways[0].InternetGatewayId' --output text --region "$AWS_REGION")
 if [ -n "$IGW" ] && [ "$IGW" != "None" ]; then
   aws ec2 detach-internet-gateway --internet-gateway-id "$IGW" --vpc-id "$VPC_ID" --region "$AWS_REGION"
   aws ec2 delete-internet-gateway --internet-gateway-id "$IGW" --region "$AWS_REGION"
 fi
-# subnets
-for SN in $(aws ec2 describe-subnets --filters "Name=vpc-id,Values=$VPC_ID" \
+# subnets — project-tagged only
+for SN in $(aws ec2 describe-subnets \
+    --filters "Name=vpc-id,Values=$VPC_ID" "Name=tag:Project,Values=$P" \
     --query 'Subnets[].SubnetId' --output text --region "$AWS_REGION"); do
   aws ec2 delete-subnet --subnet-id "$SN" --region "$AWS_REGION"
 done
-# non-default security groups
-for SG in $(aws ec2 describe-security-groups --filters "Name=vpc-id,Values=$VPC_ID" \
+# non-default security groups — project-tagged only
+for SG in $(aws ec2 describe-security-groups \
+    --filters "Name=vpc-id,Values=$VPC_ID" "Name=tag:Project,Values=$P" \
     --query "SecurityGroups[?GroupName!='default'].GroupId" --output text --region "$AWS_REGION"); do
   aws ec2 delete-security-group --group-id "$SG" --region "$AWS_REGION" 2>/dev/null
 done
-# non-main route tables
-for RT in $(aws ec2 describe-route-tables --filters "Name=vpc-id,Values=$VPC_ID" \
+# non-main route tables — project-tagged only
+for RT in $(aws ec2 describe-route-tables \
+    --filters "Name=vpc-id,Values=$VPC_ID" "Name=tag:Project,Values=$P" \
     --query 'RouteTables[?Associations[0].Main!=`true`].RouteTableId' --output text --region "$AWS_REGION"); do
   aws ec2 delete-route-table --route-table-id "$RT" --region "$AWS_REGION" 2>/dev/null
 done
-# finally the VPC (only if setup.sh created it — skip if you passed an existing VPC_ID)
-aws ec2 delete-vpc --vpc-id "$VPC_ID" --region "$AWS_REGION"
+# finally the VPC — deletes ONLY a VPC setup.sh created. Two gates, either of which
+# skips it: you supplied VPC_ID (reuse — deleting it would take shared resources with
+# it), or it isn't tagged Project=$P. No need to hand-edit or remove this line.
+if [ "$VPC_REUSED" = 1 ]; then
+  echo "VPC $VPC_ID was supplied for reuse — skipping delete-vpc (yours to keep)."
+elif [ "$(aws ec2 describe-vpcs --vpc-ids "$VPC_ID" --filters "Name=tag:Project,Values=$P" \
+      --query 'Vpcs[0].VpcId' --output text --region "$AWS_REGION" 2>/dev/null)" = "$VPC_ID" ]; then
+  aws ec2 delete-vpc --vpc-id "$VPC_ID" --region "$AWS_REGION"
+else
+  echo "VPC $VPC_ID is not tagged Project=$P — skipping delete-vpc."
+fi
 ```
 
 > SGs reference each other (three-tier chain), so a `delete-security-group` may fail
 > until the SGs that reference it are gone. Re-run the SG loop once if the first pass
 > leaves stragglers, or revoke the cross-SG rules first.
+
+#### Reused VPC
+
+Keep the VPC and delete only what this deployment added. List the candidates, then
+delete the ones you recognise — `setup.sh` names everything it creates after `$P`,
+so the `Name` tags tell you which are yours:
+
+```bash
+export VPC_ID=vpc-...   # the VPC you passed to setup.sh / the CDK
+aws ec2 describe-subnets --filters "Name=vpc-id,Values=$VPC_ID" --output table --region "$AWS_REGION" \
+  --query "Subnets[].[SubnetId,CidrBlock,Tags[?Key=='Name']|[0].Value,Tags[?Key=='Project']|[0].Value]"
+aws ec2 describe-security-groups --filters "Name=vpc-id,Values=$VPC_ID" --output table --region "$AWS_REGION" \
+  --query "SecurityGroups[].[GroupId,GroupName,Tags[?Key=='Project']|[0].Value]"
+aws ec2 describe-route-tables --filters "Name=vpc-id,Values=$VPC_ID" --output table --region "$AWS_REGION" \
+  --query "RouteTables[].[RouteTableId,Tags[?Key=='Name']|[0].Value,Tags[?Key=='Project']|[0].Value]"
+aws ec2 describe-vpc-endpoints --filters "Name=vpc-id,Values=$VPC_ID" --output table --region "$AWS_REGION" \
+  --query "VpcEndpoints[].[VpcEndpointId,ServiceName,Tags[?Key=='Project']|[0].Value]"
+# note: describe-nat-gateways takes --filter, singular
+aws ec2 describe-nat-gateways --filter "Name=vpc-id,Values=$VPC_ID" --output table --region "$AWS_REGION" \
+  --query "NatGateways[].[NatGatewayId,State,Tags[?Key=='Project']|[0].Value]"
+```
+
+A `Project=$P` tag is a hint, not proof: `setup.sh` adopts a pre-existing subnet,
+IGW, NAT, or SG that matches what it wants rather than creating one, and tags only
+resources it creates — so anything it adopted still carries your tags. Delete what
+you know you added; leave the rest. The four subnets `setup.sh` creates are
+`$P-public-a/b` and `$P-private-a/b`; its SGs are `$P-alb-sg`, `$P-task-sg`, and
+`$P-rds-sg`.
 
 ---
 

--- a/claude-apps-gateway/docs/upstream-watch.md
+++ b/claude-apps-gateway/docs/upstream-watch.md
@@ -110,6 +110,7 @@ live on 2.1.229: with the `desktop` block enabled, Claude Desktop showed the Cha
    (keep them in sync — the example is a stamped copy of the template), plus the
    README's version notes.
 3. Re-run the local verification (`cd cdk && npm test`; `./test/stamp-config.test.sh`;
+   `./test/setup-helpers.test.sh`; `./test/deploy-helpers.test.sh`;
    `bash -n cdk/scripts/setup.sh`) and add a test case if you're fixing a deployment trap.
 4. Only move the "Validated on" line above after a **live** run: deploy, browser SSO
    sign-in, and one inference call per model in `availableModels`. Static checks can't

--- a/claude-apps-gateway/test/deploy-helpers.test.sh
+++ b/claude-apps-gateway/test/deploy-helpers.test.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Tests for deploy.sh's pass-1 safety gate (DEPLOY_SH_LIB_ONLY=1 gate). Self-
+# contained (no bats): plain bash assertions, no AWS account, no network.
+# Run from anywhere:
+#   ./test/deploy-helpers.test.sh
+#
+# Why this file exists: pass 1 (`-c imageReady=false`) deploys a template holding
+# only the ECR repo, so running it over a stack that reached pass 2 tells
+# CloudFormation to delete the ~50 resources absent from it — the RDS instance and
+# the gateway's store included. The whole protection is two string→branch decisions,
+# so they get asserted here rather than reasoned about:
+#   - classify_stack_query: not-found means "first deploy"; ANY other failure aborts
+#   - needs_pass_one:       the destructive branch's narrow allowlist
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEPLOY="${REPO_ROOT}/cdk/scripts/deploy.sh"
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS + 1)); echo "  ok   - $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL - $1"; [[ -n "${2:-}" ]] && echo "         $2"; }
+
+# Load only the helpers (the gate returns before the .env load and the required-env
+# checks, so no AWS credentials or config are involved).
+# shellcheck disable=SC1090
+DEPLOY_SH_LIB_ONLY=1 source "${DEPLOY}" || { echo "FATAL: could not source ${DEPLOY}"; exit 1; }
+# deploy.sh sets -e when sourced; undo it so a failed assertion doesn't abort the run.
+set +e
+
+echo "deploy-helpers.test.sh"
+
+# ── 1. classify_stack_query — the query is a safety control, so it fails CLOSED ──
+NOT_FOUND='An error occurred (ValidationError) when calling the DescribeStacks operation: Stack with id ClaudeGatewayStack does not exist'
+
+out="$(classify_stack_query 0 'CREATE_COMPLETE' '')"
+if [[ "$?" -eq 0 && "${out}" == "CREATE_COMPLETE" ]]; then
+  pass "rc=0 yields the status verbatim"
+else
+  fail "rc=0 yields the status verbatim" "got '${out}'"
+fi
+
+out="$(classify_stack_query 255 '' "${NOT_FOUND}")"
+if [[ "$?" -eq 0 && -z "${out}" ]]; then
+  pass "ValidationError/does-not-exist yields an empty status (first deploy)"
+else
+  fail "ValidationError/does-not-exist yields an empty status (first deploy)" "got '${out}'"
+fi
+
+# Anything that is not an explicit not-found must abort. An empty status here would
+# read as "no stack yet" and run the destructive pass against a live stack.
+for err in \
+  'An error occurred (ExpiredToken) when calling the DescribeStacks operation: The security token included in the request is expired' \
+  'An error occurred (Throttling) when calling the DescribeStacks operation: Rate exceeded' \
+  'An error occurred (AccessDenied) when calling the DescribeStacks operation: not authorized' \
+  'Could not connect to the endpoint URL: "https://cloudformation.us-east-1.amazonaws.com/"' \
+  ''
+do
+  label="${err:0:46}"; label="${label:-<empty stderr>}"
+  if classify_stack_query 255 '' "${err}" >/dev/null 2>&1; then
+    fail "query failure aborts: ${label}" "expected non-zero exit"
+  else
+    pass "query failure aborts: ${label}"
+  fi
+done
+
+# A CLI that succeeds while warning on stderr (urllib3 NotOpenSSLWarning on some
+# macOS Pythons) must not contaminate the status — this is why stdout and stderr are
+# captured separately at the call site instead of with 2>&1.
+out="$(classify_stack_query 0 'ROLLBACK_COMPLETE' 'urllib3/__init__.py:35: NotOpenSSLWarning: urllib3 v2 only supports OpenSSL 1.1.1+')"
+if [[ "${out}" == "ROLLBACK_COMPLETE" ]] && needs_pass_one "${out}"; then
+  pass "a stderr warning alongside a successful query leaves the status recoverable"
+else
+  fail "a stderr warning alongside a successful query leaves the status recoverable" "got '${out}'"
+fi
+
+# ── 2. needs_pass_one — the destructive branch's allowlist ─────────────────────
+# RUN pass 1: no stack, or a stack provably holding no resources.
+for status in "" ROLLBACK_COMPLETE REVIEW_IN_PROGRESS DELETE_COMPLETE; do
+  if needs_pass_one "${status}"; then
+    pass "runs pass 1 for '${status:-<absent>}'"
+  else
+    fail "runs pass 1 for '${status:-<absent>}'" "expected the pass-1 branch"
+  fi
+done
+
+# SKIP pass 1: anything holding resources. UPDATE_FAILED is the --no-rollback
+# recovery state; the invented status stands in for a future CloudFormation value,
+# which must fail closed (skip) rather than fall into the destructive branch.
+for status in CREATE_COMPLETE UPDATE_COMPLETE UPDATE_ROLLBACK_COMPLETE \
+              UPDATE_FAILED IMPORT_COMPLETE IMPORT_ROLLBACK_COMPLETE \
+              UPDATE_COMPLETE_CLEANUP_IN_PROGRESS DELETE_FAILED CREATE_FAILED \
+              SOME_FUTURE_STATUS_CLOUDFORMATION_ADDS_LATER
+do
+  if needs_pass_one "${status}"; then
+    fail "skips pass 1 for '${status}'" "would deploy the repo-only template over a live stack"
+  else
+    pass "skips pass 1 for '${status}'"
+  fi
+done
+
+# ── 3. Statuses whose recovery is deliberately left to CDK ────────────────────
+# deploy.sh does not re-implement CloudFormation's status list, so these must all
+# take the SKIP branch rather than being special-cased. Checked against the pinned
+# CDK's own handling (2.1129): it waits out *_IN_PROGRESS, deletes and recreates a
+# failed first create, and asks before rolling a fail-paused stack forward.
+for status in CREATE_IN_PROGRESS UPDATE_IN_PROGRESS DELETE_IN_PROGRESS \
+              ROLLBACK_IN_PROGRESS UPDATE_ROLLBACK_IN_PROGRESS \
+              UPDATE_COMPLETE_CLEANUP_IN_PROGRESS \
+              ROLLBACK_FAILED UPDATE_ROLLBACK_FAILED DELETE_FAILED
+do
+  if needs_pass_one "${status}"; then
+    fail "leaves '${status}' to CDK" "took the destructive pass-1 branch"
+  else
+    pass "leaves '${status}' to CDK"
+  fi
+done
+
+echo ""
+echo "deploy-helpers.test.sh: ${PASS} passed, ${FAIL} failed"
+[[ "${FAIL}" -eq 0 ]]


### PR DESCRIPTION
## Scope: deliberately minimal

These changes are kept as small as possible so this stays a **worked example, not a production artifact**. Every addition is either a fix for something that loses data / deletes infrastructure, or a fix for VPC reuse not actually working as documented. Where a scenario genuinely isn't supported — multi-region concurrency, locked endpoint security groups, renaming a live deployment, proving ownership of resources in a shared VPC — this follows the repo's existing convention and **says so in the docs rather than automating around it**.

That's a deliberate line. An earlier draft of this branch grew an ownership-tag scheme and a wider status-handling matrix; both were removed in favour of documenting the constraint.

Net: **+556 / −57** across 8 files, one new file (a test), no dependency changes.

## Why these are required

### 1. Re-running `deploy.sh` destroyed the data plane

Pass 1 (`-c imageReady=false`) returns immediately after creating the ECR repo, so its template holds **one** resource against pass 2's **53**. `deploy.sh` ran it unconditionally at Step 1 of *every* invocation — so a second run told CloudFormation to delete everything absent from the repo-only template: the RDS instance (`deletionProtection: false`, `RemovalPolicy.DESTROY`, 1-day backups, so the gateway's store went with it), the ALB, the ECS service, all three secrets, the log group, and the VPC.

Fix: gate Step 1 on stack status, with the **destructive** branch holding the narrow allowlist so unknown and future statuses fail closed — run pass 1 only when the stack is absent or provably empty, skip to pass 2 otherwise. The status query is itself a safety control, so it doesn't fail open either: only an explicit `ValidationError`/"does not exist" counts as absent, and a throttle, expired credential, or network blip aborts rather than guessing. stdout and stderr are captured separately, so a CLI that succeeds while printing a warning to stderr can't prepend that text to the status and send a recoverable `ROLLBACK_COMPLETE` stack down the unknown-status path.

The two decisions are pure string→branch logic, so they're behind a `DEPLOY_SH_LIB_ONLY` lib gate (mirroring `setup.sh`'s `SETUP_SH_LIB_ONLY`) and asserted in `test/deploy-helpers.test.sh` — 31 assertions, no AWS account.

Everything *other* than the pass-1 decision is left to CDK on purpose, rather than re-implementing CloudFormation's status list. The comment at the gate records what that actually costs, read off the pinned CDK (2.1129) rather than assumed: it waits out `*_IN_PROGRESS`, deletes and recreates a failed first create (`ROLLBACK_COMPLETE` / `ROLLBACK_FAILED`), and **asks** before rolling a fail-paused stack forward (`CREATE_FAILED` / `UPDATE_FAILED` / `UPDATE_ROLLBACK_FAILED`). `--require-approval never` does not waive that prompt — only `--force` does — so an interactive run stops for a y/n and a non-TTY run fails with `TtyNotAttached`, in both cases after the image build.

The hand-driven CDK track can't be gated in code, so it gets a short `[!CAUTION]` at the pass-1 command.

### 2. Teardown could destroy a shared VPC's resources

`docs/teardown.md`'s network block deleted every endpoint, subnet, non-default SG, route table, NAT, and IGW filtered **only by vpc-id**, guarding just the final `delete-vpc`. Every loop is now scoped to the `Project=$P` tag `setup.sh` already stamps, and `setup.sh` now tags the VPC endpoints it creates (previously the one untagged resource).

Tag-scoping alone isn't ownership, though: `setup.sh` *adopts* a matching subnet, IGW, NAT, or SG when it finds one and tags only what it **creates**, so an adopted resource keeps whatever tags you gave it. Rather than invent an ownership marker, the automated block is now explicitly for a `setup.sh`-created VPC, and reused VPCs get a short "Reused VPC" section: five `describe` commands listing candidates with their `Name`/`Project` tags, plus the names `setup.sh` uses, so you delete what you recognise by hand.

`delete-vpc` is gated twice regardless — it skips when you supplied `VPC_ID` (recorded before the lookup can clobber it) and skips anything not tagged `Project=$P` — so a stray paste can't take the VPC. That reuse flag is decided **once**, on the first paste, because the lookup writes to `VPC_ID` too: re-deriving it would make a re-paste of the block (which the SG-straggler note asks for) read the looked-up id as "you supplied it" and skip `delete-vpc` on a VPC `setup.sh` created.

### 3. VPC reuse didn't work as documented

- **Fixed subnet CIDRs.** `setup.sh` creates subnets at `10.20.0.0/24`, `10.20.1.0/24`, `10.20.10.0/24`, `10.20.11.0/24`, so a reused VPC must be `10.20.0.0/16` or a superset with those free. The CDK track imports existing subnets, so any CIDR works. This wasn't stated anywhere.
- **Endpoint security groups.** With `createVpcEndpoints=false`, neither track touches the reused **interface** endpoints' SGs — you must allow 443 from the task SG yourself, or tasks time out fetching secrets, images, and logs. S3 is a *gateway* endpoint: route-table association, no SG, no 443. The docs previously implied otherwise. The flag is CDK-track-only, which the docs now say: `setup.sh` describes before creating, so it adopts endpoints already in the VPC and needs no equivalent.
- **Ordering.** CDK's `TaskSg` exists only in pass 2, and a pass 2 that can't stabilize **rolls back and deletes the very SG you were about to authorize** — so the documented deploy → authorize → redeploy sequence was impossible. Pass 2 now accepts rollback being disabled (`NO_ROLLBACK=1` for `deploy.sh`, `--no-rollback` by hand), off by default because the resulting `UPDATE_FAILED` must be retried or abandoned manually. Set it per run: an update requiring resource *replacement* can't be deployed with rollback disabled, so a leftover export makes an unrelated later change fail confusingly.

### 4. `deploy.sh` CodeBuild bucket, source, and IAM

- **Region-suffix the S3 build bucket** (`…-${ACCOUNT_ID}-${DEPLOY_REGION}`): CodeBuild requires its source bucket in the project's region, so an account-global name broke any second-region build. `docs/teardown.md` now has a CodeBuild-artifacts section covering the role, the project, the region-suffixed bucket, and the unsuffixed one an upgrade strands.
- **Assert the project's source on every run** (`create-project` first time, else `update-project`). A project from the previous script still pointed at the old unsuffixed bucket, and since the role now grants only the new one, `start-build` failed downloading its source on the first run after upgrading — i.e. for every existing deployment.
- **Re-assert the role + policy every run** and move the IAM-propagation sleep after every policy assertion, so a repo/region change can't hit the build before IAM propagates (intermittent ECR `AccessDenied`). Both calls now report their own failures: `create-role`'s blanket `|| true` is narrowed to `EntityAlreadyExists`, and `put-role-policy` no longer discards stderr — silencing it on a call that runs every deploy turned a real IAM failure into the script dying after "Step 3/5" with nothing printed.
- **Refuse a `GATEWAY_NAME` change** against an existing stack: pass 2 would replace the ECR repo and the service would pull from an empty one. It can't be fixed by pushing first, since the only template that creates the renamed repo ahead of the push is the destructive pass 1. A clear refusal beats a confusing ECS pull error — and because pass 1 can now be skipped, a stack with no `EcrRepositoryUri` output is caught explicitly rather than reported as that rename ( `--output text` yields `None` for a null query and an empty string for an unmatched filter; both are guarded).

### 5. Docs reconciled

The reuse guidance had ended up restated in four places, with reference-table cells reaching 111 words in an earlier draft of this branch. There's now one "Reusing an existing VPC" section in `docs/deployment.md`; both tracks and both `cdk/README.md` rows point at it, and each table cell is one sentence plus that link. Measured against `main` the four cells are *longer*, not shorter — they gained the cross-reference (`createVpcEndpoints` 40 → 54 words, `CREATE_VPC_ENDPOINTS` 21 → 40, `DEPLOY_REGION` 28 → 46, `GATEWAY_NAME` 27 → 47); the consolidation is against the draft, not against `main`.

Also reconciled while in these files: the `NOTE` claiming `deploy.sh` uses "its own inline Dockerfile and config" and "does not pass CDK context" — neither is true (it shares the tracked `Dockerfile` + `stamp-config.sh` and builds the full `CDK_CTX` from `.env`). Three more copies of that stale claim in `cdk/README.md` are fixed the same way; the real remaining deltas are the unverified staged binary and the `:latest` tag. Two stale anchors fixed (`#regions`, and `cdk/README.md`'s binary-staging link).

## Verification

No AWS account required; all local/static per `CLAUDE.md`:

- `bash -n` + `shellcheck` on `setup.sh` and `deploy.sh` (only the pre-existing `SC1091` on `source .env`)
- `./test/deploy-helpers.test.sh` — **31 passed**, new in this PR: the pass-1 allowlist (absent / `ROLLBACK_COMPLETE` / `REVIEW_IN_PROGRESS` / `DELETE_COMPLETE` → run; `CREATE_COMPLETE` / `UPDATE_COMPLETE` / `UPDATE_FAILED` / `IMPORT_COMPLETE` / `*CLEANUP_IN_PROGRESS` / `DELETE_FAILED` / `CREATE_FAILED` / an invented future status → skip), the fail-closed status query (`ExpiredToken` / `Throttling` / `AccessDenied` / unreachable endpoint / empty stderr → abort; only `ValidationError`/"does not exist" → first deploy), and that a stderr warning alongside a successful query leaves the status recoverable
- `./test/stamp-config.test.sh` (**9 passed**), `./test/setup-helpers.test.sh` (**19 passed**)
- `cd cdk && npm test` (**17 passed**), `npx cdk synth` for both passes
- All three shell suites also run under macOS's system `/bin/bash` (3.2.57)
- The three `delete-vpc` branches run against a stubbed `aws`: dedicated-and-tagged deletes, reused-untagged skips, reused-**and**-tagged skips
- The five new teardown listing queries compiled with `jmespath` against a sample response
- Every cross-reference in the touched docs resolved against GitHub's heading-slug rules
- `gateway.yaml.example` parses as YAML

The teardown block is documentation and this repo doesn't test markdown, so the stubbed-`aws` harness for it stayed throwaway; the pass-1 gate's matrix did not — it's the committed suite above.

End-to-end smoke testing against a real account + OIDC IdP remains the operator's, per the gateway quickstart.
