### PR TITLE
chore(claude-apps-gateway): bump pinned Claude Code to 2.1.229; Opus 5 as the catalog default

### DIFF
--- a/claude-apps-gateway/CLAUDE.md
+++ b/claude-apps-gateway/CLAUDE.md
@@ -41,7 +41,8 @@ The CDK app and `setup.sh` provision the **same** Fargate deployment two ways �
   cross-region inference profiles (`global.anthropic.*`) so any Bedrock region works; the
   inference-profile ARN prefix must match the profile prefix in `gateway.yaml`'s `models:`
   block (swap both to `us.`/`eu.`/`au.` together if you switch off global for data residency —
-  `jp.` also exists for Opus 4.8 and Haiku 4.5, but not Sonnet 5).
+  `jp.` exists for some models too, but geo coverage varies per model, so confirm each id
+  with `aws bedrock list-inference-profiles` rather than assuming a clean substitution).
 - **Fargate, not EC2, is the primary track for a reason.** On EC2-backed compute the default IMDSv2
   hop limit of 1 blocks the in-container metadata call → every Bedrock request 502s with
   `Could not load credentials from any providers`. Fargate task roles avoid this (ECS

--- a/claude-apps-gateway/README.md
+++ b/claude-apps-gateway/README.md
@@ -101,7 +101,7 @@ The IAM policy for the task role looks like:
 }
 ```
 
-The gateway uses **global** cross-region inference profiles (e.g., `global.anthropic.claude-opus-4-8`), so the IAM prefix is `global.anthropic.*` and any Bedrock region works. Enable Bedrock model access for the models you list; global profiles route to any commercial region, so enable access where global may route. (For data residency, switch the `gateway.yaml` `models:` block and this ARN to a geo prefix — `us.`/`eu.`/`au.`, plus `jp.` for Opus 4.8 and Haiku 4.5 (Sonnet 5 has no `jp.` profile) — together; see [`cdk/README.md`](cdk/README.md) "Regions & data residency".)
+The gateway uses **global** cross-region inference profiles (e.g., `global.anthropic.claude-opus-5`), so the IAM prefix is `global.anthropic.*` and any Bedrock region works. Enable Bedrock model access for the models you list; global profiles route to any commercial region, so enable access where global may route. (For data residency, switch the `gateway.yaml` `models:` block and this ARN to a geo prefix — `us.`/`eu.`/`au.`, and `jp.` for some models, since geo coverage varies per model — together; see [`cdk/README.md`](cdk/README.md) "Regions & data residency".)
 
 ### 4. Claude Code v2.1.195 or later
 
@@ -109,7 +109,7 @@ Both the gateway server (Linux binary) and each developer's Claude Code CLI must
 
 Developers can update with `claude update`. The gateway server uses the same binary, downloaded from the Claude Code release page and packaged into a container image.
 
-Some gateway behaviour is version-gated: v2.1.198 added cross-upstream failover on `404` and the `anthropicAws` (Claude Platform on AWS) provider — earlier gateway builds reject that provider at boot; v2.1.203 added the Claude Desktop bootstrap endpoint (`/user/bootstrap`). The worked example in this repo pins **2.1.218**, which also fixes gateway spend metering to price Bedrock application-inference-profile ARNs and other config-mapped upstream model IDs at the configured model's rates — directly relevant to this example's `global.anthropic.*` inference profiles. See [`docs/upstream-watch.md`](docs/upstream-watch.md) for a checklist to stay across gateway releases.
+Some gateway behaviour is version-gated: v2.1.198 added cross-upstream failover on `404` and the `anthropicAws` (Claude Platform on AWS) provider — earlier gateway builds reject that provider at boot; v2.1.203 added the Claude Desktop bootstrap endpoint (`/user/bootstrap`); v2.1.227 added the `desktop` block's `chatTabEnabled` and `chatAdvancedFileAnalysisEnabled` keys, the `oidc.use_proxy` flag, and the `pricing:` block. The worked example in this repo pins **2.1.229**, which adds SSE keepalive pings on streaming responses so long thinking pauses don't trip an idle timeout on the Bedrock upstream — this example still raises the ALB idle timeout to 3600s as well, since the ALB has to outlast the stream either way. The pin also carries the earlier fix that prices Bedrock application-inference-profile ARNs and other config-mapped upstream model IDs at the configured model's rates, directly relevant to this example's `global.anthropic.*` inference profiles. See [`docs/upstream-watch.md`](docs/upstream-watch.md) for a checklist to stay across gateway releases.
 
 ### 5. Device management (for pushing settings to developers)
 
@@ -202,7 +202,7 @@ that explicitly opt in. `/user/bootstrap` — the endpoint Desktop fetches its c
 returns `404` unless the matching policy carries a `desktop` key. An empty `desktop: {}`
 is enough to opt a policy in, and a `desktop` key on the `match: {}` base layer opts in
 every policy that inherits it. Requires the gateway server on **v2.1.203+** (this example
-pins 2.1.218). Pair it with `bootstrapUrl` on the client side — see
+pins 2.1.229). Pair it with `bootstrapUrl` on the client side — see
 ["How developers connect"](#claude-desktop).
 
 ```yaml
