### PR TITLE
docs: add Bedrock Agents Classic deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 > New customers are blocked from creating Bedrock Agents resources from Jul 30, 2026.
 > The successor service is **Amazon Bedrock AgentCore** (GA since Oct 2025).
 > Please migrate existing agent workloads.
-> See the [AgentCore documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/agentcore.html)
+> See the [maintenance mode announcement](https://docs.aws.amazon.com/bedrock/latest/userguide/agents-classic-maintenance-mode.html),
+> [AgentCore documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/agentcore.html),
 > and the [migration guide](https://docs.aws.amazon.com/bedrock/latest/userguide/agents-classic-migration.html).
 
 This repo contains a collection of examples and notebooks for using Anthropic on AWS.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,22 @@
 # Anthropic on AWS
 
+> ⚠️ **Deprecation Notice (Jul 2026):** Amazon Bedrock Agents has been renamed
+> "Bedrock Agents Classic" and moved to **maintenance mode** as of Jun 30, 2026.
+> New customers are blocked from creating Bedrock Agents resources from Jul 30, 2026.
+> The successor service is **Amazon Bedrock AgentCore** (GA since Oct 2025).
+> Please migrate existing agent workloads.
+> See the [AgentCore documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/agentcore.html)
+> and the [migration guide](https://docs.aws.amazon.com/bedrock/latest/userguide/agents-classic-migration.html).
+
 This repo contains a collection of examples and notebooks for using Anthropic on AWS.
 
 ## Notebooks
-
 - [Cookbooks](/cookbooks/README.md)
 
 ## Workshops
-
 - [Prompt Engineering](https://github.com/aws-samples/prompt-engineering-with-anthropic-claude-v-3)
 
 ## Demos
-
 - [Metaprompt Generator](metaprompt-generator/README.md)
 - [Tool Use (function calling) with complex tool schemas](complex-schema-tool-use/README.md)
 - [Claude Streamlit LLM Playground (supports Claude 3.5)](claude-multimodal-llm-playground/README.md)


### PR DESCRIPTION
Amazon Bedrock Agents moved to maintenance mode (Jun 30, 2026). New customers blocked from Jul 30, 2026. Successor: Amazon Bedrock AgentCore (GA since Oct 2025). Adding deprecation notice to README so contributors and users are aware of the migration path.

Fixes #