### PR TITLE
docs(claude-apps-gateway): document the Claude Desktop overlay + the parent-settings opt-in

### DIFF
--- a/claude-apps-gateway/README.md
+++ b/claude-apps-gateway/README.md
@@ -214,7 +214,7 @@ managed:
       desktop:                    # presence of this key is the opt-in
         isLocalDevMcpEnabled: false
         disableAutoUpdates: true
-        banner: { text: "Contractor build: internal use only" }
+        banner: { enabled: true, text: "Contractor build: internal use only" }
 ```
 
 The gateway derives most of the bootstrap response from the matched policy's `cli` block:

--- a/claude-apps-gateway/README.md
+++ b/claude-apps-gateway/README.md
@@ -109,7 +109,7 @@ Both the gateway server (Linux binary) and each developer's Claude Code CLI must
 
 Developers can update with `claude update`. The gateway server uses the same binary, downloaded from the Claude Code release page and packaged into a container image.
 
-Some gateway behaviour is version-gated: v2.1.198 added cross-upstream failover on `404` and the `anthropicAws` (Claude Platform on AWS) provider — earlier gateway builds reject that provider at boot. The worked example in this repo pins **2.1.218**, which also fixes gateway spend metering to price Bedrock application-inference-profile ARNs and other config-mapped upstream model IDs at the configured model's rates — directly relevant to this example's `global.anthropic.*` inference profiles. See [`docs/upstream-watch.md`](docs/upstream-watch.md) for a checklist to stay across gateway releases.
+Some gateway behaviour is version-gated: v2.1.198 added cross-upstream failover on `404` and the `anthropicAws` (Claude Platform on AWS) provider — earlier gateway builds reject that provider at boot; v2.1.203 added the Claude Desktop bootstrap endpoint (`/user/bootstrap`). The worked example in this repo pins **2.1.218**, which also fixes gateway spend metering to price Bedrock application-inference-profile ARNs and other config-mapped upstream model IDs at the configured model's rates — directly relevant to this example's `global.anthropic.*` inference profiles. See [`docs/upstream-watch.md`](docs/upstream-watch.md) for a checklist to stay across gateway releases.
 
 ### 5. Device management (for pushing settings to developers)
 
@@ -119,7 +119,7 @@ You need a way to deploy a JSON file to developer machines. This file tells Clau
 - Ansible/Chef/Puppet (Linux)
 - Manual file placement (for testing)
 
-Without this file, developers see the standard login picker instead of the Cloud gateway screen.
+Without this file, developers see the standard login picker instead of the Cloud gateway screen. If you also deploy Claude Desktop, the same MDM tool delivers Desktop's separate managed configuration (the `bootstrapUrl` key) — see ["How developers connect"](#claude-desktop).
 
 ---
 
@@ -195,6 +195,73 @@ managed:
 | Tool permissions / hooks / env (`cli` managed settings) | **Client-side** (delivered to the CLI) | **Yes** |
 
 Tool/permission policies are defense-in-depth (a patched client can ignore them); for a hard boundary use MDM-locked settings on managed devices. The governance guarantees are the server-side rows.
+
+<a id="claude-desktop-overlay"></a>
+**Claude Desktop overlay.** The same gateway serves Claude Desktop, but only for policies
+that explicitly opt in. `/user/bootstrap` — the endpoint Desktop fetches its config from —
+returns `404` unless the matching policy carries a `desktop` key. An empty `desktop: {}`
+is enough to opt a policy in, and a `desktop` key on the `match: {}` base layer opts in
+every policy that inherits it. Requires the gateway server on **v2.1.203+** (this example
+pins 2.1.218). Pair it with `bootstrapUrl` on the client side — see
+["How developers connect"](#claude-desktop).
+
+```yaml
+managed:
+  policies:
+    - match: { groups: [eng-contractors] }
+      cli:
+        availableModels: [claude-haiku-4-5]
+      desktop:                    # presence of this key is the opt-in
+        isLocalDevMcpEnabled: false
+        disableAutoUpdates: true
+        banner: { text: "Contractor build: internal use only" }
+```
+
+The gateway derives most of the bootstrap response from the matched policy's `cli` block:
+the model list from `availableModels`, disabled tools from **bare tool-name**
+`permissions.deny` entries, the egress allowlist from `sandbox.network.allowedDomains`,
+and — when `telemetry.forward_to` is set — an OTLP endpoint pointing back at the gateway,
+which fans out to your destinations. Keys with no Desktop equivalent are omitted, including
+`hooks` and scoped rules like `Bash(npm *)`; if a restriction matters for Desktop, express
+it as a bare tool name.
+
+The `desktop:` block itself holds only the Desktop-specific gates that have no CLI
+equivalent. Every key is optional (Desktop applies its own default for anything omitted),
+and unknown keys **fail gateway boot**:
+
+| Key | Effect |
+|---|---|
+| `modelDiscoveryEnabled` | Whether Desktop fetches `/v1/models` for its picker; `false` relies solely on the policy's model list |
+| `coworkTabEnabled`, `isClaudeCodeForDesktopEnabled` | Show or hide individual tabs |
+| `isDesktopExtensionEnabled`, `isDesktopExtensionSignatureRequired` | Desktop extension loading and signature checks |
+| `isLocalDevMcpEnabled` | Allow locally defined MCP servers |
+| `disableAutoUpdates`, `autoUpdaterEnforcementHours` | Auto-update policy |
+| `banner` | Persistent banner in the app: `enabled`, `text`, `backgroundColor`, `textColor`, `linkUrl` |
+
+Two traps worth knowing before you ship a `desktop` block, both hit on a live deploy:
+
+- **`banner` needs `enabled: true`.** `banner: { text: "…" }` on its own renders *nothing* —
+  Desktop's `enabled` sub-key has no default, and `text` only applies when it's truthy.
+  Write `banner: { enabled: true, text: "…" }`.
+- **The accepted key set is bounded by the pinned gateway version, and validation is
+  strict** — an unknown key fails boot and crash-loops the ECS task. The table above is the
+  full set as of 2.1.221. Notably `chatTabEnabled` is *not* in it, so a Desktop client
+  pointed at the gateway loses its **Chat** tab (Cowork and Code default on; Chat has no
+  default and can't be re-enabled from either side) — filed upstream as
+  [anthropics/claude-code#83723](https://github.com/anthropics/claude-code/issues/83723).
+  See [`docs/upstream-watch.md`](docs/upstream-watch.md) for how to probe a new key against
+  the pin.
+
+If you don't deploy Claude Desktop, leave `desktop` out entirely — `/user/bootstrap` then
+returns `404` for every user, which is the safe default. Either way, `/user/bootstrap` is
+on the same host and port as everything else, so the internal ALB needs no new listener
+rule or target group.
+
+**Audit events.** Each bootstrap fetch is logged as `desktop_bootstrap.serve` or
+`desktop_bootstrap.denied`; the denial carries a reason (`not_configured`,
+`policy_not_opted_in`, or `no_policy_matched`) plus the user's identity. Those land in the
+task's stderr → CloudWatch (`/claude-gateway/gateway`) alongside `session.mint`,
+`inference`, and the rest.
 
 ---
 
@@ -401,9 +468,19 @@ Admins push one JSON file to developer machines via MDM (Jamf, Intune, etc.):
 ```json
 {
   "forceLoginMethod": "gateway",
-  "forceLoginGatewayUrl": "https://claude-gateway.internal.company.com"
+  "forceLoginGatewayUrl": "https://claude-gateway.internal.company.com",
+  "parentSettingsBehavior": "merge"
 }
 ```
+
+The first two keys point `/login` at the gateway. The third is the one that's easy to
+miss: Claude Desktop delivers the gateway's policy to the Claude Code sessions it
+launches as *parent settings*, and Claude Code **ignores parent settings** on any
+machine that has an admin-deployed managed source unless the highest-priority source
+sets `parentSettingsBehavior: "merge"`. Without it, those embedded sessions run with
+none of the gateway's restrictions and **nothing warns you**. Machines where developers
+sign in through `/login` don't need it (every invocation fetches policy from the gateway
+directly), but it's harmless there — so push all three keys everywhere.
 
 Deploy that file to each device, typically via your MDM platform. The file path differs by platform:
 
@@ -413,7 +490,31 @@ Deploy that file to each device, typically via your MDM platform. The file path 
 | Linux and WSL | `/etc/claude-code/managed-settings.json` |
 | Windows | `C:\Program Files\ClaudeCode\managed-settings.json`, or Group Policy via the HKLM registry |
 
+Only the **highest-priority** admin source's value counts, and these are not merged
+across sources: an HKLM registry policy or a macOS managed-preferences plist outranks
+the `managed-settings.json` file, and the gateway's own `managed.policies[].cli` block
+outranks both. So if you deliver policy via Group Policy or a configuration profile, put
+all three keys *there* rather than in the file — and mirror `parentSettingsBehavior` into
+the gateway policy's `cli` block too, since that's what wins on connected machines.
+
 After that, developers just run `claude /login` → press Enter → browser SSO → done.
+
+### Claude Desktop
+
+Claude Desktop connects to the same gateway through a **different** MDM key, in Desktop's
+own managed configuration — not the two `forceLogin*` keys above:
+
+```json
+{ "bootstrapUrl": "https://claude-gateway.internal.company.com/user/bootstrap" }
+```
+
+Desktop derives the OIDC issuer from that URL, runs the same browser SSO, and fetches its
+configuration from the gateway instead of from Anthropic. It needs a **server-side opt-in
+as well**: `/user/bootstrap` returns `404` unless the policy matching the user carries a
+`desktop` key. See ["Claude Desktop" under capability 2](#claude-desktop-overlay) for that half.
+
+A developer who uses both the CLI and Desktop signs in to each separately; the gateway
+session isn't shared between them.
 
 ---
 
@@ -442,7 +543,7 @@ No license fee. Approximately $37/month for minimal AWS infrastructure (ECS $9 +
 No. Gateway requires browser SSO. Configure CI against Amazon Bedrock directly with IAM credentials.
 
 **Q: What about Claude Desktop / Cowork?**
-Claude Desktop (including Chat, Cowork, and Claude Code) can route through the gateway. Configure the gateway URL in the desktop app's managed settings via MDM.
+Supported, with an opt-in on both sides. Client side: set `bootstrapUrl` to `<public_url>/user/bootstrap` in Claude Desktop's own managed configuration — that's a different key from the CLI's `forceLoginGatewayUrl`. Server side: the policy matching the user must carry a `desktop` key, or `/user/bootstrap` returns `404`. Model access and policy then follow the same per-group rules as the CLI. See ["Claude Desktop overlay"](#claude-desktop-overlay). Separately, if Desktop launches embedded Claude Code sessions, `parentSettingsBehavior: "merge"` must be in the winning managed source or those sessions get none of the gateway's policy.
 
 **Q: Can they fail over between regions?**
 Yes. Configure multiple upstreams with different regions. The gateway tries them in order and fails over on 5xx/429.

--- a/claude-apps-gateway/cdk/README.md
+++ b/claude-apps-gateway/cdk/README.md
@@ -222,7 +222,8 @@ Push this JSON file to developer machines via your MDM tool (Jamf, Intune, Ansib
 ```json
 {
   "forceLoginMethod": "gateway",
-  "forceLoginGatewayUrl": "https://claude-gateway.internal.company.com"
+  "forceLoginGatewayUrl": "https://claude-gateway.internal.company.com",
+  "parentSettingsBehavior": "merge"
 }
 ```
 
@@ -233,6 +234,14 @@ Push this JSON file to developer machines via your MDM tool (Jamf, Intune, Ansib
 | Windows | `C:\Program Files\ClaudeCode\managed-settings.json` |
 
 Developers then run `claude /login`, press Enter, complete browser SSO, and they're connected.
+
+`parentSettingsBehavior: "merge"` lets Claude Desktop deliver the gateway's policy to the
+embedded Claude Code sessions it launches; without it those sessions ignore the parent
+settings and run unpoliced on any managed machine. It's harmless on CLI-only machines, so
+push all three keys everywhere. If you deploy Claude Desktop as a client in its own right,
+it also needs `bootstrapUrl` (→ `<public_url>/user/bootstrap`) in Desktop's own managed
+configuration and a `desktop` key on the matching gateway policy — see the root
+[README](../README.md#claude-desktop) and the config reference.
 
 ## Configuration reference
 

--- a/claude-apps-gateway/cdk/gateway.yaml.example
+++ b/claude-apps-gateway/cdk/gateway.yaml.example
@@ -149,6 +149,13 @@ managed:
     #     availableModels: [claude-haiku-4-5]
     #     enforceAvailableModels: true
     #     permissions: { allow: [Read, Grep] }
+    #   # Claude Desktop feature gates (see the desktop: note on the base policy below).
+    #   desktop:
+    #     isLocalDevMcpEnabled: false
+    #     disableAutoUpdates: true
+    #     # `enabled: true` is REQUIRED — Desktop's banner.enabled has no default, so a
+    #     # banner with only `text:` renders nothing.
+    #     banner: { enabled: true, text: "Contractor build: internal use only" }
     # Per-team cost attribution: OTEL_RESOURCE_ATTRIBUTES is stamped on every
     # OTLP export, so CloudWatch's PromQL layer can group spend/usage by team
     # (sum by ("@resource.team.id") (...)) same as user.id/user.email already are.
@@ -165,6 +172,46 @@ managed:
           - claude-haiku-4-5
           # - claude-fable-5   # opt-in — see the models: block note below
         enforceAvailableModels: true
+        # CLAUDE DESKTOP, part 1 of 2 (uncomment if you deploy Desktop). Desktop hands
+        # this policy to the embedded Claude Code sessions it launches as PARENT
+        # settings, and Claude Code IGNORES parent settings on a machine with an
+        # admin-deployed managed source unless the WINNING source opts in with this key
+        # — so mirror it in the MDM managed-settings.json (and in any HKLM policy /
+        # macOS plist, which outrank the file). Machines that never sign in to the
+        # gateway get policy from that file alone. Left off by default because it also
+        # lets ANY launching host (Agent SDK app, IDE extension) supply parent settings;
+        # the filter is restrictive-only except for allow rules and sandbox allowlists,
+        # so pair it with the allowManaged*Only locks. See the README.
+        # parentSettingsBehavior: merge
+      #
+      # CLAUDE DESKTOP, part 2 of 2 — the /user/bootstrap opt-in. Presence of a
+      # `desktop` key is what makes the gateway serve Desktop's configuration to this
+      # policy's users; without it /user/bootstrap 404s for everyone (the safe default,
+      # so this stays commented) and Desktop reports it can't fetch its config. Each
+      # request is audited as desktop_bootstrap.serve / .denied. On the match:{} base
+      # layer it opts in every policy that inherits. Requires gateway >= 2.1.203.
+      #
+      # `desktop: {}` on its own is a complete opt-in. The keys below are optional
+      # feature gates with no CLI equivalent; each one omitted keeps Desktop's own
+      # default, and an UNKNOWN key here fails gateway boot. The rest of the response
+      # comes from the cli: block above — availableModels, bare tool-name
+      # permissions.deny entries, sandbox.network.allowedDomains, and an OTLP endpoint
+      # when telemetry.forward_to is set. hooks and scoped rules like Bash(npm *) have
+      # no Desktop equivalent and are dropped.
+      #
+      # Desktop clients need the other half: `bootstrapUrl` set to
+      # <public_url>/user/bootstrap in Claude Desktop's own managed configuration — a
+      # DIFFERENT key from the CLI's forceLoginGatewayUrl.
+      # desktop:
+      #   modelDiscoveryEnabled: false          # rely only on availableModels above
+      #   coworkTabEnabled: true
+      #   isClaudeCodeForDesktopEnabled: true
+      #   isDesktopExtensionEnabled: true
+      #   isDesktopExtensionSignatureRequired: true
+      #   isLocalDevMcpEnabled: false
+      #   disableAutoUpdates: false
+      #   autoUpdaterEnforcementHours: 72
+      #   banner: { enabled: true, text: "Internal gateway build", linkUrl: https://wiki.example.com/claude }
 
 # Optional blocks, left commented:
 #

--- a/claude-apps-gateway/cdk/gateway.yaml.template
+++ b/claude-apps-gateway/cdk/gateway.yaml.template
@@ -156,6 +156,13 @@ managed:
     #     availableModels: [claude-haiku-4-5]
     #     enforceAvailableModels: true
     #     permissions: { allow: [Read, Grep] }
+    #   # Claude Desktop feature gates (see the desktop: note on the base policy below).
+    #   desktop:
+    #     isLocalDevMcpEnabled: false
+    #     disableAutoUpdates: true
+    #     # `enabled: true` is REQUIRED — Desktop's banner.enabled has no default, so a
+    #     # banner with only `text:` renders nothing.
+    #     banner: { enabled: true, text: "Contractor build: internal use only" }
     # Per-team cost attribution: OTEL_RESOURCE_ATTRIBUTES is stamped on every
     # OTLP export, so CloudWatch's PromQL layer can group spend/usage by team
     # (sum by ("@resource.team.id") (...)) same as user.id/user.email already are.
@@ -172,6 +179,46 @@ managed:
           - claude-haiku-4-5
           # - claude-fable-5   # opt-in — see the models: block note below
         enforceAvailableModels: true
+        # CLAUDE DESKTOP, part 1 of 2 (uncomment if you deploy Desktop). Desktop hands
+        # this policy to the embedded Claude Code sessions it launches as PARENT
+        # settings, and Claude Code IGNORES parent settings on a machine with an
+        # admin-deployed managed source unless the WINNING source opts in with this key
+        # — so mirror it in the MDM managed-settings.json (and in any HKLM policy /
+        # macOS plist, which outrank the file). Machines that never sign in to the
+        # gateway get policy from that file alone. Left off by default because it also
+        # lets ANY launching host (Agent SDK app, IDE extension) supply parent settings;
+        # the filter is restrictive-only except for allow rules and sandbox allowlists,
+        # so pair it with the allowManaged*Only locks. See the README.
+        # parentSettingsBehavior: merge
+      #
+      # CLAUDE DESKTOP, part 2 of 2 — the /user/bootstrap opt-in. Presence of a
+      # `desktop` key is what makes the gateway serve Desktop's configuration to this
+      # policy's users; without it /user/bootstrap 404s for everyone (the safe default,
+      # so this stays commented) and Desktop reports it can't fetch its config. Each
+      # request is audited as desktop_bootstrap.serve / .denied. On the match:{} base
+      # layer it opts in every policy that inherits. Requires gateway >= 2.1.203.
+      #
+      # `desktop: {}` on its own is a complete opt-in. The keys below are optional
+      # feature gates with no CLI equivalent; each one omitted keeps Desktop's own
+      # default, and an UNKNOWN key here fails gateway boot. The rest of the response
+      # comes from the cli: block above — availableModels, bare tool-name
+      # permissions.deny entries, sandbox.network.allowedDomains, and an OTLP endpoint
+      # when telemetry.forward_to is set. hooks and scoped rules like Bash(npm *) have
+      # no Desktop equivalent and are dropped.
+      #
+      # Desktop clients need the other half: `bootstrapUrl` set to
+      # <public_url>/user/bootstrap in Claude Desktop's own managed configuration — a
+      # DIFFERENT key from the CLI's forceLoginGatewayUrl.
+      # desktop:
+      #   modelDiscoveryEnabled: false          # rely only on availableModels above
+      #   coworkTabEnabled: true
+      #   isClaudeCodeForDesktopEnabled: true
+      #   isDesktopExtensionEnabled: true
+      #   isDesktopExtensionSignatureRequired: true
+      #   isLocalDevMcpEnabled: false
+      #   disableAutoUpdates: false
+      #   autoUpdaterEnforcementHours: 72
+      #   banner: { enabled: true, text: "Internal gateway build", linkUrl: https://wiki.example.com/claude }
 
 # Optional blocks, left commented:
 #

--- a/claude-apps-gateway/docs/deployment.md
+++ b/claude-apps-gateway/docs/deployment.md
@@ -226,7 +226,8 @@ Then push the managed-settings file to developer machines via MDM:
 ```json
 {
   "forceLoginMethod": "gateway",
-  "forceLoginGatewayUrl": "https://claude-gateway.example.com"
+  "forceLoginGatewayUrl": "https://claude-gateway.example.com",
+  "parentSettingsBehavior": "merge"
 }
 ```
 
@@ -236,9 +237,32 @@ Then push the managed-settings file to developer machines via MDM:
 | Linux / WSL | `/etc/claude-code/managed-settings.json` |
 | Windows | `C:\Program Files\ClaudeCode\managed-settings.json` |
 
+`parentSettingsBehavior: "merge"` is the key that's easy to drop. Claude Code ignores
+settings supplied by a launching process (*parent settings*) on any machine with an
+admin-deployed managed source unless the winning source sets it — and Claude Desktop
+delivers the gateway's policy to the embedded Claude Code sessions it launches *as* parent
+settings. Omit it and those sessions run unpoliced with no warning. Only the
+highest-priority admin source's value counts and the sources don't merge, so if you deliver
+policy via an HKLM registry policy or a macOS managed-preferences plist (both outrank the
+`managed-settings.json` file), put all three keys there instead — and mirror
+`parentSettingsBehavior` into the gateway policy's `cli` block, which outranks both on
+connected machines.
+
 Publish the cert's SHA-256 fingerprint (printed by `setup.sh`, or the
 `CertFingerprintHint` stack output) so developers can confirm the prompt on first
 `/login`. (A public, browser-trusted ACM cert shows no prompt — see prerequisite 2.)
+
+### Claude Desktop
+
+Claude Desktop connects to the same gateway, but through Desktop's own managed
+configuration and a different key — `bootstrapUrl`, pointed at `<public_url>/user/bootstrap`
+— plus a server-side opt-in: the policy matching the user must carry a `desktop` key or
+`/user/bootstrap` returns `404`. The gateway server must be on v2.1.203 or later (this
+example pins 2.1.218). Desktop then runs the same browser SSO and fetches its config from
+the gateway; per-group model access and policy match the CLI's. The endpoint shares the
+gateway's host and port, so the ALB needs no extra listener rule. See the
+[config reference](https://code.claude.com/docs/en/claude-apps-gateway-config#claude-desktop-overlay)
+and the README's capability 2 for the `desktop:` feature gates.
 
 ## Telemetry
 

--- a/claude-apps-gateway/docs/gotchas.md
+++ b/claude-apps-gateway/docs/gotchas.md
@@ -413,3 +413,37 @@ interactive picker doesn't special-case an existing gateway session.
 just use the session (`claude -p "…"`). Confirm the session works end-to-end with a
 real prompt; an `inference` event in the gateway audit log is the proof that
 CLI → gateway → Bedrock → back all work.
+
+---
+
+## 19. Claude Desktop needs a server-side opt-in, or `/user/bootstrap` 404s
+
+**Symptom:** Claude Desktop is pointed at the gateway (its managed configuration has
+`bootstrapUrl: <public_url>/user/bootstrap`), sign-in succeeds, but Desktop reports it
+**couldn't fetch its bootstrap configuration**. The gateway audit log shows
+`desktop_bootstrap.denied` with a reason.
+
+**Why:** unlike the CLI, Desktop's config endpoint is opt-in per policy. `/user/bootstrap`
+returns `404` unless the policy matching the user carries a `desktop` key. The denial
+reason names which case you hit:
+- `not_configured` — no policy in the whole config has a `desktop` key.
+- `policy_not_opted_in` — a policy matched the user, but it (and the `match: {}` base it
+  inherits from) has no `desktop` key.
+- `no_policy_matched` — no policy matched the user at all (check group/email matching).
+
+This is the *safe* default: leaving `desktop` out means the gateway serves nobody's Desktop
+config, so a fleet that only uses the CLI is never accidentally exposing a Desktop surface.
+
+**Fix:** add a `desktop` key to the policy that matches the user, or to the `match: {}`
+base layer to opt in everyone who inherits it. `desktop: {}` alone is enough; the optional
+feature gates (`isLocalDevMcpEnabled`, `banner`, …) are documented on capability 2 in the
+[README](../README.md#claude-desktop-overlay). The gateway server must be on **v2.1.203+**
+(this example pins 2.1.218). The template ships this block commented out —
+[`cdk/gateway.yaml.template`](../cdk/gateway.yaml.template), under the `match: {}` policy.
+
+**Not the same as** `parentSettingsBehavior: "merge"`. That key governs a *different*
+Desktop integration — whether the embedded Claude Code sessions Desktop launches accept the
+gateway's policy as parent settings — and lives in the client `managed-settings.json` (and
+mirrored in the policy's `cli` block), not in the `desktop` block. Missing *that* key fails
+silently with no 404 and no warning; see the ["How developers connect"](../README.md#how-developers-connect)
+section. A full Desktop deployment sets both.

--- a/claude-apps-gateway/docs/upstream-watch.md
+++ b/claude-apps-gateway/docs/upstream-watch.md
@@ -46,6 +46,27 @@ exceeds our pin, we're behind on that feature. Two known ones we already track:
 
 - `anthropicAws` (Claude Platform on AWS) provider — **requires ≥ 2.1.198**
 - cross-upstream failover on `404` — **added in 2.1.198**
+- Claude Desktop bootstrap endpoint (`/user/bootstrap`, the `desktop` policy key) — **requires ≥ 2.1.203**
+
+**The `desktop` block's key set is bounded by the pin, and the block is validated
+strictly** — an unknown key fails gateway boot (crash-loops the container on ECS), so a
+key copied from the docs page for a newer release takes the deployment down. As of
+`2.1.221` the accepted keys are exactly: `modelDiscoveryEnabled`, `coworkTabEnabled`,
+`isClaudeCodeForDesktopEnabled`, `isDesktopExtensionEnabled`,
+`isDesktopExtensionSignatureRequired`, `isLocalDevMcpEnabled`, `disableAutoUpdates`,
+`autoUpdaterEnforcementHours`, `banner`. Verify a new key against the pinned binary
+before shipping it:
+
+```bash
+# boots and reports `Unrecognized key(s) in object: '<key>'` if the pin doesn't know it
+claude gateway --config /tmp/probe.yaml
+```
+
+Known gap: `chatTabEnabled` exists in Claude Desktop (since build `1.13576.0`) but is
+**not** in the gateway schema through 2.1.221, so a bootstrap-configured Desktop loses its
+Chat tab with no way to re-enable it — filed as
+[anthropics/claude-code#83723](https://github.com/anthropics/claude-code/issues/83723).
+Re-test on each bump and drop this note if the key lands.
 
 ### 3. Re-check the two facts this example is sensitive to
 

--- a/claude-apps-gateway/workshop/02-policy/README.md
+++ b/claude-apps-gateway/workshop/02-policy/README.md
@@ -109,6 +109,29 @@ strictKnownMarketplaces:
   - { source: github, repo: "your-org/approved-plugins" }
 ```
 