@@ -232,25 +232,18 @@ and unknown keys **fail gateway boot**:
 | Key | Effect |
 |---|---|
 | `modelDiscoveryEnabled` | Whether Desktop fetches `/v1/models` for its picker; `false` relies solely on the policy's model list |
-| `coworkTabEnabled`, `isClaudeCodeForDesktopEnabled` | Show or hide individual tabs |
+| `coworkTabEnabled`, `isClaudeCodeForDesktopEnabled` | Show or hide the Cowork and Code tabs; both show unless set `false` |
+| `chatTabEnabled` | Show or hide the Chat tab — **hidden unless set `true`**. Needs gateway **≥ 2.1.227** |
+| `chatAdvancedFileAnalysisEnabled` | Let Claude run code in a local sandbox from the Chat tab to analyse attached files it can't read natively (spreadsheets, presentations). Off unless set `true`; no effect when the policy's `permissions.deny` disables `Bash`. Needs gateway **≥ 2.1.227** |
 | `isDesktopExtensionEnabled`, `isDesktopExtensionSignatureRequired` | Desktop extension loading and signature checks |
 | `isLocalDevMcpEnabled` | Allow locally defined MCP servers |
 | `disableAutoUpdates`, `autoUpdaterEnforcementHours` | Auto-update policy |
 | `banner` | Persistent banner in the app: `enabled`, `text`, `backgroundColor`, `textColor`, `linkUrl` |
 
