### PR TITLE
fix(claude-apps-gateway): key the image tag on the baked config; document admin-API enablement

### DIFF
--- a/claude-apps-gateway/README.md
+++ b/claude-apps-gateway/README.md
@@ -303,10 +303,21 @@ counters, an audit log, and per-developer PII. The example's RDS is deliberately
 disposable (`removalPolicy: DESTROY`, `deletionProtection: false`, 1-day backups,
 single-AZ), so turning this on is a conscious opt-in, not a default.
 
-**How to enable it** — three steps:
+**How to enable it** — three steps. This is a deliberate opt-in, so neither track
+provisions the admin keys for you; the code you need is below.
 
-**1. Mint the admin keys as secrets** (≥32 chars each), the same way the JWT/OIDC
-secrets are created:
+> [!IMPORTANT]
+> All three steps must land **together**, in the same deploy. The gateway expands
+> `${GATEWAY_ADMIN_WRITE_KEY}` when it reads the config, so a half-applied change
+> fails in one of two ways:
+> - **Config block without the secrets injected** → the container dies at boot with
+>   `undefined env var in config: GATEWAY_ADMIN_WRITE_KEY` (a crash-loop, not a 401).
+> - **Secrets injected without the config block** → the admin routes are never
+>   mounted, and requests fall through to developer-session auth, so `curl` gets
+>   `auth.denied` / `missing_token` even though the key is correct.
+
+**1. Mint the admin keys as secrets** (≥32 chars each — `openssl rand -base64 32`
+gives 44), the same way the JWT/OIDC secrets are created:
 
 ```bash
 aws secretsmanager create-secret --name claude-gateway-admin-write-key \
@@ -316,18 +327,50 @@ aws secretsmanager create-secret --name claude-gateway-admin-read-key \
 ```
 
 **2. Inject them into the container**, alongside `GATEWAY_JWT_SECRET` /
-`OIDC_CLIENT_SECRET`:
+`OIDC_CLIENT_SECRET`. Note it is the **execution** role that reads secrets (the ECS
+agent resolves them before the container starts), not the task role.
 
-- **CDK** — add to the `secrets:` map in `cdk/lib/claude-gateway-stack.ts` and grant
-  the task role `secretsmanager:GetSecretValue` on the two new ARNs:
+- **CDK** (`cdk/lib/claude-gateway-stack.ts`) — look up the two secrets and add them
+  to the container's `secrets:` map. `ecs.Secret.fromSecretsManager` grants the
+  execution role `secretsmanager:GetSecretValue` for you, so there is no separate
+  IAM edit:
   ```ts
+  const adminWriteSecret = secretsmanager.Secret.fromSecretNameV2(
+    this, 'AdminWriteKey', `${gatewayName}-admin-write-key`);
+  const adminReadSecret = secretsmanager.Secret.fromSecretNameV2(
+    this, 'AdminReadKey', `${gatewayName}-admin-read-key`);
+
+  // ...then inside the container definition's `secrets:` map:
   GATEWAY_ADMIN_WRITE_KEY: ecs.Secret.fromSecretsManager(adminWriteSecret),
   GATEWAY_ADMIN_READ_KEY:  ecs.Secret.fromSecretsManager(adminReadSecret),
   ```
-- **setup.sh** — add matching entries to the container `secrets` array and the IAM
-  secrets policy.
+- **`setup.sh`** — resolve the two ARNs next to the existing ones (phase 4), add them
+  to the exec-role secrets policy (phase 5a), and add them to the container `secrets`
+  array (phase 6):
+  ```bash
+  # phase 4, alongside JWT_SECRET_ARN / OIDC_SECRET_ARN:
+  ADMIN_WRITE_ARN="$(aws_q secretsmanager describe-secret \
+    --secret-id "${PROJECT}-admin-write-key" --query ARN)"
+  ADMIN_READ_ARN="$(aws_q secretsmanager describe-secret \
+    --secret-id "${PROJECT}-admin-read-key" --query ARN)"
+  ```
+  ```diff
+   # phase 5a — EXEC_SECRETS_POLICY Resource list:
+  -   "Resource":["${JWT_SECRET_ARN}","${OIDC_SECRET_ARN}","${DB_SECRET_ARN}"]},
+  +   "Resource":["${JWT_SECRET_ARN}","${OIDC_SECRET_ARN}","${DB_SECRET_ARN}",
+  +               "${ADMIN_WRITE_ARN}","${ADMIN_READ_ARN}"]},
+  ```
+  ```diff
+   # phase 6 — container `secrets` array (add --arg adminWriteArn/adminReadArn to
+   # the surrounding `jq` call so these expand):
+     {name: "DB_PASSWORD", valueFrom: ($dbArn + ":password::")}
+  +   ,{name: "GATEWAY_ADMIN_WRITE_KEY", valueFrom: $adminWriteArn}
+  +   ,{name: "GATEWAY_ADMIN_READ_KEY", valueFrom: $adminReadArn}
+  ```
 