+**Extend the policy to Claude Desktop:**
+The same per-group policy can serve Claude Desktop, but only for policies that opt in. Add a
+`desktop` key **alongside** `cli` and the gateway serves that policy's users at
+`/user/bootstrap` (Desktop's config endpoint); leave it out and `/user/bootstrap` returns
+`404`. `desktop: {}` alone opts a policy in — the keys below are Desktop-only feature gates,
+and unknown keys fail gateway boot. Needs the gateway server on v2.1.203+.
+```yaml
+- match: { groups: [contractors] }
+  cli:
+    availableModels: [claude-haiku-4-5]
+  desktop:
+    isLocalDevMcpEnabled: false      # block locally defined MCP servers
+    disableAutoUpdates: true
+    banner: { text: "Contractor build: internal use only" }
+```
+The bootstrap response is derived from `cli` (models from `availableModels`, disabled tools
+from bare-name `permissions.deny`, egress from `sandbox.network.allowedDomains`); `hooks` and
+scoped rules like `Bash(npm *)` have no Desktop equivalent and are dropped. Desktop clients
+also need `bootstrapUrl` set to `<public_url>/user/bootstrap` in Desktop's own managed
+configuration. Separately, so that the Claude Code sessions Desktop *launches* inherit this
+policy, the client `managed-settings.json` must carry `parentSettingsBehavior: "merge"` —
+see the root README.
+
 ### How groups work
 
 The gateway reads group membership from the IdP token's `groups` claim. For this to work:

--- a/claude-apps-gateway/workshop/02-policy/README.md
+++ b/claude-apps-gateway/workshop/02-policy/README.md
@@ -122,7 +122,8 @@ and unknown keys fail gateway boot. Needs the gateway server on v2.1.203+.
   desktop:
     isLocalDevMcpEnabled: false      # block locally defined MCP servers
     disableAutoUpdates: true
-    banner: { text: "Contractor build: internal use only" }
+    # `enabled: true` is required — a banner with only `text:` renders nothing
+    banner: { enabled: true, text: "Contractor build: internal use only" }
 ```
 The bootstrap response is derived from `cli` (models from `availableModels`, disabled tools
 from bare-name `permissions.deny`, egress from `sandbox.network.allowedDomains`); `hooks` and


### PR DESCRIPTION
## What

Anthropic added official Claude Desktop support to the apps gateway. This documents it. Two
separate mechanisms were previously missing or wrong here — one of them (2) is a silent
correctness bug for anyone who followed the existing snippets.

**1. Desktop as a gateway client.** The client half is `bootstrapUrl` →
`<public_url>/user/bootstrap` in Desktop's *own* managed configuration — a different key from
the CLI's `forceLoginGatewayUrl`. The server half is an explicit opt-in: `/user/bootstrap`
returns `404` unless the matching policy carries a `desktop` key, so `desktop: {}` on the
`match: {}` base opts in everyone who inherits it. Requires gateway ≥ 2.1.203 (this example
pins 2.1.218).

**2. Policy delivery to Desktop's embedded Claude Code sessions.** All three
`managed-settings.json` snippets were missing `parentSettingsBehavior: "merge"`. Claude Code
ignores parent settings on a machine with an admin-deployed managed source unless the winning
source sets it — and Desktop delivers gateway policy to the sessions it launches *as* parent
settings. Following the old snippet left those sessions **unpoliced, with no warning**. This
is the correctness fix in here.

The FAQ answer was also wrong ("configure the gateway URL in the desktop app's managed
settings") — it names the wrong key and omits the server-side opt-in.

## Two traps found while validating against a live deployment

- **`banner: { text: … }` renders nothing.** Desktop's `banner.enabled` has no default and
  `text` only applies when it's truthy, so the doc-style example needed `enabled: true`.
- **The `desktop` block is validated strictly and its key set is bounded by the pin** — an
  unknown key fails boot and crash-loops the ECS task. Verified against 2.1.218–2.1.221: nine
  keys accepted, and `chatTabEnabled` is *not* among them, so a bootstrap-configured Desktop
  loses its Chat tab with no way to restore it. Filed upstream as
  [anthropics/claude-code#83723](https://github.com/anthropics/claude-code/issues/83723) and
  noted in `docs/upstream-watch.md` with a probe recipe for future bumps.

## Scope

Docs + config template only. `/user/bootstrap` is same-host/same-port, so the ALB needs no new
listener rule or target group and **the CDK stack is unchanged**. `gateway.yaml.template` and
`gateway.yaml.example` kept in sync.

## Verification

Existing suites pass unchanged, no new tests (no code paths added):

- `cd cdk && npm test` — 17 passed
- `./test/stamp-config.test.sh` — 9 passed
- `./test/setup-helpers.test.sh` — 14 passed
- `bash -n` clean on all four `cdk/scripts/*.sh`
- `yaml.safe_load` clean on `gateway.yaml.example`

Capability 1 (`bootstrapUrl` → bootstrap config served, and the `404` when the opt-in is
missing) and both traps were confirmed against a live deployment; that's where the
`chatTabEnabled` gap and the `banner.enabled` behavior came from.

Rebased onto current `main`; no overlap with the `au.`/`jp.` prefix fix in #270.
