### PR TITLE
docs(claude-apps-gateway): add cost guide; correct the ~$37/month figure

### DIFF
--- a/claude-apps-gateway/README.md
+++ b/claude-apps-gateway/README.md
@@ -584,7 +584,7 @@ curl -X POST https://<gateway>/oauth/device_authorization
 ## FAQ
 
 **Q: How much does it cost?**
-No license fee. Approximately $37/month for minimal AWS infrastructure (ECS $9 + RDS $12 + ALB $16). Plus Amazon Bedrock inference (same as without the gateway).
+No license or per-seat fee. A live deploy of this example idles at roughly **$185/month** (us-east-1, stack defaults): the two largest line items are the six interface VPC endpoints (~$88) and the NAT gateway (~$35), then Fargate (~$30), the ALB (~$18), and RDS (~$14). Amazon Bedrock inference is separate, charged at the same rates as calling Bedrock directly, and dominates at any real scale. See [`docs/costs.md`](docs/costs.md) for the breakdown and the posture trade-offs that reduce it.
 
 **Q: Can CI/CD pipelines use the gateway?**
 No. Gateway requires browser SSO. Configure CI against Amazon Bedrock directly with IAM credentials.
@@ -620,6 +620,7 @@ Existing signed-in developers keep working (tokens validate locally). New sign-i
 | Resource | Link |
 |----------|------|
 | **Deployment guide (this repo)** | [`docs/deployment.md`](docs/deployment.md) |
+| Cost breakdown & trade-offs (this repo) | [`docs/costs.md`](docs/costs.md) |
 | Field guide to deployment traps (this repo) | [`docs/gotchas.md`](docs/gotchas.md) |
 | Official docs | https://code.claude.com/docs/en/claude-apps-gateway |
 | Config reference | https://code.claude.com/docs/en/claude-apps-gateway-config |

--- a/claude-apps-gateway/README.md
+++ b/claude-apps-gateway/README.md
@@ -435,7 +435,7 @@ curl -X POST https://<gateway>/oauth/device_authorization
 ## FAQ
 
 **Q: How much does it cost?**
-No license fee. Approximately $37/month for minimal AWS infrastructure (ECS $9 + RDS $12 + ALB $16). Plus Amazon Bedrock inference (same as without the gateway).
+No license or per-seat fee. A live deploy of this example idles at roughly **$185/month** (us-east-1, stack defaults): the two largest line items are the six interface VPC endpoints (~$88) and the NAT gateway (~$35), then Fargate (~$30), the ALB (~$18), and RDS (~$14). Amazon Bedrock inference is separate, charged at the same rates as calling Bedrock directly, and dominates at any real scale. See [`docs/costs.md`](docs/costs.md) for the breakdown and the posture trade-offs that reduce it.
 
 **Q: Can CI/CD pipelines use the gateway?**
 No. Gateway requires browser SSO. Configure CI against Amazon Bedrock directly with IAM credentials.
@@ -471,6 +471,7 @@ Existing signed-in developers keep working (tokens validate locally). New sign-i
 | Resource | Link |
 |----------|------|
 | **Deployment guide (this repo)** | [`docs/deployment.md`](docs/deployment.md) |
+| Cost breakdown & trade-offs (this repo) | [`docs/costs.md`](docs/costs.md) |
 | Field guide to deployment traps (this repo) | [`docs/gotchas.md`](docs/gotchas.md) |
 | Official docs | https://code.claude.com/docs/en/claude-apps-gateway |
 | Config reference | https://code.claude.com/docs/en/claude-apps-gateway-config |