-**3. Uncomment the `admin:` block** in `gateway.yaml` and redeploy:
+**3. Uncomment the `admin:` block** in **`cdk/gateway.yaml.template`** — not the
+generated `gateway.yaml`, which `stamp-config.sh` overwrites on every deploy — then
+redeploy:
 
 ```yaml
 admin:
@@ -335,8 +378,19 @@ admin:
     - { id: terraform, key: "${GATEWAY_ADMIN_WRITE_KEY}" }
   read_keys:
     - { id: reporting, key: "${GATEWAY_ADMIN_READ_KEY}" }
+  # Optional. `admin_groups` lets members of an IdP group call the admin API with
+  # their session bearer token instead of a key; `blocked_message` is appended to
+  # the 429 a capped developer sees. The block is validated strictly — unknown
+  # keys are rejected at boot.
   blocked_message: "Contact platform-team@company.com to request a higher limit."
 ```
+
+Because the config is **baked into the image**, editing the template only takes
+effect once a new image is built and the service points at it. `setup.sh` handles
+this automatically (its default image tag hashes the stamped config, so a config
+edit produces a new tag and a real rebuild). On the CDK track, build and push a new
+tag and re-run pass 2 with `-c imageTag=<new-tag>` — see
+[`docs/deployment.md`](docs/deployment.md#track-b--cdk-two-pass).
 
 > ⚠️ **Harden RDS before relying on this.** Enabling admin makes Postgres hold
 > durable spend + audit + PII. The shipped database is disposable — enable deletion

--- a/claude-apps-gateway/cdk/gateway.yaml.example
+++ b/claude-apps-gateway/cdk/gateway.yaml.example
@@ -173,9 +173,18 @@ managed:
 #     - { id: terraform, key: "${GATEWAY_ADMIN_WRITE_KEY}" }
 #   read_keys:
 #     - { id: reporting, key: "${GATEWAY_ADMIN_READ_KEY}" }
+#   # Both optional: admin_groups lets members of an IdP group call the admin API
+#   # with their session bearer token instead of an x-api-key; blocked_message is
+#   # appended to the 429 a capped developer sees. The admin block is validated
+#   # STRICTLY — an unknown key here fails the boot.
 #   admin_groups: [platform-finops]
-#   # NOTE: enabling admin makes Postgres hold durable spend + audit + PII. Harden
+#   blocked_message: "Contact platform-team@company.com to request a higher limit."
+#   # NOTE 1: enabling admin makes Postgres hold durable spend + audit + PII. Harden
 #   # RDS (backups, deletion protection, multi-AZ) — see the README "Productionising".
+#   # NOTE 2: uncommenting this is NOT sufficient on its own. The ${...} keys are
+#   # expanded by the gateway at boot from the task definition's env, so the two
+#   # secrets must be minted and injected in the SAME deploy or the container
+#   # crash-loops with "undefined env var in config". Full steps: README §5.
 #
 # Model catalog. Each id maps to a GLOBAL cross-region inference profile
 # (global.anthropic.*), which resolves from ANY Bedrock region — so this config is

--- a/claude-apps-gateway/cdk/gateway.yaml.template
+++ b/claude-apps-gateway/cdk/gateway.yaml.template
@@ -180,9 +180,18 @@ managed:
 #     - { id: terraform, key: "${GATEWAY_ADMIN_WRITE_KEY}" }
 #   read_keys:
 #     - { id: reporting, key: "${GATEWAY_ADMIN_READ_KEY}" }
+#   # Both optional: admin_groups lets members of an IdP group call the admin API
+#   # with their session bearer token instead of an x-api-key; blocked_message is
+#   # appended to the 429 a capped developer sees. The admin block is validated
+#   # STRICTLY — an unknown key here fails the boot.
 #   admin_groups: [platform-finops]
-#   # NOTE: enabling admin makes Postgres hold durable spend + audit + PII. Harden
+#   blocked_message: "Contact platform-team@company.com to request a higher limit."
+#   # NOTE 1: enabling admin makes Postgres hold durable spend + audit + PII. Harden
 #   # RDS (backups, deletion protection, multi-AZ) — see the README "Productionising".
+#   # NOTE 2: uncommenting this is NOT sufficient on its own. The ${...} keys are
+#   # expanded by the gateway at boot from the task definition's env, so the two
+#   # secrets must be minted and injected in the SAME deploy or the container
+#   # crash-loops with "undefined env var in config". Full steps: README §5.
 #
 # Model catalog. Each id maps to a GLOBAL cross-region inference profile
 # (global.anthropic.*), which resolves from ANY Bedrock region — so this config is

--- a/claude-apps-gateway/cdk/scripts/setup.sh
+++ b/claude-apps-gateway/cdk/scripts/setup.sh
@@ -17,7 +17,9 @@
 # (it's claude-gateway.<ZONE_NAME>), so there is no "deploy to learn the URL" pass.
 # The only ordering constraint is image-before-service. A single run handles it:
 # the image is built and pushed (phase 3) before the service is created (phase 6).
-# Re-run any time to roll a new image.
+# Re-run any time to roll a new image: because the default image tag hashes the
+# stamped config, editing gateway.yaml.template yields a new tag and a genuine
+# rebuild — a config change can't be silently skipped as "already in ECR".
 #
 # ── Prerequisites you must satisfy out of band ────────────────────────────────
 #     * Bedrock MODEL ACCESS enabled for each Claude model you list in
@@ -60,6 +62,22 @@ aws_q() { aws "$@" --output text --region "${AWS_REGION}" 2>/dev/null; }
 sha_of() {
   if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | awk '{print $1}';
   else shasum -a 256 "$1" | awk '{print $1}'; fi
+}
+
+# config_image_tag — derive the image tag from BOTH things baked into the image:
+# the pinned binary version AND the stamped config. Config is baked, not mounted
+# (see gateway.yaml.template's header), so the image is binary+config — a tag keyed
+# on the version alone stays identical when only the config changes. The existing
+# "tag already in ECR" check then skips the rebuild while the service still gets
+# redeployed, so the config edit silently never ships. That is the trap behind
+# a reported admin-API failure: uncommenting `admin:` and re-running looked like a
+# successful deploy but served the previous image, whose config had no admin block,
+# so the request fell through to session auth (auth.denied / missing_token).
+# Keying the tag on the config hash makes any config change a new tag by
+# construction, with no operator discipline required.
+config_image_tag() {
+  local version="$1" config="$2"
+  printf '%s-%s\n' "${version}" "$(sha_of "${config}" | cut -c1-12)"
 }
 
 # resolve_container_tool — honor CONTAINER_TOOL if set (and fail if it isn't on
@@ -114,8 +132,9 @@ if [[ "${SETUP_SH_LIB_ONLY:-}" == "1" ]]; then return 0 2>/dev/null || exit 0; f
 AWS_REGION="${AWS_REGION:-us-east-1}"
 PROJECT="${PROJECT:-claude-gateway}"
 
-# Pin the Claude Code version. Drives BOTH the download URL and the image tag, so
-# the artifact is self-describing. The gateway subcommand floor is 2.1.195; the
+# Pin the Claude Code version. Drives the download URL and the image-tag PREFIX
+# (the tag is <version>-<config-hash>, so the artifact names both of its inputs —
+# see config_image_tag). The gateway subcommand floor is 2.1.195; the
 # version must also be >= the newest managed-settings key you use (we ship a live
 # managed.policies block). 2.1.198 added 404-failover across upstreams and the
 # anthropicAws (Claude Platform on AWS) provider, both referenced in
@@ -131,7 +150,11 @@ CLAUDE_SHA256="${CLAUDE_SHA256:-}"
 CLAUDE_BINARY="${CLAUDE_BINARY:-./claude}"
 
 ECR_REPO="${ECR_REPO:-${PROJECT}}"
-IMAGE_TAG="${IMAGE_TAG:-${CLAUDE_VERSION}}"
+# IMAGE_TAG is deliberately NOT defaulted here: the default is derived in phase 2
+# from CLAUDE_VERSION + the hash of the stamped gateway.yaml (see config_image_tag),
+# which cannot be computed until the config has been stamped. Set IMAGE_TAG to pin
+# an explicit tag and opt out of the content-derived default.
+IMAGE_TAG="${IMAGE_TAG:-}"
 
 DB_INSTANCE="${DB_INSTANCE:-${PROJECT}-db}"
 DB_NAME="${DB_NAME:-claude_gateway}"
@@ -190,7 +213,8 @@ info "caller $(aws_q sts get-caller-identity --query Arn)"
 # Fail fast on the OIDC client secret BEFORE the slow phases (RDS alone is ~9 min).
 preflight_oidc_secret
 REGISTRY="${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
-IMAGE_URI="${REGISTRY}/${ECR_REPO}:${IMAGE_TAG}"
+# IMAGE_URI is assembled in phase 2, once the config is stamped and IMAGE_TAG is
+# known (the default tag hashes the stamped config — see config_image_tag).
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Phase 1 — ECR
@@ -211,20 +235,35 @@ aws ecr get-login-password --region "${AWS_REGION}" \
 # ──────────────────────────────────────────────────────────────────────────────
 # Phase 2 — Image: stamp config, download + verify binary, build, push
 # ──────────────────────────────────────────────────────────────────────────────
-log "Phase 2: build and push image ${IMAGE_URI}"
+log "Phase 2: build and push image"
+
+# 2a. Stamp gateway.yaml from the committed template. This runs BEFORE the
+# "already in ECR" check on purpose: the stamped config feeds the default image
+# tag, so the tag can only be known once the config exists. (Stamping is local,
+# cheap and idempotent — safe to redo on every run.)
+info "stamping gateway.yaml from template"
+PUBLIC_URL="${PUBLIC_URL}" AWS_REGION="${AWS_REGION}" \
+OIDC_ISSUER="${OIDC_ISSUER}" OIDC_CLIENT_ID="${OIDC_CLIENT_ID}" \
+ALLOWED_EMAIL_DOMAINS="${ALLOWED_EMAIL_DOMAINS}" \
+DB_NAME="${DB_NAME}" \
+"${SCRIPT_DIR}/stamp-config.sh"
+
+# Default the tag from binary version + stamped-config hash, so editing
+# gateway.yaml.template always yields a new tag and a real rebuild.
+if [[ -z "${IMAGE_TAG}" ]]; then
+  IMAGE_TAG="$(config_image_tag "${CLAUDE_VERSION}" ./gateway.yaml)"
+  info "image tag (derived from version + config hash): ${IMAGE_TAG}"
+else
+  info "image tag (pinned via IMAGE_TAG): ${IMAGE_TAG}"
+fi
+IMAGE_URI="${REGISTRY}/${ECR_REPO}:${IMAGE_TAG}"
 
 if aws_q ecr describe-images --repository-name "${ECR_REPO}" \
      --image-ids imageTag="${IMAGE_TAG}" >/dev/null; then
-  skip "image tag ${IMAGE_TAG} already in ECR — re-run with a new IMAGE_TAG to rebuild"
+  # With the derived tag this now means the binary AND the config are unchanged,
+  # so there is genuinely nothing to rebuild.
+  skip "image ${IMAGE_URI} already in ECR (same binary + config) — nothing to rebuild"
 else
-  # 2a. Stamp gateway.yaml from the committed template.
-  info "stamping gateway.yaml from template"
-  PUBLIC_URL="${PUBLIC_URL}" AWS_REGION="${AWS_REGION}" \
-  OIDC_ISSUER="${OIDC_ISSUER}" OIDC_CLIENT_ID="${OIDC_CLIENT_ID}" \
-  ALLOWED_EMAIL_DOMAINS="${ALLOWED_EMAIL_DOMAINS}" \
-  DB_NAME="${DB_NAME}" \
-  "${SCRIPT_DIR}/stamp-config.sh"
-
   # 2b. Import + verify the GPG signing key.
   info "importing Claude Code release signing key"
   curl -fsSL "${KEYS_URL}" | gpg --import 2>/dev/null || die "failed to import signing key"

--- a/claude-apps-gateway/docs/deployment.md
+++ b/claude-apps-gateway/docs/deployment.md
@@ -194,6 +194,29 @@ aws ecs update-service --cluster claude-gateway --service claude-gateway --force
 To roll a new image later: push a new tag, then re-run pass 2 with
 `-c imageTag=<tag>`.
 
+> [!IMPORTANT]
+> **A config change needs a new image tag.** `gateway.yaml` is baked into the image,
+> not mounted (ECS `secrets:` injects env vars only, never files — see
+> [`gotchas.md` §13](gotchas.md#13-config-is-baked--the-image-is-per-environment)), so
+> editing `gateway.yaml.template` has no effect until you rebuild **and** point the
+> service at the new image. The tag above is the bare `CLAUDE_VERSION`, which does not
+> change when only the config does — so re-running the build would overwrite
+> `:2.1.218` in place, and re-running pass 2 with the same `-c imageTag` leaves the
+> task definition unchanged, meaning ECS may not redeploy at all. Either symptom looks
+> like a successful deploy that silently kept the old config.
+>
+> Include the config in the tag so this can't happen (this is what `setup.sh` does by
+> default):
+>
+> ```bash
+> CONFIG_HASH=$(shasum -a 256 gateway.yaml | cut -c1-12)
+> IMAGE_TAG="${CLAUDE_VERSION}-${CONFIG_HASH}"
+> docker build --platform=linux/amd64 --provenance=false -t "${ECR_URI}:${IMAGE_TAG}" .
+> docker push "${ECR_URI}:${IMAGE_TAG}"
+> # then pass 2 with the matching tag:
+> npx cdk deploy -c imageTag="${IMAGE_TAG}" ...
+> ```
+
 > [!NOTE]
 > `cdk/scripts/deploy.sh` is a separate convenience script that builds the image
 > via CodeBuild using its own inline Dockerfile and config. It does **not** use the

--- a/claude-apps-gateway/test/setup-helpers.test.sh
+++ b/claude-apps-gateway/test/setup-helpers.test.sh
@@ -134,6 +134,50 @@ else
   fail "placeholder error suggests put-secret-value" "${msg}"
 fi
 
+# ── 4. config_image_tag — the tag must cover binary version AND baked config ───
+# Config is baked into the image, so a tag keyed on CLAUDE_VERSION alone stays the
+# same when only the config changes; the "already in ECR" check then skips the
+# rebuild while the service is still redeployed, silently serving the old config.
+cfg_a="${TMP}/gw-a.yaml"
+cfg_b="${TMP}/gw-b.yaml"
+printf 'listen:\n  port: 8080\n'                  > "${cfg_a}"
+printf 'listen:\n  port: 8080\nadmin:\n  x: 1\n'  > "${cfg_b}"
+
+tag_a="$(config_image_tag 2.1.218 "${cfg_a}")"
+tag_b="$(config_image_tag 2.1.218 "${cfg_b}")"
+
+if [[ "${tag_a}" == 2.1.218-* ]]; then
+  pass "tag is prefixed with the pinned version"
+else
+  fail "tag is prefixed with the pinned version" "got ${tag_a}"
+fi
+
+if [[ "${tag_a}" != "${tag_b}" ]]; then
+  pass "config change (uncommented admin block) yields a different tag"
+else
+  fail "config change (uncommented admin block) yields a different tag" \
+       "both were ${tag_a} — a config edit would silently reuse the old image"
+fi
+
+if [[ "$(config_image_tag 2.1.218 "${cfg_a}")" == "${tag_a}" ]]; then
+  pass "same version + same config is deterministic (idempotent re-runs)"
+else
+  fail "same version + same config is deterministic (idempotent re-runs)"
+fi
+
+if [[ "$(config_image_tag 2.1.219 "${cfg_a}")" != "${tag_a}" ]]; then
+  pass "binary version bump alone yields a different tag"
+else
+  fail "binary version bump alone yields a different tag"
+fi
+
+# Must be a valid ECR tag: [A-Za-z0-9_.-] only, <=128 chars.
+if [[ "${tag_a}" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+  pass "derived tag is a valid ECR image tag"
+else
+  fail "derived tag is a valid ECR image tag" "got ${tag_a}"
+fi
+
 echo ""
 echo "setup-helpers.test.sh: ${PASS} passed, ${FAIL} failed"
 [[ "${FAIL}" -eq 0 ]]


### PR DESCRIPTION
Fixes the deployment trap behind #273.

## The problem

`gateway.yaml` is baked into the image, not mounted (on ECS a task definition's
`secrets:` injects env vars only, and the image is distroless with no shell to template
at boot). But the image tag was derived from `CLAUDE_VERSION` alone, while the image is
really *binary + config*.

So a config-only change produced no new tag:

- **`setup.sh`** — the idempotency check skipped the build (`image tag ... already in
  ECR`) while still re-registering the task definition and rolling the service. The
  deploy looks successful; the new tasks pull the same old image.
- **CDK (`docs/deployment.md`)** — same root issue, quieter: the documented push uses the
  bare version tag, so a rebuild overwrites it in place, and re-running pass 2 with an
  unchanged `-c imageTag` leaves the task definition identical, so ECS may not redeploy
  at all.

In #273 that surfaced as an admin-API failure: uncommenting the `admin:` block and
redeploying left the container running its previous config, so the admin routes were
never mounted and the request fell through to developer-session auth — returning
`auth.denied` / `missing_token` rather than `admin.denied` / `invalid_key`. The reported
symptom was therefore *not* caused by the missing admin-key provisioning (that would
crash-loop the container on `undefined env var in config`, not serve a 401).

## Changes

- **`cdk/scripts/setup.sh`** — new `config_image_tag()` helper; the image tag now
  defaults to `<version>-<config-hash>`, so any template edit yields a new tag and a
  genuine rebuild. Config stamping moved ahead of the ECR check (the tag depends on the
  stamped config), and the skip message now means "same binary *and* config".
  `IMAGE_TAG` still overrides to pin an explicit tag.
- **`docs/deployment.md`** — Track B never said a config change needs a new image tag.
  Documented, with the config-hash recipe.
- **`README.md` §5** — replaced the prose "inject them into the container" step with
  working CDK and `setup.sh` code; corrected task role → **execution** role (the ECS
  agent resolves secrets before the container starts); pointed step 3 at
  `cdk/gateway.yaml.template` rather than the generated `gateway.yaml`, which
  `stamp-config.sh` overwrites; and called out that all three steps must land in the
  same deploy, since half-applying fails two different ways and only one looks like an
  auth error.
- **`cdk/gateway.yaml.template` / `.example`** — documented `admin_groups` and
  `blocked_message` (the template and README each showed only one), noted the block is
  validated strictly so unknown keys fail the boot, and warned that uncommenting alone
  crash-loops the container.
- **`test/setup-helpers.test.sh`** — five cases covering the tag derivation: config
  change yields a new tag, determinism across re-runs, version-bump sensitivity, and
  ECR tag validity.

No new configuration surface or feature flags — the fix is a corrected default plus
documentation, keeping this a worked example rather than a product.

## Verification

Offline (no AWS account needed): `bash -n`, `shellcheck`, `test/setup-helpers.test.sh`
(19 passed), `test/stamp-config.test.sh` (9 passed), `cd cdk && npm test` (17 passed),
`npx cdk synth`. The uncommented `admin:` block was also parsed and checked against the
gateway's strict admin schema.

Live, on an ECS Fargate deployment (us-east-1):

1. **Reproduced #273** — a valid-length `x-api-key` against a gateway with no `admin:`
   block logged exactly `{"evt":"auth.denied","reason":"missing_token","path":"/v1/organizations/spend_limits/effective"}`,
   with the container healthy (2/2, `/healthz` 200) — confirming a stale image rather
   than a boot failure.
2. **Enabled admin correctly** — the same wrong-key request then returned
   `admin.denied` / `invalid_key`, proving the router mounts. Correct write key →
   `200`; `POST` a cap → `200`; the same `POST` with the *read* key → `403 requires
   write:spend_limits`.
3. **Demonstrated the tag fix on real artifacts** — same binary, two stamped configs:
   the old scheme produced `2.1.218` for both; the new scheme produced
   `2.1.218-3cb07511f94c` and `2.1.218-53c52556eb1e`.
4. **Full teardown + fresh CDK deploy** following the rewritten docs verbatim — stack
   `UPDATE_COMPLETE`, 2/2 tasks, both ALB targets healthy, image tag
   `2.1.218-39e683173ebe` from the documented recipe; `dig` → private IPs only,
   `/healthz` 200, `/readyz` `ready`, discovery doc valid, `device_authorization`
   issuing codes.

Two README claims were also confirmed against the live deployment: the execution role
(not the task role) is what holds `secretsmanager:GetSecretValue`, and
`openssl rand -base64 32` yields 44 characters, clearing the schema's 32-character
minimum.

Refs #273