-Two traps worth knowing before you ship a `desktop` block, both hit on a live deploy:
-
-- **`banner` needs `enabled: true`.** `banner: { text: "…" }` on its own renders *nothing* —
-  Desktop's `enabled` sub-key has no default, and `text` only applies when it's truthy.
-  Write `banner: { enabled: true, text: "…" }`.
-- **The accepted key set is bounded by the pinned gateway version, and validation is
-  strict** — an unknown key fails boot and crash-loops the ECS task. The table above is the
-  full set as of 2.1.221. Notably `chatTabEnabled` is *not* in it, so a Desktop client
-  pointed at the gateway loses its **Chat** tab (Cowork and Code default on; Chat has no
-  default and can't be re-enabled from either side) — filed upstream as
-  [anthropics/claude-code#83723](https://github.com/anthropics/claude-code/issues/83723).
-  See [`docs/upstream-watch.md`](docs/upstream-watch.md) for how to probe a new key against
-  the pin.
+The table above is the full accepted key set as of 2.1.229. Three traps bite here — a
+banner that renders nothing, a silently missing Chat tab, and an unknown key that
+crash-loops the ECS task; all three are written up in
+[`docs/gotchas.md`](docs/gotchas.md#20-three-ways-the-desktop-block-itself-bites).
 
 If you don't deploy Claude Desktop, leave `desktop` out entirely — `/user/bootstrap` then
 returns `404` for every user, which is the safe default. Either way, `/user/bootstrap` is
@@ -305,12 +298,12 @@ upstreams:
 
 # Explicit catalog → global cross-region inference profiles, so the config is
 # region-agnostic. (For data residency, swap global. for a geo prefix: us./eu./au.,
-# plus jp. for Opus 4.8 and Haiku 4.5 — Sonnet 5 has no jp. profile.)
+# and jp. for some models — geo coverage varies per model.)
 auto_include_builtin_models: false
 models:
-  - id: claude-opus-4-8
-    label: Claude Opus 4.8
-    upstream_model: { bedrock: global.anthropic.claude-opus-4-8 }
+  - id: claude-opus-5
+    label: Claude Opus 5
+    upstream_model: { bedrock: global.anthropic.claude-opus-5 }
   - id: claude-haiku-4-5
     label: Claude Haiku 4.5   # no short alias — dated profile id
     upstream_model: { bedrock: global.anthropic.claude-haiku-4-5-20251001-v1:0 }

--- a/claude-apps-gateway/cdk/README.md
+++ b/claude-apps-gateway/cdk/README.md
@@ -318,8 +318,8 @@ inference confined to a specific geography, switch the catalog off global:
 
 - Edit the `models:` block (in `deploy.sh`'s inline `gateway.yaml`, or your stamped
   `gateway.yaml` on the hardened path) — replace each `global.` prefix with a geo
-  profile (`us.` / `eu.` / `au.`, plus `jp.` for Opus 4.8 and Haiku 4.5 — Sonnet 5 has
-  no `jp.` profile). Confirm the exact id per model with
+  profile (`us.` / `eu.` / `au.`, and `jp.` for some models — geo coverage varies per
+  model, so it isn't uniform across the catalog). Confirm the exact id per model with
   `aws bedrock list-inference-profiles --region <your-region>` — they're not a clean
   substitution (e.g. Claude Haiku 4.5 has no short alias, only a dated id).
 - Change `inference-profile/global.anthropic.*` → your geo prefix in
@@ -327,7 +327,7 @@ inference confined to a specific geography, switch the catalog off global:
 - A geo (or in-region) profile only routes within that geography, so pick a
   `BEDROCK_REGION` the profile actually spans.
 
-**Default model set.** The shipped catalog is Claude Opus 4.8, Sonnet 5, and Haiku 4.5
+**Default model set.** The shipped catalog is Claude Opus 5, Sonnet 5, and Haiku 4.5
 — all three invoke via their global profiles from any region. **Claude Fable 5 is
 opt-in**: on Bedrock it requires a non-default data-retention mode that isn't enabled
 in every region, so it returns `ValidationException: data retention mode 'default' is

--- a/claude-apps-gateway/cdk/bin/app.ts
+++ b/claude-apps-gateway/cdk/bin/app.ts
@@ -33,7 +33,7 @@ import { GatewayStack } from '../lib/claude-gateway-stack';
  *     imageReady      "false" for pass 1 (repo only), "true"/unset for pass 2
  *   BUILD-TIME (stamped into the image by stamp-config.sh; shown here for parity,
  *   not passed to the running task — changing them means a new image, by design):
- *     claudeVersion   default 2.1.218
+ *     claudeVersion   default 2.1.229
  *     oidcIssuer, oidcClientId, allowedEmailDomains
  */
 const app = new cdk.App();
@@ -45,7 +45,7 @@ const region = ctx('region') ?? process.env.CDK_DEFAULT_REGION ?? 'us-east-1';
 // the inference-profile IAM ARN at a different region. NOTE: cross-region Bedrock
 // also needs the VPC Bedrock interface endpoint reworked — see the stack.
 const bedrockRegion = ctx('bedrockRegion') ?? region;
-const claudeVersion = ctx('claudeVersion') ?? '2.1.218';
+const claudeVersion = ctx('claudeVersion') ?? '2.1.229';
 
 new GatewayStack(app, 'ClaudeGatewayStack', {
   env: { account: process.env.CDK_DEFAULT_ACCOUNT, region },

--- a/claude-apps-gateway/cdk/gateway.yaml.example
+++ b/claude-apps-gateway/cdk/gateway.yaml.example
@@ -167,7 +167,7 @@ managed:
     - match: {}
       cli:
         availableModels:
-          - claude-opus-4-8
+          - claude-opus-5
           - claude-sonnet-5
           - claude-haiku-4-5
           # - claude-fable-5   # opt-in — see the models: block note below
@@ -206,6 +206,10 @@ managed:
       #   modelDiscoveryEnabled: false          # rely only on availableModels above
       #   coworkTabEnabled: true
       #   isClaudeCodeForDesktopEnabled: true
+      #   # Chat tab is HIDDEN unless set true (Cowork and Code default on). Both of
+      #   # these keys need gateway >= 2.1.227 — on an older pin they fail boot.
+      #   chatTabEnabled: true
+      #   chatAdvancedFileAnalysisEnabled: false  # no effect if permissions.deny blocks Bash
       #   isDesktopExtensionEnabled: true
       #   isDesktopExtensionSignatureRequired: true
       #   isLocalDevMcpEnabled: false
@@ -236,7 +240,7 @@ managed:
 # Model catalog. Each id maps to a GLOBAL cross-region inference profile
 # (global.anthropic.*), which resolves from ANY Bedrock region — so this config is
 # region-agnostic. For data residency, swap global. for a geo profile (us./eu./au.,
-# plus jp. for Opus 4.8 and Haiku 4.5 — Sonnet 5 has no jp. profile) and confirm the
+# and jp. for some models — geo coverage varies per model) and confirm the
 # exact id per model with `aws bedrock list-inference-profiles`
 # (see the README "Regions & data residency"). Claude Haiku 4.5 has no short alias —
 # it uses the dated profile id. For provisioned throughput, point `bedrock:` at the PT ARN.
@@ -247,10 +251,10 @@ managed:
 # enable the retention prereq for your region, uncomment it in availableModels above,
 # and uncomment the entry below.
 models:
-  - id: claude-opus-4-8
-    label: Claude Opus 4.8
+  - id: claude-opus-5
+    label: Claude Opus 5
     upstream_model:
-      bedrock: global.anthropic.claude-opus-4-8
+      bedrock: global.anthropic.claude-opus-5
   - id: claude-sonnet-5
     label: Claude Sonnet 5
     upstream_model:

--- a/claude-apps-gateway/cdk/gateway.yaml.template
+++ b/claude-apps-gateway/cdk/gateway.yaml.template
@@ -174,7 +174,7 @@ managed:
     - match: {}
       cli:
         availableModels:
-          - claude-opus-4-8
+          - claude-opus-5
           - claude-sonnet-5
           - claude-haiku-4-5
           # - claude-fable-5   # opt-in — see the models: block note below
@@ -213,6 +213,10 @@ managed:
       #   modelDiscoveryEnabled: false          # rely only on availableModels above
       #   coworkTabEnabled: true
       #   isClaudeCodeForDesktopEnabled: true
+      #   # Chat tab is HIDDEN unless set true (Cowork and Code default on). Both of
+      #   # these keys need gateway >= 2.1.227 — on an older pin they fail boot.
+      #   chatTabEnabled: true
+      #   chatAdvancedFileAnalysisEnabled: false  # no effect if permissions.deny blocks Bash
       #   isDesktopExtensionEnabled: true
       #   isDesktopExtensionSignatureRequired: true
       #   isLocalDevMcpEnabled: false
@@ -243,7 +247,7 @@ managed:
 # Model catalog. Each id maps to a GLOBAL cross-region inference profile
 # (global.anthropic.*), which resolves from ANY Bedrock region — so this config is
 # region-agnostic. For data residency, swap global. for a geo profile (us./eu./au.,
-# plus jp. for Opus 4.8 and Haiku 4.5 — Sonnet 5 has no jp. profile) and confirm the
+# and jp. for some models — geo coverage varies per model) and confirm the
 # exact id per model with `aws bedrock list-inference-profiles`
 # (see the README "Regions & data residency"). Claude Haiku 4.5 has no short alias —
 # it uses the dated profile id. For provisioned throughput, point `bedrock:` at the PT ARN.
@@ -254,10 +258,10 @@ managed:
 # enable the retention prereq for your region, uncomment it in availableModels above,
 # and uncomment the entry below.
 models:
-  - id: claude-opus-4-8
-    label: Claude Opus 4.8
+  - id: claude-opus-5
+    label: Claude Opus 5
     upstream_model:
-      bedrock: global.anthropic.claude-opus-4-8
+      bedrock: global.anthropic.claude-opus-5
   - id: claude-sonnet-5
     label: Claude Sonnet 5
     upstream_model:

--- a/claude-apps-gateway/cdk/scripts/setup.sh
+++ b/claude-apps-gateway/cdk/scripts/setup.sh
@@ -138,9 +138,11 @@ PROJECT="${PROJECT:-claude-gateway}"
 # version must also be >= the newest managed-settings key you use (we ship a live
 # managed.policies block). 2.1.198 added 404-failover across upstreams and the
 # anthropicAws (Claude Platform on AWS) provider, both referenced in
-# gateway.yaml.template; keep this >= 2.1.198 if you rely on either. See the README
-# "Version coupling" note.
-CLAUDE_VERSION="${CLAUDE_VERSION:-2.1.218}"
+# gateway.yaml.template; keep this >= 2.1.198 if you rely on either. 2.1.227 added
+# the desktop chatTabEnabled / chatAdvancedFileAnalysisEnabled keys, and 2.1.229
+# added SSE keepalive pings on streaming responses (Bedrock included). See the
+# README "Version coupling" note.
+CLAUDE_VERSION="${CLAUDE_VERSION:-2.1.229}"
 RELEASES_URL="${RELEASES_URL:-https://downloads.claude.ai/claude-code-releases}"
 KEYS_URL="${KEYS_URL:-https://downloads.claude.ai/keys/claude-code.asc}"
 # Anthropic Claude Code release signing key fingerprint (verify the imported key).

--- a/claude-apps-gateway/cdk/test/gateway-stack.test.ts
+++ b/claude-apps-gateway/cdk/test/gateway-stack.test.ts
@@ -21,7 +21,7 @@ const REGION = 'us-east-1';
 const PASS2: GatewayStackProps = {
   env: { account: ACCOUNT, region: REGION },
   imageReady: true,
-  imageTag: '2.1.218',
+  imageTag: '2.1.229',
   publicUrl: 'https://claude-gateway.example.com',
   certArn: `arn:aws:acm:${REGION}:${ACCOUNT}:certificate/abc-123`,
   zoneName: 'example.com',
@@ -36,7 +36,7 @@ function synth(props: GatewayStackProps): Template {
 }
 
 describe('pass 1 (imageReady: false) — ECR repo only', () => {
-  const template = synth({ env: PASS2.env, imageReady: false, imageTag: '2.1.218' });
+  const template = synth({ env: PASS2.env, imageReady: false, imageTag: '2.1.229' });
 
   test('creates the ECR repository', () => {
     template.resourceCountIs('AWS::ECR::Repository', 1);

--- a/claude-apps-gateway/docs/deployment.md
+++ b/claude-apps-gateway/docs/deployment.md
@@ -34,14 +34,14 @@ a common failure:
      --inference-config '{"maxTokens":5}' >/dev/null && echo model access OK
    ```
 
-   Not every model has a short-alias inference profile. `claude-opus-4-8`,
+   Not every model has a short-alias inference profile. `claude-opus-5`,
    `claude-sonnet-5`, and `claude-fable-5` do, but **Haiku 4.5 exists only as the
    dated profile** `global.anthropic.claude-haiku-4-5-20251001-v1:0` — the short
    `global.anthropic.claude-haiku-4-5` is rejected as `ValidationException: invalid`.
    Run `aws bedrock list-inference-profiles` for the exact IDs. In `gateway.yaml`'s
    `models:` block the friendly name (`claude-haiku-4-5`) maps to the dated profile;
    for data residency, swap the `global.` prefix for a geo profile (`us.`/`eu.`/`au.`, plus
-   `jp.` for Opus 4.8 and Haiku 4.5 — Sonnet 5 has no `jp.` profile).
+   and `jp.` for some models — geo coverage varies per model).
 2. **An ACM cert** for your gateway hostname, passed as `CERT_ARN` / `-c certArn`.
    On first `/login` the CLI pins the cert's SHA-256 fingerprint and prompts the
    developer to confirm it — intended behavior (the CLI pinning the authentic
@@ -153,7 +153,7 @@ ALLOWED_EMAIL_DOMAINS=example.com \
 # Download the pinned linux-x64 binary and verify it (versions must match the
 # claudeVersion pin in bin/app.ts). setup.sh's phase 2 shows the full
 # GPG-signed-manifest verification; the abbreviated form:
-CLAUDE_VERSION=2.1.218
+CLAUDE_VERSION=2.1.229
 curl -fL -o claude "https://downloads.claude.ai/claude-code-releases/${CLAUDE_VERSION}/linux-x64/claude"
 curl -fsSL "https://downloads.claude.ai/claude-code-releases/${CLAUDE_VERSION}/manifest.json" \
   | jq -r '.platforms["linux-x64"].checksum' | xargs -I{} sh -c 'echo "{}  claude" | shasum -a 256 -c'
@@ -202,7 +202,7 @@ To roll a new image later: push a new tag, then re-run pass 2 with
 > editing `gateway.yaml.template` has no effect until you rebuild **and** point the
 > service at the new image. The tag above is the bare `CLAUDE_VERSION`, which does not
 > change when only the config does — so re-running the build would overwrite
-> `:2.1.218` in place, and re-running pass 2 with the same `-c imageTag` leaves the
+> `:2.1.229` in place, and re-running pass 2 with the same `-c imageTag` leaves the
 > task definition unchanged, meaning ECS may not redeploy at all. Either symptom looks
 > like a successful deploy that silently kept the old config.
 >
@@ -281,7 +281,7 @@ Claude Desktop connects to the same gateway, but through Desktop's own managed
 configuration and a different key — `bootstrapUrl`, pointed at `<public_url>/user/bootstrap`
 — plus a server-side opt-in: the policy matching the user must carry a `desktop` key or
 `/user/bootstrap` returns `404`. The gateway server must be on v2.1.203 or later (this
-example pins 2.1.218). Desktop then runs the same browser SSO and fetches its config from
+example pins 2.1.229). Desktop then runs the same browser SSO and fetches its config from
 the gateway; per-group model access and policy match the CLI's. The endpoint shares the
 gateway's host and port, so the ALB needs no extra listener rule. See the
 [config reference](https://code.claude.com/docs/en/claude-apps-gateway-config#claude-desktop-overlay)

--- a/claude-apps-gateway/docs/gotchas.md
+++ b/claude-apps-gateway/docs/gotchas.md
@@ -438,7 +438,7 @@ config, so a fleet that only uses the CLI is never accidentally exposing a Deskt
 base layer to opt in everyone who inherits it. `desktop: {}` alone is enough; the optional
 feature gates (`isLocalDevMcpEnabled`, `banner`, …) are documented on capability 2 in the
 [README](../README.md#claude-desktop-overlay). The gateway server must be on **v2.1.203+**
-(this example pins 2.1.218). The template ships this block commented out —
+(this example pins 2.1.229). The template ships this block commented out —
 [`cdk/gateway.yaml.template`](../cdk/gateway.yaml.template), under the `match: {}` policy.
 
 **Not the same as** `parentSettingsBehavior: "merge"`. That key governs a *different*
@@ -447,3 +447,39 @@ gateway's policy as parent settings — and lives in the client `managed-setting
 mirrored in the policy's `cli` block), not in the `desktop` block. Missing *that* key fails
 silently with no 404 and no warning; see the ["How developers connect"](../README.md#how-developers-connect)
 section. A full Desktop deployment sets both.
+
+---
+
+## 20. Three ways the `desktop` block itself bites  **[hit live]**
+
+Once `/user/bootstrap` is serving (gotcha 19), the contents of the `desktop` block have
+their own traps. The key/effect table lives in the
+[README](../README.md#claude-desktop-overlay); these are the three failure modes.
+
+**A banner with only `text:` renders nothing.**  **[hit live]**
+`banner: { text: "…" }` looks correct and boots clean, but Desktop shows no banner:
+`enabled` has no default, and `text` only applies when it's truthy. Write
+`banner: { enabled: true, text: "…" }`.
+
+**The Chat tab is hidden unless you ask for it.**
+Cowork and Code default *on*; Chat does not. A `desktop` block that omits
+`chatTabEnabled: true` silently costs Desktop users that tab — nothing in the boot log or
+the bootstrap response flags it. Through 2.1.221 the key wasn't in the schema at all, so
+there was no way to re-enable it from either side (filed upstream as
+[anthropics/claude-code#83723](https://github.com/anthropics/claude-code/issues/83723),
+fixed in 2.1.227, which this example now pins past). It's now a choice rather than a dead
+end, but the default still costs you the tab.
+
+**An unknown key crash-loops the ECS task.**
+The block is validated *strictly* and the accepted key set is bounded by the pinned gateway
+version, so a key copied from the docs page for a newer release fails boot — the container
+exits, ECS restarts it, and the service never stabilises. The README's table is the full set
+as of 2.1.229. Probe a new key against the pinned binary before shipping it:
+
+```bash
+# reports `Unrecognized key(s) in object: '<key>'` if the pin doesn't know it
+claude gateway --config /tmp/probe.yaml
+```
+
+`chatTabEnabled` and `chatAdvancedFileAnalysisEnabled` are the current examples: both need
+**≥ 2.1.227**. See [`upstream-watch.md`](upstream-watch.md) for the version-gate checklist.

--- a/claude-apps-gateway/docs/upstream-watch.md
+++ b/claude-apps-gateway/docs/upstream-watch.md
@@ -11,9 +11,8 @@ Run it **before each version bump** and **when a gateway release ships**.
 ## Current pin
 
 - **Pinned version:** `2.1.229` (see `CLAUDE_VERSION` in `cdk/scripts/setup.sh` and `claudeVersion` in `cdk/bin/app.ts`)
-- **Validated on:** `2.1.218` (live end-to-end: deploy + SSO sign-in + Bedrock inference). The
-  `2.1.229` bump is verified statically only — `npm test`, the bash tests, and a config
-  parse. Re-run the live smoke test before relying on it.
+- **Validated on:** `2.1.229` (live end-to-end: deploy + SSO sign-in + Bedrock inference on
+  Claude Opus 5, plus the Claude Desktop overlay serving a Chat tab via `/user/bootstrap`)
 - **Floor:** `2.1.195` (the `gateway` subcommand floor)
 
 Update the "Pinned version" line here whenever `CLAUDE_VERSION` changes.
@@ -69,21 +68,36 @@ pinned binary before shipping it:
 claude gateway --config /tmp/probe.yaml
 ```
 
+That probe is worth running against *two* binaries — the pin and the release below the
+gate — because it fails fast and needs no AWS: it reaches the config-schema check before
+touching Postgres, so `could not connect to Postgres` already means the schema passed.
+Verified this way for the 2.1.227 gate: `2.1.226` exits with `Unrecognized key(s) in
+object: 'chatTabEnabled', 'chatAdvancedFileAnalysisEnabled'` at
+`managed.policies[0].desktop`, while `2.1.229` gets past `config.load`.
+
 Closed gap: `chatTabEnabled` was missing from the gateway schema through 2.1.221, so a
 bootstrap-configured Desktop lost its Chat tab with no way to re-enable it — filed as
 [anthropics/claude-code#83723](https://github.com/anthropics/claude-code/issues/83723).
 **2.1.227 added the key** (plus `chatAdvancedFileAnalysisEnabled`), and this example now
 pins past it. The issue is still open upstream even though the fix shipped. Note the
 default: Chat is *hidden* unless `chatTabEnabled: true`, so a `desktop` block that omits it
-still costs Desktop users the tab — it's now a choice rather than a dead end.
+still costs Desktop users the tab — it's now a choice rather than a dead end. Confirmed
+live on 2.1.229: with the `desktop` block enabled, Claude Desktop showed the Chat tab.
 
-### 3. Re-check the two facts this example is sensitive to
+### 3. Re-check the facts this example is sensitive to
 
 - **Managed-settings keys.** We ship a live `managed.policies[].cli` block and set
   `enforceAvailableModels: true` with `auto_include_builtin_models`. A model ID or a
   `cli` key newer than the pin fails **at gateway boot** or is rejected server-side
   at `/v1/messages`. Confirm every model in `availableModels` and every `cli` key is
   known to the pinned version. (See the README's Claude Code version prerequisite.)
+- **Model IDs are two claims, not one.** A model can be current in Claude Code and still
+  have no Bedrock inference profile under our `global.` prefix — the release notes don't
+  tell you. Check the upstream side directly before shipping a catalog change:
+  `aws bedrock list-inference-profiles --query "inferenceProfileSummaries[?contains(inferenceProfileId,'<model>')]"`,
+  then one `aws bedrock-runtime converse --model-id global.anthropic.<model>` per entry.
+  Done for the 2.1.229 catalog: `global.anthropic.claude-opus-5` is ACTIVE and all three
+  shipped models return 200.
 - **Bedrock IAM ARN families.** The two-ARN grant (`inference-profile/global.anthropic.*`
   **and** `foundation-model/anthropic.*`) is asserted in the CDK tests. If the docs'
   IAM table changes, update the policy and the test.
@@ -97,6 +111,12 @@ still costs Desktop users the tab — it's now a choice rather than a dead end.
    README's version notes.
 3. Re-run the local verification (`cd cdk && npm test`; `./test/stamp-config.test.sh`;
    `bash -n cdk/scripts/setup.sh`) and add a test case if you're fixing a deployment trap.
+4. Only move the "Validated on" line above after a **live** run: deploy, browser SSO
+   sign-in, and one inference call per model in `availableModels`. Static checks can't
+   catch a model ID Bedrock doesn't serve or a schema key the pin rejects. The
+   laptop-side probe (`/healthz`, `/readyz`, the discovery doc) needs a route to the
+   private ALB — DNS alone isn't proof, since the hostname resolves publicly to its
+   private addresses whether or not the VPN is up. Check the route, not `dig`.
 
 ## Automated reminder
 

--- a/claude-apps-gateway/docs/upstream-watch.md
+++ b/claude-apps-gateway/docs/upstream-watch.md
@@ -10,8 +10,10 @@ Run it **before each version bump** and **when a gateway release ships**.
 
 ## Current pin
 
-- **Pinned version:** `2.1.218` (see `CLAUDE_VERSION` in `cdk/scripts/setup.sh` and `claudeVersion` in `cdk/bin/app.ts`)
-- **Validated on:** `2.1.218` (live end-to-end: deploy + SSO sign-in + Bedrock inference)
+- **Pinned version:** `2.1.229` (see `CLAUDE_VERSION` in `cdk/scripts/setup.sh` and `claudeVersion` in `cdk/bin/app.ts`)
+- **Validated on:** `2.1.218` (live end-to-end: deploy + SSO sign-in + Bedrock inference). The
+  `2.1.229` bump is verified statically only — `npm test`, the bash tests, and a config
+  parse. Re-run the live smoke test before relying on it.
 - **Floor:** `2.1.195` (the `gateway` subcommand floor)
 
 Update the "Pinned version" line here whenever `CLAUDE_VERSION` changes.
@@ -42,31 +44,38 @@ curl -fsSL https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGEL
 ### 2. Look for version tripwires in the docs
 
 Any doc phrase like *"requires v2.1.X or later"* or *"as of vN"* is a gate. If X
-exceeds our pin, we're behind on that feature. Two known ones we already track:
+exceeds our pin, we're behind on that feature. The ones we already track:
 
 - `anthropicAws` (Claude Platform on AWS) provider — **requires ≥ 2.1.198**
 - cross-upstream failover on `404` — **added in 2.1.198**
+- complete-credentials validation on a partial Bedrock `auth:` block — **added in 2.1.207**
 - Claude Desktop bootstrap endpoint (`/user/bootstrap`, the `desktop` policy key) — **requires ≥ 2.1.203**
+- `desktop.chatTabEnabled` + `desktop.chatAdvancedFileAnalysisEnabled` — **require ≥ 2.1.227**
+- `oidc.use_proxy` (gateway's own IdP requests through `HTTPS_PROXY`) — **requires ≥ 2.1.227**
+- `pricing:` block (contracted rates for the spend meter; also needs `admin:`) — **requires ≥ 2.1.227**
+- `model must be a string` → `400` — **added in 2.1.221**; `model is required` → **2.1.228**
 
 **The `desktop` block's key set is bounded by the pin, and the block is validated
 strictly** — an unknown key fails gateway boot (crash-loops the container on ECS), so a
 key copied from the docs page for a newer release takes the deployment down. As of
-`2.1.221` the accepted keys are exactly: `modelDiscoveryEnabled`, `coworkTabEnabled`,
-`isClaudeCodeForDesktopEnabled`, `isDesktopExtensionEnabled`,
-`isDesktopExtensionSignatureRequired`, `isLocalDevMcpEnabled`, `disableAutoUpdates`,
-`autoUpdaterEnforcementHours`, `banner`. Verify a new key against the pinned binary
-before shipping it:
+`2.1.229` the accepted keys are exactly: `modelDiscoveryEnabled`, `coworkTabEnabled`,
+`isClaudeCodeForDesktopEnabled`, `chatTabEnabled`, `chatAdvancedFileAnalysisEnabled`,
+`isDesktopExtensionEnabled`, `isDesktopExtensionSignatureRequired`, `isLocalDevMcpEnabled`,
+`disableAutoUpdates`, `autoUpdaterEnforcementHours`, `banner`. Verify a new key against the
+pinned binary before shipping it:
 
 ```bash
 # boots and reports `Unrecognized key(s) in object: '<key>'` if the pin doesn't know it
 claude gateway --config /tmp/probe.yaml
 ```
 
-Known gap: `chatTabEnabled` exists in Claude Desktop (since build `1.13576.0`) but is
-**not** in the gateway schema through 2.1.221, so a bootstrap-configured Desktop loses its
-Chat tab with no way to re-enable it — filed as
+Closed gap: `chatTabEnabled` was missing from the gateway schema through 2.1.221, so a
+bootstrap-configured Desktop lost its Chat tab with no way to re-enable it — filed as
 [anthropics/claude-code#83723](https://github.com/anthropics/claude-code/issues/83723).
-Re-test on each bump and drop this note if the key lands.
+**2.1.227 added the key** (plus `chatAdvancedFileAnalysisEnabled`), and this example now
+pins past it. The issue is still open upstream even though the fix shipped. Note the
+default: Chat is *hidden* unless `chatTabEnabled: true`, so a `desktop` block that omits it
+still costs Desktop users the tab — it's now a choice rather than a dead end.
 
 ### 3. Re-check the two facts this example is sensitive to
 

--- a/claude-apps-gateway/test/setup-helpers.test.sh
+++ b/claude-apps-gateway/test/setup-helpers.test.sh
@@ -143,10 +143,10 @@ cfg_b="${TMP}/gw-b.yaml"
 printf 'listen:\n  port: 8080\n'                  > "${cfg_a}"
 printf 'listen:\n  port: 8080\nadmin:\n  x: 1\n'  > "${cfg_b}"
 
-tag_a="$(config_image_tag 2.1.218 "${cfg_a}")"
-tag_b="$(config_image_tag 2.1.218 "${cfg_b}")"
+tag_a="$(config_image_tag 2.1.229 "${cfg_a}")"
+tag_b="$(config_image_tag 2.1.229 "${cfg_b}")"
 
-if [[ "${tag_a}" == 2.1.218-* ]]; then
+if [[ "${tag_a}" == 2.1.229-* ]]; then
   pass "tag is prefixed with the pinned version"
 else
   fail "tag is prefixed with the pinned version" "got ${tag_a}"
@@ -159,7 +159,7 @@ else
        "both were ${tag_a} — a config edit would silently reuse the old image"
 fi
 
-if [[ "$(config_image_tag 2.1.218 "${cfg_a}")" == "${tag_a}" ]]; then
+if [[ "$(config_image_tag 2.1.229 "${cfg_a}")" == "${tag_a}" ]]; then
   pass "same version + same config is deterministic (idempotent re-runs)"
 else
   fail "same version + same config is deterministic (idempotent re-runs)"


### PR DESCRIPTION
## What

**1. The pin.** `CLAUDE_VERSION` in `cdk/scripts/setup.sh`, `claudeVersion` in
`cdk/bin/app.ts`, plus the version references in docs and test fixtures. The gain that
matters for this example: 2.1.229 adds SSE keepalive pings on streaming responses, which
prevents idle-timeout disconnects on the **Bedrock** upstream. The ALB idle timeout stays
at 3600s regardless — the ALB has to outlast the stream either way.

**2. Claude Opus 5 replaces Opus 4.8 as the shipped catalog default.** 2.1.219 made
`claude-opus-5` Claude Code's default Opus. The catalog stays at three models (Opus 5,
Sonnet 5, Haiku 4.5) — this is a sample, not a menu.

**3. `chatTabEnabled` ** PR #277 recorded
that the key wasn't in the gateway schema through 2.1.221, so a bootstrap-configured Claude
Desktop lost its **Chat** tab with no way to restore it
([anthropics/claude-code#83723](https://github.com/anthropics/claude-code/issues/83723)).
**2.1.227 added it**, along with `chatAdvancedFileAnalysisEnabled`. Both are now in the
`desktop` key table and the commented template block, flagged `≥ 2.1.227`.


## Also in here

- **The three `desktop`-block traps move from README → `docs/gotchas.md` (entry 20).** The
  README keeps the reference table; gotchas keeps the symptom/why/fix field notes, which is
  the split gotcha 19 already implied.
- **Version gates recorded but deliberately unused:** `oidc.use_proxy`, `pricing:` (both
  ≥ 2.1.227), and the `model`-field validation. Listed in `upstream-watch.md` so the next
  sweep starts from a current list.
- **Softened the per-model `jp.` geo-profile claims**, which were keyed to Opus 4.8. Geo
  coverage varies per model, so the docs now say to confirm each id rather than implying a
  clean prefix substitution.

## Scope

Pin + config template + docs + test fixtures. **No CDK construct changes** — the only stack
delta is the image tag. `gateway.yaml.template` and `gateway.yaml.example` kept in sync; the
`desktop` block stays commented out, so `/user/bootstrap` still returns `404` by default and
`chatTabEnabled: true` ships as a ready-to-uncomment line rather than a live default.

## Verification

`cd cdk && npm test` (17 pass) · `npx cdk synth` both passes · `./test/stamp-config.test.sh`
(9) · `./test/setup-helpers.test.sh` (19) · `shellcheck` + `bash -n cdk/scripts/setup.sh` ·
YAML parse · `availableModels`-vs-catalog cross-check.