--- a/claude-apps-gateway/cdk/README.md
+++ b/claude-apps-gateway/cdk/README.md
@@ -258,7 +258,7 @@ All values come from `.env`. The CDK code reads them at deploy time.
 | `OIDC_CLIENT_SECRET` | OAuth client secret from your IdP app registration; `deploy.sh` seeds it into Secrets Manager (never baked into the image) and refuses to deploy while it's still the placeholder |
 | `ALLOWED_EMAIL_DOMAINS` | Only users with these email domains can sign in |
 | `BEDROCK_REGION` | Region whose Bedrock endpoint the gateway calls (the upstream `region:` + the inference-profile IAM ARN). Any region works — the gateway uses global inference profiles. See [Regions & data residency](#regions--data-residency) |
-| `DEPLOY_REGION` | Optional. Region the **stack** deploys into (VPC/ALB/RDS/ECR/ECS/CodeBuild). Defaults to `BEDROCK_REGION`; `deploy.sh` exports it as `AWS_REGION`/`AWS_DEFAULT_REGION` so every `aws` call and CDK agree. See [Regions](#regions) |
+| `DEPLOY_REGION` | Optional. Region the **stack** deploys into (VPC/ALB/RDS/ECR/ECS/CodeBuild). Defaults to `BEDROCK_REGION`; `deploy.sh` exports it as `AWS_REGION`/`AWS_DEFAULT_REGION` so every `aws` call and CDK agree. See [Regions & data residency](#regions--data-residency) |
 | `CERT_ARN` | Imported ACM cert ARN for `GATEWAY_HOSTNAME` (required; `deploy.sh` maps it to the `certArn` context) |
 | `INGRESS_CIDR` | VPN/corp **client** CIDR developers connect from — **not** the VPC CIDR (required; maps to `ingressCidr`) |
 | `VPC_ID` | Optional. Reuse an existing VPC (e.g. to keep a Client VPN association intact) instead of creating one; maps to `vpcId` |
@@ -496,14 +496,23 @@ This deletes the ECS service, ALB, RDS database, ECR repository, IAM roles, secu
 
 ## Cost
 
+Idling, before any inference traffic (us-east-1, stack defaults):
+
 | Resource | Monthly cost |
 |----------|-------------|
-| ECS Fargate (0.5 vCPU, 1 GB — gateway + ADOT sidecar) | ~$9 |
-| RDS db.t4g.micro | ~$12 |
-| Application Load Balancer | ~$16 |
-| ACM certificate | Free |
-| **Total** | **~$37** |
+| 6 interface VPC endpoints × 2 AZs | ~$88 |
+| NAT gateway | ~$35 |
+| ECS Fargate (0.5 vCPU, 1 GB — gateway + ADOT sidecar), 2 tasks | ~$30 |
+| Application Load Balancer | ~$18 |
+| RDS db.t4g.micro (single-AZ, 20 GB gp3) | ~$14 |
+| ACM certificate, S3 gateway endpoint | Free |
+| **Total** | **~$185** |
+
+> The first two lines are two thirds of the bill and are absent from an
+> "ECS + RDS + ALB" estimate. **[`docs/costs.md`](../docs/costs.md)** covers the
+> endpoint posture options and what each one gives up, plus single-AZ endpoints
+> and VPC reuse.
 
 The ADOT collector runs as a sidecar inside the gateway's Fargate task (a small memory reservation), so per-user usage telemetry adds no separate service cost. Turning telemetry off (deleting the `telemetry:` block — see "Telemetry" under "How traffic flows") saves nothing here, since there's no idle task to remove.
 
-No license or per-seat fee from Anthropic. Amazon Bedrock inference costs are separate and the same as calling Amazon Bedrock directly without the gateway.
+No license or per-seat fee from Anthropic. Amazon Bedrock inference costs are separate, the same as calling Amazon Bedrock directly without the gateway, and dominate the total at any real fleet size.

--- a/claude-apps-gateway/cdk/README.md
+++ b/claude-apps-gateway/cdk/README.md
@@ -244,7 +244,7 @@ All values come from `.env`. The CDK code reads them at deploy time.
 | `OIDC_CLIENT_SECRET` | OAuth client secret from your IdP app registration; `deploy.sh` seeds it into Secrets Manager (never baked into the image) and refuses to deploy while it's still the placeholder |
 | `ALLOWED_EMAIL_DOMAINS` | Only users with these email domains can sign in |
 | `BEDROCK_REGION` | Region whose Bedrock endpoint the gateway calls (the upstream `region:` + the inference-profile IAM ARN). Any region works — the gateway uses global inference profiles. See [Regions & data residency](#regions--data-residency) |
-| `DEPLOY_REGION` | Optional. Region the **stack** deploys into (VPC/ALB/RDS/ECR/ECS/CodeBuild). Defaults to `BEDROCK_REGION`; `deploy.sh` exports it as `AWS_REGION`/`AWS_DEFAULT_REGION` so every `aws` call and CDK agree. See [Regions](#regions) |
+| `DEPLOY_REGION` | Optional. Region the **stack** deploys into (VPC/ALB/RDS/ECR/ECS/CodeBuild). Defaults to `BEDROCK_REGION`; `deploy.sh` exports it as `AWS_REGION`/`AWS_DEFAULT_REGION` so every `aws` call and CDK agree. See [Regions & data residency](#regions--data-residency) |
 | `CERT_ARN` | Imported ACM cert ARN for `GATEWAY_HOSTNAME` (required; `deploy.sh` maps it to the `certArn` context) |
 | `INGRESS_CIDR` | VPN/corp **client** CIDR developers connect from — **not** the VPC CIDR (required; maps to `ingressCidr`) |
 | `VPC_ID` | Optional. Reuse an existing VPC (e.g. to keep a Client VPN association intact) instead of creating one; maps to `vpcId` |
@@ -481,14 +481,23 @@ This deletes the ECS service, ALB, RDS database, ECR repository, IAM roles, secu
 
 ## Cost
 
+Idling, before any inference traffic (us-east-1, stack defaults):
+
 | Resource | Monthly cost |
 |----------|-------------|
-| ECS Fargate (0.5 vCPU, 1 GB — gateway + ADOT sidecar) | ~$9 |
-| RDS db.t4g.micro | ~$12 |
-| Application Load Balancer | ~$16 |
-| ACM certificate | Free |
-| **Total** | **~$37** |
+| 6 interface VPC endpoints × 2 AZs | ~$88 |
+| NAT gateway | ~$35 |
+| ECS Fargate (0.5 vCPU, 1 GB — gateway + ADOT sidecar), 2 tasks | ~$30 |
+| Application Load Balancer | ~$18 |
+| RDS db.t4g.micro (single-AZ, 20 GB gp3) | ~$14 |
+| ACM certificate, S3 gateway endpoint | Free |
+| **Total** | **~$185** |
+
+> The first two lines are two thirds of the bill and are absent from an
+> "ECS + RDS + ALB" estimate. **[`docs/costs.md`](../docs/costs.md)** covers the
+> endpoint posture options and what each one gives up, plus single-AZ endpoints
+> and VPC reuse.
 
 The ADOT collector runs as a sidecar inside the gateway's Fargate task (a small memory reservation), so per-user usage telemetry adds no separate service cost. Turning telemetry off (deleting the `telemetry:` block — see "Telemetry" under "How traffic flows") saves nothing here, since there's no idle task to remove.
 
-No license or per-seat fee from Anthropic. Amazon Bedrock inference costs are separate and the same as calling Amazon Bedrock directly without the gateway.
+No license or per-seat fee from Anthropic. Amazon Bedrock inference costs are separate, the same as calling Amazon Bedrock directly without the gateway, and dominate the total at any real fleet size.

--- a/claude-apps-gateway/docs/costs.md
+++ b/claude-apps-gateway/docs/costs.md
@@ -1,0 +1,118 @@
+# Cost
+
+What this example bills at its defaults, and what changing the network security
+posture saves. Figures are **us-east-1, stack defaults**; rates vary by region.
+
+There is no license or per-seat fee for the gateway. Bedrock inference is billed
+separately at the same rates as calling Bedrock directly.
+
+---
+
+## Baseline
+
+Idle, before any inference traffic:
+
+| Line item | Per day | Per month | Rate |
+|---|---|---|---|
+| 6 interface VPC endpoints × 2 AZs | ~$2.90 | ~$88 | $0.01 per endpoint per AZ-hour, + $0.01/GB |
+| NAT gateway | ~$1.15 | ~$35 | $0.045/hr, + $0.045/GB |
+| ECS Fargate, 2 tasks (0.5 vCPU, 1 GB) | ~$1.00 | ~$30 | Gateway + ADOT sidecar share the task |
+| Application Load Balancer | ~$0.60 | ~$18 | + LCU charges |
+| RDS `db.t4g.micro`, single-AZ, 20 GB gp3 | ~$0.45 | ~$14 | |
+| ACM certificate | free | free | |
+| S3 gateway endpoint | free | free | Gateway endpoints have no hourly or per-GB charge |
+| **Total** | **~$6.10** | **~$185** | |
+
+
+**Client VPN**, if you built the sketch in [`connectivity.md`](connectivity.md) to
+give laptops a private path: ~$2.40/day (~$73/month) per subnet association, plus
+$0.05/hour per connected developer.
+
+---
+
+## Endpoint posture
+
+### How it works today
+
+The stack creates six interface endpoints so that no AWS-service traffic leaves
+the VPC. The tasks also sit in `PRIVATE_WITH_EGRESS` subnets behind a NAT
+gateway, and **NAT cannot be removed**: the gateway makes server-side calls to
+the OIDC issuer for discovery, JWKS, and the token exchange, which is internet
+egress for a public IdP (Okta, Entra, Google Workspace). See
+`cdk/lib/claude-gateway-stack.ts:122`.
+
+Every service the endpoints cover is therefore also reachable over NAT. Removing
+an endpoint does not break function; that leg falls back to the public AWS
+endpoint over NAT, with no error raised. The endpoint buys the private path only.
+
+### What each endpoint protects
+
+| Endpoint | Traffic on that leg | Frequency |
+|---|---|---|
+| Bedrock runtime | Prompts and completions | Every request |
+| CloudWatch Logs + monitoring | Auth events, `user.email`, `user.id`. No prompt content | Continuous |
+| Secrets Manager | OIDC client secret, DB password | Task start |
+| ECR API + Docker | Image manifests and auth tokens | Task start |
+
+Removing the two ECR endpoints does not send image data over NAT. Layer
+downloads are S3 presigned URLs routed through the free S3 gateway endpoint, so
+only manifest and auth calls become public.
+
+### Options
+
+| Posture | Endpoints | Monthly | Over NAT instead of PrivateLink |
+|---|---|---|---|
+| Full private (default) | 6 × 2 AZ | ~$88 | IdP leg only |
+| Private inference | Bedrock only, 1 × 2 AZ | ~$15 | Secrets at task start, ECR metadata, logs, metrics |
+| NAT only | none | $0 | All AWS-service traffic, including prompts |
+
+
+- **Private inference:** comment out the five non-Bedrock `addIfaceEndpoint` calls
+  at `cdk/lib/claude-gateway-stack.ts:153-157`, keeping `BedrockRuntimeEndpoint`
+  and the S3 gateway endpoint. Mirror in `setup.sh`.
+- **NAT only:** `-c createVpcEndpoints=false`. This also drops the free S3 gateway
+  endpoint. The flag exists for VPC reuse
+  ([`../cdk/README.md`](../cdk/README.md#cdk-context-variables)), where the reused
+  VPC already provides the same private egress; on a fresh VPC it is a posture
+  change.
+
+### Before removing the Bedrock endpoint
+
+- **Check for an `aws:SourceVpce` condition.** If an SCP, a Bedrock resource
+  policy, or a Config rule requires private connectivity for this workload,
+  removing the endpoint denies access rather than degrading posture.
+- **Know which claim changes.** "No data to Anthropic" is unaffected, since
+  Bedrock is an AWS service either way. What changes is the "AWS traffic never
+  leaves the VPC" statement in
+  [`../cdk/README.md`](../cdk/README.md#regions--data-residency). Retaining the
+  Bedrock endpoint keeps that true for prompt content.
+
+---
+
+## Reductions that do not change security posture
+
+**Reuse an existing VPC.** If a VPC already has these interface endpoints and a
+NAT gateway:
+
+```bash
+-c vpcId=vpc-0123456789abcdef -c createVpcEndpoints=false
+```
+
+Moves ~$123/month off this workload onto shared infrastructure. Authorise 443
+from the task security group on those endpoints; see the `vpcId` /
+`createVpcEndpoints` rows in
+[`../cdk/README.md`](../cdk/README.md#cdk-context-variables).
+
+**Single-AZ endpoints (non-production).** Interface endpoints bill per ENI, one
+per subnet, and CDK places them in both private subnets. One AZ halves whichever
+posture above (~$44/month on full private, ~$7 on private inference). Tasks in
+the other AZ then reach the endpoint cross-AZ, adding per-GB transfer and an AZ
+dependency that partly negates `desiredCount: 2`.
+
+**Log retention.** The gateway log group defaults to three months
+(`cdk/lib/claude-gateway-stack.ts:230`). Set it to the audit requirement; the
+OTLP metrics, not the logs, are the analytics surface.
+
+**Tear down when idle.** A demo or pilot bills ~$185/month whether or not anyone
+signs in. See [`teardown.md`](teardown.md).
+

--- a/claude-apps-gateway/docs/deployment.md
+++ b/claude-apps-gateway/docs/deployment.md
@@ -326,6 +326,9 @@ Fargate (2× gateway) is ~$1/day, the ALB ~$0.60/day, RDS
 [`connectivity.md`](connectivity.md), add ~$2.40/day per subnet association plus
 $0.05/h per connected client. Tear down when idle ([`teardown.md`](teardown.md)).
 
+For the full monthly breakdown and the posture trade-offs that reduce it, see
+[`costs.md`](costs.md).
+
 ## Removing a deployment
 
 CDK: `npx cdk destroy`. `setup.sh`: by hand, in reverse dependency order — follow

--- a/claude-apps-gateway/docs/deployment.md
+++ b/claude-apps-gateway/docs/deployment.md
@@ -374,6 +374,9 @@ Fargate (2× gateway) is ~$1/day, the ALB ~$0.60/day, RDS
 [`connectivity.md`](connectivity.md), add ~$2.40/day per subnet association plus
 $0.05/h per connected client. Tear down when idle ([`teardown.md`](teardown.md)).
 
+For the full monthly breakdown and the posture trade-offs that reduce it, see
+[`costs.md`](costs.md).
+
 ## Removing a deployment
 
 CDK: `npx cdk destroy`. `setup.sh`: by hand, in reverse dependency order — follow


### PR DESCRIPTION
## Problem

The README FAQ and `cdk/README.md` both quoted **~\$37/month**, derived from an "ECS + RDS + ALB" component list. That omits two line items the stack creates:

- **six interface VPC endpoints × 2 AZs** — ~\$88/month
- **NAT gateway** — ~\$35/month

Together those are two thirds of the actual bill. A live deploy idles at **~\$185/month** (us-east-1, stack defaults), which is the figure `docs/deployment.md` already carried as ~\$5–7/day. So the repo contradicted itself, and the two most-read places had the wrong number.

## Changes

- **New `docs/costs.md`** — per-line-item baseline (daily and monthly, with rates), then the endpoint posture options, then the reductions that cost no posture.
- **Corrected** the cost tables in `README.md` (FAQ) and `cdk/README.md`, both now pointing at the new doc.
- **`docs/deployment.md`** — kept its short "Cost expectations" paragraph, added a pointer.
- **Drive-by:** fixed a pre-existing broken anchor in `cdk/README.md` (`#regions` → `#regions--data-residency`).

## Why the endpoint posture section is the core of it

It is the largest reduction available and the only one that trades security for cost, so the doc treats it as a decision rather than a tip.

NAT cannot be removed: the gateway makes server-side calls to the OIDC issuer for discovery, JWKS, and the token exchange, which is internet egress for a public IdP. Every service the interface endpoints cover is therefore *also* reachable over NAT. Removing an endpoint does not break function — that leg falls back to the public AWS endpoint with no error raised. The endpoint buys the private path only.

Because that failure is silent, the doc records what traffic each leg actually carries so the trade can be judged rather than guessed:

| Endpoint | Traffic on that leg | Frequency |
|---|---|---|
| Bedrock runtime | Prompts and completions | Every request |
| CloudWatch Logs + monitoring | Auth events, `user.email`, `user.id`. No prompt content | Continuous |
| Secrets Manager | OIDC client secret, DB password | Task start |
| ECR API + Docker | Image manifests and auth tokens | Task start |

Which yields three postures:

| Posture | Endpoints | Monthly | Over NAT instead of PrivateLink |
|---|---|---|---|
| Full private (default) | 6 × 2 AZ | ~\$88 | IdP leg only |
| Private inference | Bedrock only, 1 × 2 AZ | ~\$15 | Secrets at task start, ECR metadata, logs, metrics |
| NAT only | none | \$0 | All AWS-service traffic, including prompts |

Keeping only the Bedrock endpoint costs ~\$15/month instead of ~\$88 and preserves the private path for prompt content, which is the part a security review probes. The doc also flags the two pre-flight checks: look for an `aws:SourceVpce` condition (an SCP or resource policy makes removal a hard denial, not a soft posture change), and note that "no data to Anthropic" is unaffected either way — the claim that changes is the narrower "AWS traffic never leaves the VPC".

## Deliberately not adding config flags

Every posture is documented as a hand-edit against a cited line range, not a new CDK context variable. This is a worked example, and each flag added is a flag to maintain and test. `createVpcEndpoints` already exists for VPC reuse and is referenced as-is.

## Verification

Docs only, no code or template changes. All internal links and heading anchors resolve, and the four cited `claude-gateway-stack.ts` line references were checked against the code on `main`.