### PR TITLE
fix(claude-apps-gateway): PR #282 doc follow-ups; fix stale Desktop-default comment

### DIFF
--- a/claude-apps-gateway-bootstrap/bootstrap/config/bootstrap-config.example.json
+++ b/claude-apps-gateway-bootstrap/bootstrap/config/bootstrap-config.example.json
@@ -1,6 +1,8 @@
 {
   "allowUserAddedMcpServers": false,
   "chatTabEnabled": true,
+  "coworkTabEnabled": true,
+  "isClaudeCodeForDesktopEnabled": true,
   "coworkWebSearchEnabled": false,
   "disableNonessentialTelemetry": true,
   "disabledBuiltinTools": [

--- a/claude-apps-gateway-bootstrap/bootstrap/server.js
+++ b/claude-apps-gateway-bootstrap/bootstrap/server.js
@@ -147,8 +147,13 @@ app.get('/user/bootstrap', async (req, res) => {
       ? {}
       : { isLocalDevMcpEnabled: cfg.allowUserAddedMcpServers }),
     // Surface toggles (bootstrap-config-v2 schema): chatTabEnabled / coworkTabEnabled /
-    // isClaudeCodeForDesktopEnabled. Emitted only when set in the S3 config so an omitted
-    // key keeps the client default.
+    // isClaudeCodeForDesktopEnabled. Emitted only when set in the S3 config, but the client
+    // defaults are NOT uniform: coworkTabEnabled and isClaudeCodeForDesktopEnabled show unless
+    // set false, while chatTabEnabled is HIDDEN unless explicitly set true (see the gateway
+    // README's Claude Desktop overlay table). Omitting chatTabEnabled from the S3 config costs
+    // Desktop users the Chat tab, not "keeps the default" — set it explicitly if you want Chat
+    // visible. Gateway requires >= 2.1.227 for the key on that side; see
+    // ../../claude-apps-gateway/docs/upstream-watch.md.
     ...(cfg.chatTabEnabled === undefined ? {} : { chatTabEnabled: cfg.chatTabEnabled }),
     ...(cfg.coworkTabEnabled === undefined ? {} : { coworkTabEnabled: cfg.coworkTabEnabled }),
     ...(cfg.isClaudeCodeForDesktopEnabled === undefined

--- a/claude-apps-gateway/README.md
+++ b/claude-apps-gateway/README.md
@@ -243,7 +243,7 @@ and unknown keys **fail gateway boot**:
 The table above is the full accepted key set as of 2.1.229. Three traps bite here — a
 banner that renders nothing, a silently missing Chat tab, and an unknown key that
 crash-loops the ECS task; all three are written up in
-[`docs/gotchas.md`](docs/gotchas.md#20-three-ways-the-desktop-block-itself-bites).
+[`docs/gotchas.md`](docs/gotchas.md#20-three-ways-the-desktop-block-itself-bites--hit-live).
 
 If you don't deploy Claude Desktop, leave `desktop` out entirely — `/user/bootstrap` then
 returns `404` for every user, which is the safe default. Either way, `/user/bootstrap` is
@@ -337,11 +337,11 @@ upstreams:
     auth: {}
 
 models:
-  - id: claude-opus-4-8
-    label: Claude Opus 4.8
+  - id: claude-opus-5
+    label: Claude Opus 5
     upstream_model:
       bedrock-pt: arn:aws:bedrock:us-east-1:111111111111:provisioned-model/abcdef
-      bedrock-od: us.anthropic.claude-opus-4-8
+      bedrock-od: us.anthropic.claude-opus-5
 ```
 
 **Key points:**

--- a/claude-apps-gateway/cdk/README.md
+++ b/claude-apps-gateway/cdk/README.md
@@ -437,9 +437,9 @@ upstreams:
 # Global inference profiles → region-agnostic (see "Regions & data residency")
 auto_include_builtin_models: false
 models:
-  - id: claude-opus-4-8
-    label: Claude Opus 4.8
-    upstream_model: { bedrock: global.anthropic.claude-opus-4-8 }
+  - id: claude-opus-5
+    label: Claude Opus 5
+    upstream_model: { bedrock: global.anthropic.claude-opus-5 }
 ```
 
 **5. Trust the self-signed cert:**

--- a/claude-apps-gateway/docs/deployment.md
+++ b/claude-apps-gateway/docs/deployment.md
@@ -40,7 +40,7 @@ a common failure:
    `global.anthropic.claude-haiku-4-5` is rejected as `ValidationException: invalid`.
    Run `aws bedrock list-inference-profiles` for the exact IDs. In `gateway.yaml`'s
    `models:` block the friendly name (`claude-haiku-4-5`) maps to the dated profile;
-   for data residency, swap the `global.` prefix for a geo profile (`us.`/`eu.`/`au.`, plus
+   for data residency, swap the `global.` prefix for a geo profile (`us.`/`eu.`/`au.`,
    and `jp.` for some models — geo coverage varies per model).
 2. **An ACM cert** for your gateway hostname, passed as `CERT_ARN` / `-c certArn`.
    On first `/login` the CLI pins the cert's SHA-256 fingerprint and prompts the


### PR DESCRIPTION
## What

Three defects left over from #282, all in text/examples the diff's own hunks didn't cover, plus one related bug found independently in `claude-apps-gateway-bootstrap`.

**In `claude-apps-gateway/`:**

1. `README.md:246` — the link to `docs/gotchas.md#20-three-ways-the-desktop-block-itself-bites` was missing GitHub's actual slug suffix. The target heading is `## 20. Three ways the desktop block itself bites **[hit live]**`, and the double space before the bold marker produces a double-hyphen slug (`--hit-live`), matching the repo's existing precedent at `docs/gotchas.md#13-config-is-baked--the-image-is-per-environment`. The link landed at the top of the file instead of the gotcha it pointed to.
2. `docs/deployment.md:43-44` — an orphaned "plus" left over from rewording the `jp.` clause: "...au., plus\nand jp. for some models...".
3. `cdk/README.md` and `README.md` still shipped `claude-opus-4-8` in two example blocks (`cdk/README.md`'s local-dev example, `README.md`'s failover example), directly contradicting the "shipped catalog is Claude Opus 5..." line #282 added earlier in the same files.

**In `claude-apps-gateway-bootstrap/`** (pre-existing, unrelated to #282):

The comment above the `chatTabEnabled` passthrough in `server.js` claimed omitting any of the three Desktop surface toggles "keeps the client default." True for `coworkTabEnabled`/`isClaudeCodeForDesktopEnabled` (show unless `false`), false for `chatTabEnabled` (hidden unless explicitly `true`, per the gateway README's Desktop overlay table). The example config set only 1 of the 3 toggles as a result — now sets all three explicitly, and the comment states the asymmetry.

## Why

All four are mechanical — no design judgment involved, just checking that changed lines are consistent with the rest of the file/repo they live in, not just internally correct. Caught in an independent second-pass review after #282 merged.

## Verification

- `shellcheck cdk/scripts/setup.sh` — clean
- `./test/setup-helpers.test.sh` — 19/19
- `./test/stamp-config.test.sh` — 9/9
- `node --check` on `bootstrap/server.js` — clean
- `node --test test/authorize.test.mjs` (bootstrap) — 5/5
- `grep -rn "2\.1\.218\|claude-opus-4-8"` across `claude-apps-gateway/` — no remaining hits outside two pre-existing, out-of-scope refs (`README.md:174,352`, predate #282, left alone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)