### PR TITLE
feat: add claude-code-on-agentcore-runtime-microvm sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,12 @@ cdk-nag-output.txt
 **/test/
 !claude-code-on-lambda-microvm/**/test/
 !claude-code-on-lambda-microvm/**/test/**
+!claude-code-on-agentcore-runtime-microvm/**/bin/
+!claude-code-on-agentcore-runtime-microvm/**/bin/**
+!claude-code-on-agentcore-runtime-microvm/**/lib/
+!claude-code-on-agentcore-runtime-microvm/**/lib/**
+!claude-code-on-agentcore-runtime-microvm/**/test/
+!claude-code-on-agentcore-runtime-microvm/**/test/**
 **/.next/
 **/__pycache__/
 mkdocs-env/*

--- a/claude-code-on-agentcore-runtime-microvm/.gitignore
+++ b/claude-code-on-agentcore-runtime-microvm/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+cdk.out/
+deployment*.json
+!deployment.example.json
+*.log
+cdk.context.json

--- a/claude-code-on-agentcore-runtime-microvm/README.md
+++ b/claude-code-on-agentcore-runtime-microvm/README.md
@@ -140,6 +140,48 @@ Only the `/portal/*` static asset routes (the SPA shell) are unauthenticated;
 every route that touches session or workspace data requires either the
 Cognito authorizer (portal) or SigV4/IAM (CLI).
 
+## Public access
+
+The API this portal is served from is a **private** API Gateway: its resource
+policy rejects any request that doesn't arrive through the stack's
+`execute-api` VPC interface endpoint. A freshly deployed stack is therefore
+unreachable from a laptop — including the `PortalUrl` — until you give
+yourself a network path into the VPC. `trustedClientCidr` only widens the
+endpoint's security group; on its own it does not create connectivity.
+
+Two ways to get one:
+
+1. **Network into the VPC** — Client VPN, Site-to-Site VPN, Direct Connect,
+   or a Transit Gateway attachment, with `trustedClientCidr` set to the
+   routed client range. Keeps everything private, no public surface.
+2. **Front it with CloudFront** — a distribution using a
+   [VPC origin](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-vpc-origins.html)
+   pointed at an internal ALB whose IP target group is the `execute-api` VPC
+   endpoint's ENIs. CloudFront reaches the ALB over AWS's private network, so
+   the ALB stays internal and the API stays private. Three details matter:
+   - CloudFront must inject an `x-apigw-api-id: <rest-api-id>` origin header.
+     Once the request no longer arrives with the `execute-api` hostname in
+     `Host`, that header is what API Gateway resolves the API from.
+   - Use an ALB rather than an NLB. The ALB re-encrypts to the VPC endpoint
+     without validating its certificate, which sidesteps the certificate
+     mismatch you'd hit passing TLS straight through to a hostname the
+     endpoint's certificate doesn't cover.
+   - Register the CloudFront portal URL as a Cognito callback/logout URL with
+     the `portalPublicUrls` context flag, or the OAuth redirect is rejected:
+
+     ```bash
+     npm run deploy -- --config deployment.json --profile <profile> \
+       -c portalPublicUrls=https://<distribution>.cloudfront.net/v1/portal
+     ```
+
+     Declaring it here rather than editing the user pool client by hand keeps
+     the callback list intact across redeploys.
+
+   Caveat: VPC endpoint ENI IPs are not contractually stable, so a static IP
+   target group can go stale if AWS rescales the endpoint. For anything
+   long-lived, refresh the target group from `describe-vpc-endpoints` on a
+   schedule.
+
 ## Operator CLI
 
 ```bash

--- a/claude-code-on-agentcore-runtime-microvm/README.md
+++ b/claude-code-on-agentcore-runtime-microvm/README.md
@@ -1,0 +1,175 @@
+# Claude Code on Amazon Bedrock AgentCore Runtime
+
+A private, governed Claude Code developer sandbox: each session provisions
+an isolated [Amazon Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock/latest/userguide/agentcore.html)
+microVM (Claude Code CLI + VS Code CLI pre-installed) behind an IAM-authorized
+API, with an interactive shell and S3-backed checkpoint/restore so a
+workspace survives across sessions.
+
+This is a sibling to
+[`claude-code-on-lambda-microvm`](../claude-code-on-lambda-microvm): same
+governed developer-sandbox architecture and API shape, but running on
+AgentCore Runtime (microVM compute type) instead of Lambda MicroVMs. See that
+sample's README for a longer discussion of the underlying access-pattern
+tradeoffs; this README only covers what's specific to the AgentCore Runtime
+implementation.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    CLI["Operator CLI<br/>(client/)"]
+    Portal["Browser Portal<br/>Cognito-gated"]
+
+    subgraph AWS["AWS account"]
+        APIGW["API Gateway<br/>IAM-authorized"]
+        CP["Control Plane<br/>session lifecycle service"]
+        DDB[("DynamoDB<br/>sessions / claims")]
+        S3[("S3<br/>checkpoint bucket")]
+        AR["AgentCore Runtime<br/>microVM container<br/>Claude Code CLI + VS Code CLI"]
+    end
+
+    CLI -- "REST (SigV4)<br/>bootstrap / terminate" --> APIGW --> CP
+    CLI -- "WSS (SigV4)<br/>InvokeAgentRuntimeCommandShell" --> AR
+    Portal -- "REST (Cognito)<br/>/portal/sessions*" --> APIGW
+    Portal -- "browser shell WebSocket" --> AR
+    CP -- "bootstrap / invoke / checkpoint" --> AR
+    CP <--> DDB
+    AR -- "checkpoint.tar.gz on terminate" --> S3
+    AR -- "restore on bootstrap" --> S3
+```
+
+## What gets deployed
+
+- a VPC, KMS key, S3 checkpoint bucket, and DynamoDB sessions/claims tables;
+- a private, IAM-authorized API Gateway backed by the control-plane Lambda;
+- an `AWS::BedrockAgentCore::Runtime` running the `agent-runtime/` container
+  image (Claude Code CLI + VS Code CLI);
+- optionally (`enablePortal`, **on by default**), a Cognito user pool and a
+  small portal Lambda that serves a single-page browser terminal behind a
+  Cognito user pool authorizer.
+
+## Prerequisites
+
+- Node.js 22+, Docker (for the container image build/push), and the AWS CDK
+  CLI (`npx cdk`, bundled via `devDependencies`).
+- An AWS account/region with access to the AgentCore Runtime service and the
+  Bedrock model configured in `bedrockModelId`.
+- An AWS CLI profile with permission to deploy the stack, push to ECR, and
+  (for the portal) manage the Cognito user pool.
+
+## Quick start
+
+Install and validate:
+
+```bash
+npm ci
+npm run build
+npm test
+```
+
+Copy and edit the deployment configuration:
+
+```bash
+cp deployment.example.json deployment.json
+```
+
+At minimum, review `region`, `vpcCidr`, `trustedClientCidr` (the CIDR allowed
+to reach the private API), `bedrockModelId`, and `enablePortal`.
+
+Deploy (builds/pushes the container image, then `cdk deploy`s the stack):
+
+```bash
+npm run deploy -- --config deployment.json --profile <profile> --require-approval never
+```
+
+Confirm the container is healthy without going through the control-plane API
+or the portal:
+
+```bash
+npm run smoke-test -- --profile <profile> --region <region>
+```
+
+## Portal setup and first login
+
+`enablePortal` defaults to `true`. When the stack finishes deploying, read
+the `PortalUrl` and `PortalUserPoolId` outputs:
+
+```bash
+aws cloudformation describe-stacks \
+  --stack-name ClaudeAgentCoreRuntimeStack \
+  --profile <profile> --region <region> \
+  --query "Stacks[0].Outputs"
+```
+
+The portal's Cognito user pool has **self-signup disabled** — there's no
+public signup page, by design. Create the first user yourself:
+
+```bash
+aws cognito-idp admin-create-user \
+  --user-pool-id <PortalUserPoolId> \
+  --username '<user@example.com>' \
+  --user-attributes \
+    Name=email,Value='<user@example.com>' \
+    Name=email_verified,Value=true \
+  --region <region> \
+  --profile <profile>
+```
+
+Cognito emails a temporary password and requires setting a new one at first
+sign-in (password policy: 12+ characters, upper/lower/digit/symbol). To skip
+email delivery and set the temporary password yourself instead, add
+`--message-action SUPPRESS --temporary-password '<TempPassw0rd!>'` to the
+command above — you're still forced to change it on first sign-in.
+
+To log in:
+
+1. Open the `PortalUrl` from the stack outputs.
+2. Choose **Sign in** and complete the Cognito hosted UI flow (temporary
+   password, then a new permanent password on first login).
+3. Back on the portal, choose **Create environment**, name a workspace, and
+   wait for it to reach `RUNNING`.
+4. Choose **Connect** to open the terminal in the browser. From
+   `/workspace`, run `claude`.
+
+The portal only exposes terminal access (`accessMode: "terminal"`). VS Code
+access and other lifecycle operations (`suspend`, `resume`, JSON output) are
+available through the operator CLI — see below.
+
+Only the `/portal/*` static asset routes (the SPA shell) are unauthenticated;
+every route that touches session or workspace data requires either the
+Cognito authorizer (portal) or SigV4/IAM (CLI).
+
+## Operator CLI
+
+```bash
+npm run client -- --profile <profile> --region <region> start
+```
+
+`start` creates or reuses a terminal session and attaches. `list`, `status`,
+`suspend`, `resume`, and `terminate` manage sessions from the same IAM
+principal. Run `npm run client -- --help` for the full command reference.
+
+## Lifecycle and checkpointing
+
+AgentCore Runtime has no native pause primitive and no session
+list/describe API, so `control-plane/` emulates suspend/resume itself:
+`terminate` checkpoints `/workspace` to S3 as a `.tar.gz`, and the next
+`start`/`resume` for the same workspace restores it. Sessions are
+checkpoint-terminated automatically after `idleAfterSeconds` of shell
+inactivity (default 900s), and hit an 8h hard cap regardless of activity.
+The interactive shell connection itself has a 1h TTL — the CLI and portal
+both reconnect automatically.
+
+## Security and limitations
+
+- The API is private and IAM-authorized by default; the portal path adds a
+  Cognito user pool authorizer on top, scoped to `/portal/sessions*`. Static
+  portal assets (HTML/JS/CSS/`config.json`) are intentionally public, since
+  a browser needs to load them before it has a Cognito token.
+- `cdk-nag` (AwsSolutions) is clean with documented suppressions in
+  `infra/lib/nag-acks.ts`, including the portal-specific ones (Cognito
+  advanced-security tier, MFA, and the public static-asset routes above).
+- Advanced security features and MFA on the Cognito user pool are deferred
+  to production hardening, matching the baseline-cost posture of the rest of
+  the sample.

--- a/claude-code-on-agentcore-runtime-microvm/agent-runtime/Dockerfile
+++ b/claude-code-on-agentcore-runtime-microvm/agent-runtime/Dockerfile
@@ -1,0 +1,63 @@
+FROM public.ecr.aws/docker/library/python:3.12-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      bash \
+      ca-certificates \
+      curl \
+      git \
+      gzip \
+      jq \
+      libstdc++6 \
+      nodejs \
+      npm \
+      openssh-client \
+      procps \
+      tar \
+      unzip \
+      util-linux \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd --gid 1000 developer \
+    && useradd --uid 1000 --gid 1000 --create-home --shell /bin/bash developer \
+    && install -d -m 0755 /etc/claude-code \
+    && install -d -o developer -g developer -m 0750 /workspace
+
+COPY tool-versions.json /opt/claude-agentcore/tool-versions.json
+
+RUN CLAUDE_CODE_VERSION="$(jq --exit-status --raw-output \
+      '.claudeCode.version' /opt/claude-agentcore/tool-versions.json)" \
+    && CLAUDE_CODE_SHA256="$(jq --exit-status --raw-output \
+      '.claudeCode.sha256' /opt/claude-agentcore/tool-versions.json)" \
+    && curl --fail --location --silent --show-error \
+      "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/${CLAUDE_CODE_VERSION}/linux-arm64/claude" \
+      --output /usr/local/bin/claude \
+    && echo "${CLAUDE_CODE_SHA256}  /usr/local/bin/claude" | sha256sum --check --strict \
+    && chmod 0755 /usr/local/bin/claude
+
+RUN VSCODE_CLI_VERSION="$(jq --exit-status --raw-output \
+      '.vscodeCli.version' /opt/claude-agentcore/tool-versions.json)" \
+    && VSCODE_CLI_COMMIT="$(jq --exit-status --raw-output \
+      '.vscodeCli.commit' /opt/claude-agentcore/tool-versions.json)" \
+    && VSCODE_CLI_SHA256="$(jq --exit-status --raw-output \
+      '.vscodeCli.sha256' /opt/claude-agentcore/tool-versions.json)" \
+    && curl --fail --location --silent --show-error \
+      "https://update.code.visualstudio.com/commit:${VSCODE_CLI_COMMIT}/cli-alpine-arm64/stable" \
+      --output /tmp/vscode-cli.tar.gz \
+    && echo "${VSCODE_CLI_SHA256}  /tmp/vscode-cli.tar.gz" | sha256sum --check --strict \
+    && tar -xzf /tmp/vscode-cli.tar.gz -C /usr/local/bin code \
+    && chmod 0755 /usr/local/bin/code \
+    && rm -f /tmp/vscode-cli.tar.gz \
+    && /usr/local/bin/code --version | grep -F "${VSCODE_CLI_VERSION}"
+
+COPY agent.py /opt/claude-agentcore/agent.py
+RUN chown root:root /opt/claude-agentcore/agent.py \
+    && chmod 0755 /opt/claude-agentcore/agent.py \
+    && ln -s /opt/claude-agentcore/agent.py /usr/local/bin/developer-shell
+
+ENV PYTHONUNBUFFERED=1
+EXPOSE 8080
+# AgentCore Runtime HTTP protocol contract: host 0.0.0.0, port 8080,
+# GET /ping, POST /invocations. See
+# docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-http-protocol-contract.html
+ENTRYPOINT ["python3", "-u", "/opt/claude-agentcore/agent.py"]

--- a/claude-code-on-agentcore-runtime-microvm/agent-runtime/agent.py
+++ b/claude-code-on-agentcore-runtime-microvm/agent-runtime/agent.py
@@ -1,0 +1,668 @@
+#!/usr/bin/env python3
+"""AgentCore Runtime HTTP protocol contract server and shell/session helpers.
+
+Implements GET /ping and POST /invocations per the AgentCore Runtime HTTP
+protocol contract (port 8080, host 0.0.0.0). Also runs the Claude Code
+workspace lifecycle: restore /workspace from the S3 checkpoint on the first
+invocation for a runtimeSessionId, and checkpoint back to S3 on a "suspend"
+or "terminate" lifecycle command sent through /invocations.
+
+Terminal access itself goes through AWS's InvokeAgentRuntimeCommandShell,
+which spawns its own PTY session directly against this container (see
+docs/deployment-guide.md); this script does not implement the shell
+WebSocket protocol -- AWS's own service handles that framing. This script
+only handles the one-shot /invocations lifecycle commands the control plane
+sends (session bootstrap, suspend, terminate) and workspace checkpoint I/O.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import gzip
+import hashlib
+import http.client
+import io
+import json
+import logging
+import os
+import pwd
+import re
+import shutil
+import ssl
+import subprocess
+import sys
+import tarfile
+import tempfile
+import threading
+import time
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path, PurePosixPath
+from typing import Any
+from urllib.parse import parse_qs, urlsplit
+
+LOG = logging.getLogger("claude-agentcore-agent")
+
+WORKSPACE = Path("/workspace")
+DEVELOPER_HOME = WORKSPACE / ".claude-home"
+CLAUDE_SETTINGS = DEVELOPER_HOME / ".claude" / "settings.json"
+STATE_DIRECTORY = Path("/var/lib/claude-agentcore")
+SESSION_CONFIGURATION = STATE_DIRECTORY / "session.json"
+CLAUDE_BINARY = Path("/usr/local/bin/claude")
+
+WORKSPACE_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+SESSION_ID_PATTERN = re.compile(r"^[A-Za-z0-9-]{1,128}$")
+OWNER_HASH_PATTERN = re.compile(r"^[a-f0-9]{64}$")
+AWS_REGION_PATTERN = re.compile(r"^[a-z]{2}(?:-gov)?-[a-z]+-\d$")
+BEDROCK_MODEL_PATTERN = re.compile(
+    r"^(?:(?:us|eu|au|global)\.)?"
+    r"anthropic\.claude-[A-Za-z0-9._:-]{1,180}$"
+)
+
+MAX_RUN_HOOK_PAYLOAD_BYTES = 4 * 1024
+MAX_DECODED_RUN_HOOK_PAYLOAD_BYTES = 16 * 1024
+COMPRESSED_RUN_HOOK_PAYLOAD_PREFIX = "gzip-base64:"
+MAX_CHECKPOINT_BYTES = int(
+    os.environ.get("MAX_CHECKPOINT_BYTES", str(128 * 1024 * 1024))
+)
+MAX_EXTRACTED_BYTES = int(
+    os.environ.get("MAX_EXTRACTED_BYTES", str(1024 * 1024 * 1024))
+)
+MAX_ARCHIVE_MEMBERS = 200_000
+CHECKPOINT_TIMEOUT_SECONDS = 50
+
+
+@dataclass(frozen=True)
+class Session:
+    session_id: str
+    owner_hash: str
+    workspace_id: str
+    aws_region: str
+    inference_mode: str
+    bedrock_model_id: str | None
+    checkpoint_download_url: str | None
+    checkpoint_upload_url: str
+    access_mode: str = "terminal"
+
+
+class Runtime:
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._session: Session | None = None
+        self._checkpoint_current = False
+
+    def bootstrap(self, payload: str) -> dict[str, Any]:
+        session = parse_run_hook_payload(payload)
+        with self._lock:
+            if self._session and self._session != session:
+                raise ValueError("A different session is already initialized")
+            if self._session:
+                return {"status": "already-initialized"}
+
+            STATE_DIRECTORY.mkdir(parents=True, exist_ok=True, mode=0o700)
+            checkpoint = download_checkpoint(session)
+            try:
+                if checkpoint:
+                    restore_workspace(checkpoint)
+                else:
+                    reset_workspace()
+            finally:
+                if checkpoint:
+                    checkpoint.unlink(missing_ok=True)
+
+            initialize_developer_home()
+            write_terminal_defaults()
+            write_session_configuration(session)
+            self._session = session
+            self._checkpoint_current = False
+            LOG.info(
+                "session initialized",
+                extra={"session_id": session.session_id},
+            )
+        return {"status": "initialized", "sessionId": session.session_id}
+
+    def checkpoint(self, operation: str) -> dict[str, Any]:
+        with self._lock:
+            if not self._session:
+                return {"status": "no-active-session"}
+            if self._checkpoint_current:
+                return {"status": "already-current"}
+            archive = create_workspace_archive()
+            try:
+                upload_checkpoint(self._session, archive)
+                self._checkpoint_current = True
+            finally:
+                archive.unlink(missing_ok=True)
+        LOG.info("workspace checkpoint uploaded", extra={"operation": operation})
+        return {"status": "checkpointed", "operation": operation}
+
+
+RUNTIME = Runtime()
+
+
+def parse_run_hook_payload(value: str) -> Session:
+    decoded = decode_run_hook_payload(value)
+    try:
+        payload = json.loads(decoded)
+    except json.JSONDecodeError as error:
+        raise ValueError("runHookPayload is not valid JSON") from error
+    if not isinstance(payload, dict) or payload.get("version") != 1:
+        raise ValueError("Unsupported run hook payload")
+
+    session_id = required_string(payload, "sessionId", 128)
+    owner_hash = required_string(payload, "ownerHash", 64)
+    workspace_id = required_string(payload, "workspaceId", 64)
+    aws_region = required_string(payload, "awsRegion", 32)
+    if not AWS_REGION_PATTERN.fullmatch(aws_region):
+        raise ValueError("Invalid awsRegion")
+    inference_mode = required_string(payload, "inferenceMode", 32)
+    if inference_mode not in ("bedrock", "claude-ai", "claude-gateway"):
+        raise ValueError("Unsupported inferenceMode")
+    bedrock_model_id = (
+        required_string(payload, "bedrockModelId", 220)
+        if inference_mode == "bedrock"
+        else None
+    )
+    if bedrock_model_id is not None and not BEDROCK_MODEL_PATTERN.fullmatch(
+        bedrock_model_id
+    ):
+        raise ValueError("Invalid bedrockModelId")
+    checkpoint = payload.get("checkpoint")
+    if not isinstance(checkpoint, dict):
+        raise ValueError("checkpoint must be an object")
+    download_value = checkpoint.get("downloadUrl")
+    checkpoint_download_url = (
+        download_value if isinstance(download_value, str) and download_value else None
+    )
+    checkpoint_upload_url = required_string(checkpoint, "uploadUrl", 8_000)
+
+    if not SESSION_ID_PATTERN.fullmatch(session_id):
+        raise ValueError("Invalid sessionId")
+    if not OWNER_HASH_PATTERN.fullmatch(owner_hash):
+        raise ValueError("Invalid ownerHash")
+    if not WORKSPACE_ID_PATTERN.fullmatch(workspace_id):
+        raise ValueError("Invalid workspaceId")
+
+    return Session(
+        session_id=session_id,
+        owner_hash=owner_hash,
+        workspace_id=workspace_id,
+        aws_region=aws_region,
+        inference_mode=inference_mode,
+        bedrock_model_id=bedrock_model_id,
+        checkpoint_download_url=checkpoint_download_url,
+        checkpoint_upload_url=checkpoint_upload_url,
+    )
+
+
+def decode_run_hook_payload(value: str) -> str:
+    if not value.startswith(COMPRESSED_RUN_HOOK_PAYLOAD_PREFIX):
+        return value
+    encoded = value.removeprefix(COMPRESSED_RUN_HOOK_PAYLOAD_PREFIX)
+    try:
+        compressed = base64.b64decode(encoded, validate=True)
+        with gzip.GzipFile(fileobj=io.BytesIO(compressed)) as stream:
+            decoded = stream.read(MAX_DECODED_RUN_HOOK_PAYLOAD_BYTES + 1)
+    except (binascii.Error, EOFError, OSError) as error:
+        raise ValueError("runHookPayload compression is invalid") from error
+    if len(decoded) > MAX_DECODED_RUN_HOOK_PAYLOAD_BYTES:
+        raise ValueError("runHookPayload exceeds the decoded size limit")
+    return decoded.decode("utf-8")
+
+
+def required_string(value: dict[str, Any], key: str, max_length: int) -> str:
+    result = value.get(key)
+    if (
+        not isinstance(result, str)
+        or not result
+        or len(result.encode("utf-8")) > max_length
+    ):
+        raise ValueError(f"{key} must be a non-empty string")
+    return result
+
+
+def write_terminal_defaults() -> None:
+    developer = pwd.getpwnam("developer")
+    settings: dict[str, Any] = {}
+    if CLAUDE_SETTINGS.exists():
+        try:
+            value = json.loads(CLAUDE_SETTINGS.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            value = {}
+        if isinstance(value, dict):
+            settings = value
+    settings.setdefault("theme", "dark-ansi")
+    settings.setdefault("tui", "fullscreen")
+    CLAUDE_SETTINGS.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    os.chown(CLAUDE_SETTINGS.parent, developer.pw_uid, developer.pw_gid)
+    atomic_json_write(
+        CLAUDE_SETTINGS,
+        settings,
+        mode=0o600,
+        owner=developer.pw_uid,
+        group=developer.pw_gid,
+    )
+
+
+def session_environment(session: Session) -> dict[str, str]:
+    environment = {
+        "AWS_REGION": session.aws_region,
+        "AWS_DEFAULT_REGION": session.aws_region,
+        "HOME": str(WORKSPACE / ".home"),
+        "USER": "developer",
+        "SHELL": "/bin/bash",
+        "TERM": "xterm-256color",
+        "PATH": "/usr/local/bin:/usr/bin:/bin",
+        "CLAUDE_CONFIG_DIR": str(CLAUDE_SETTINGS.parent),
+        "DISABLE_AUTOUPDATER": "1",
+        "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+    }
+    if session.inference_mode == "bedrock" and session.bedrock_model_id:
+        environment["CLAUDE_CODE_USE_BEDROCK"] = "1"
+        environment["ANTHROPIC_MODEL"] = session.bedrock_model_id
+    return environment
+
+
+def write_session_configuration(session: Session) -> None:
+    environment = session_environment(session)
+    developer = pwd.getpwnam("developer")
+    STATE_DIRECTORY.mkdir(parents=True, exist_ok=True)
+    os.chown(STATE_DIRECTORY, 0, developer.pw_gid)
+    os.chmod(STATE_DIRECTORY, 0o750)
+    atomic_json_write(
+        SESSION_CONFIGURATION,
+        {"environment": environment},
+        mode=0o640,
+        owner=0,
+        group=developer.pw_gid,
+    )
+
+
+def load_session_environment() -> dict[str, str]:
+    try:
+        value = json.loads(SESSION_CONFIGURATION.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise RuntimeError("Session configuration is unavailable") from error
+    environment = value.get("environment") if isinstance(value, dict) else None
+    if not isinstance(environment, dict):
+        raise RuntimeError("Session environment is invalid")
+    return environment
+
+
+def require_developer_user(launcher: str) -> None:
+    developer = pwd.getpwnam("developer")
+    if os.geteuid() != developer.pw_uid:
+        raise RuntimeError(f"{launcher} must run as the developer user")
+
+
+def launch_shell() -> None:
+    require_developer_user("developer-shell")
+    environment = load_session_environment()
+    os.chdir(WORKSPACE)
+    os.umask(0o027)
+    os.execve("/bin/bash", ["/bin/bash", "--login"], environment)
+
+
+def download_checkpoint(session: Session) -> Path | None:
+    if not session.checkpoint_download_url:
+        return None
+    target = checkpoint_target(session.checkpoint_download_url, session.aws_region)
+    connection = https_connection(target)
+    try:
+        connection.request("GET", target[2])
+        response = connection.getresponse()
+        if response.status == 404:
+            response.read()
+            return None
+        if response.status != 200:
+            response.read(64 * 1024)
+            raise RuntimeError(
+                f"Checkpoint download failed with HTTP {response.status}"
+            )
+        descriptor, name = tempfile.mkstemp(
+            prefix="checkpoint-download-", suffix=".tar.gz", dir=STATE_DIRECTORY
+        )
+        try:
+            with os.fdopen(descriptor, "wb") as destination:
+                received = 0
+                while chunk := response.read(1024 * 1024):
+                    received += len(chunk)
+                    if received > MAX_CHECKPOINT_BYTES:
+                        raise RuntimeError("Checkpoint exceeds the size limit")
+                    destination.write(chunk)
+            return Path(name)
+        except Exception:
+            Path(name).unlink(missing_ok=True)
+            raise
+    finally:
+        connection.close()
+
+
+def upload_checkpoint(session: Session, archive: Path) -> None:
+    size = archive.stat().st_size
+    if size > MAX_CHECKPOINT_BYTES:
+        raise RuntimeError(f"Compressed checkpoint is {size} bytes; limit exceeded")
+    target = checkpoint_target(session.checkpoint_upload_url, session.aws_region)
+    connection = https_connection(target)
+    try:
+        connection.putrequest("PUT", target[2])
+        connection.putheader("Content-Type", "application/gzip")
+        connection.putheader("Content-Length", str(size))
+        connection.endheaders()
+        with archive.open("rb") as source:
+            while chunk := source.read(1024 * 1024):
+                connection.send(chunk)
+        response = connection.getresponse()
+        response.read(64 * 1024)
+        if response.status != 200:
+            raise RuntimeError(f"Checkpoint upload failed with HTTP {response.status}")
+    finally:
+        connection.close()
+
+
+def checkpoint_target(value: str, region: str) -> tuple[str, int, str]:
+    parsed = urlsplit(value)
+    hostname = parsed.hostname or ""
+    query = parse_qs(parsed.query)
+    expected_suffix = f".s3.{region}.amazonaws.com"
+    if (
+        parsed.scheme != "https"
+        or not hostname
+        or (
+            hostname != f"s3.{region}.amazonaws.com"
+            and not hostname.endswith(expected_suffix)
+        )
+        or "X-Amz-Signature" not in query
+    ):
+        raise ValueError("Checkpoint URL is not an approved S3 URL")
+    return hostname, parsed.port or 443, f"{parsed.path}?{parsed.query}"
+
+
+def https_connection(target: tuple[str, int, str]) -> http.client.HTTPSConnection:
+    return http.client.HTTPSConnection(
+        target[0],
+        target[1],
+        timeout=CHECKPOINT_TIMEOUT_SECONDS,
+        context=ssl.create_default_context(),
+    )
+
+
+def atomic_json_write(
+    path: Path, value: dict[str, Any], *, mode: int, owner: int, group: int
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary = Path(name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as destination:
+            json.dump(value, destination, separators=(",", ":"), sort_keys=True)
+            destination.write("\n")
+        os.chmod(temporary, mode)
+        os.chown(temporary, owner, group)
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def reset_workspace() -> None:
+    staging = Path(tempfile.mkdtemp(prefix="workspace-empty-", dir=STATE_DIRECTORY))
+    install_workspace(staging)
+
+
+def restore_workspace(archive: Path) -> None:
+    staging = Path(tempfile.mkdtemp(prefix="workspace-restore-", dir=STATE_DIRECTORY))
+    try:
+        extract_archive_safely(archive, staging)
+        install_workspace(staging)
+    except Exception:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+
+
+def install_workspace(staging: Path) -> None:
+    if WORKSPACE.exists():
+        shutil.rmtree(WORKSPACE)
+    os.replace(staging, WORKSPACE)
+    os.chmod(WORKSPACE, 0o750)
+    chown_tree(WORKSPACE, "developer")
+
+
+def initialize_developer_home() -> None:
+    developer = pwd.getpwnam("developer")
+    DEVELOPER_HOME.mkdir(parents=True, exist_ok=True, mode=0o700)
+    os.chmod(DEVELOPER_HOME, 0o700)
+    os.chown(DEVELOPER_HOME, developer.pw_uid, developer.pw_gid)
+    home = WORKSPACE / ".home"
+    home.mkdir(parents=True, exist_ok=True, mode=0o700)
+    os.chown(home, developer.pw_uid, developer.pw_gid)
+
+
+def extract_archive_safely(archive: Path, destination: Path) -> None:
+    regular_members: list[tuple[tarfile.TarInfo, Path]] = []
+    directory_members: list[tuple[tarfile.TarInfo, Path]] = []
+    symlink_members: list[tuple[tarfile.TarInfo, Path]] = []
+    seen: set[Path] = set()
+    extracted_bytes = 0
+
+    with tarfile.open(archive, mode="r:gz") as source:
+        members = source.getmembers()
+        if len(members) > MAX_ARCHIVE_MEMBERS:
+            raise ValueError("Checkpoint contains too many members")
+        for member in members:
+            relative = safe_member_path(member.name)
+            if relative == Path("."):
+                continue
+            if relative in seen:
+                raise ValueError("Checkpoint contains duplicate paths")
+            seen.add(relative)
+            target = destination / relative
+            if member.isdir():
+                directory_members.append((member, target))
+            elif member.isreg():
+                if member.size < 0:
+                    raise ValueError("Checkpoint contains an invalid file size")
+                extracted_bytes += member.size
+                if extracted_bytes > MAX_EXTRACTED_BYTES:
+                    raise ValueError("Checkpoint expands beyond the configured limit")
+                regular_members.append((member, target))
+            elif member.issym():
+                validate_symlink(relative, member.linkname)
+                symlink_members.append((member, target))
+            else:
+                raise ValueError(f"Unsupported checkpoint member: {member.name}")
+
+        for member, target in sorted(
+            directory_members, key=lambda item: len(item[1].parts)
+        ):
+            target.mkdir(parents=True, exist_ok=True)
+            os.chmod(target, safe_mode(member.mode, directory=True))
+        for member, target in regular_members:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            source_file = source.extractfile(member)
+            if source_file is None:
+                raise ValueError("Checkpoint file content is unavailable")
+            with source_file, target.open("xb") as destination_file:
+                shutil.copyfileobj(source_file, destination_file, 1024 * 1024)
+            os.chmod(target, safe_mode(member.mode, directory=False))
+        for member, target in symlink_members:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            os.symlink(member.linkname, target)
+
+
+def safe_member_path(name: str) -> Path:
+    if "\x00" in name:
+        raise ValueError("Checkpoint contains a NUL path")
+    value = PurePosixPath(name)
+    if value.is_absolute():
+        raise ValueError("Checkpoint contains an absolute path")
+    parts = [part for part in value.parts if part not in ("", ".")]
+    if any(part == ".." for part in parts):
+        raise ValueError("Checkpoint path escapes the workspace")
+    if not parts:
+        return Path(".")
+    return Path(*parts)
+
+
+def validate_symlink(relative: Path, linkname: str) -> None:
+    link = PurePosixPath(linkname)
+    if link.is_absolute() or "\x00" in linkname:
+        raise ValueError("Checkpoint contains an unsafe symbolic link")
+    depth = len(relative.parent.parts)
+    for part in link.parts:
+        if part in ("", "."):
+            continue
+        if part == "..":
+            depth -= 1
+            if depth < 0:
+                raise ValueError("Symbolic link escapes the workspace")
+        else:
+            depth += 1
+
+
+def safe_mode(mode: int, directory: bool) -> int:
+    permissions = mode & 0o777
+    if directory:
+        return permissions or 0o750
+    return permissions or 0o640
+
+
+def create_workspace_archive() -> Path:
+    STATE_DIRECTORY.mkdir(parents=True, exist_ok=True, mode=0o700)
+    descriptor, name = tempfile.mkstemp(
+        prefix="checkpoint-upload-", suffix=".tar.gz", dir=STATE_DIRECTORY
+    )
+    os.close(descriptor)
+    archive = Path(name)
+    total_bytes = 0
+
+    def archive_filter(member: tarfile.TarInfo) -> tarfile.TarInfo | None:
+        nonlocal total_bytes
+        member.uid = 1000
+        member.gid = 1000
+        member.uname = "developer"
+        member.gname = "developer"
+        member.mode &= 0o777
+        if member.isreg():
+            total_bytes += member.size
+            if total_bytes > MAX_EXTRACTED_BYTES:
+                raise RuntimeError("Workspace exceeds the checkpoint limit")
+            return member
+        if member.isdir():
+            return member
+        if member.issym():
+            relative = safe_member_path(member.name)
+            validate_symlink(relative, member.linkname)
+            return member
+        return None
+
+    try:
+        with tarfile.open(
+            archive, mode="w:gz", compresslevel=6, dereference=False
+        ) as destination:
+            for child in sorted(WORKSPACE.iterdir(), key=lambda item: item.name):
+                destination.add(
+                    child, arcname=child.name, recursive=True, filter=archive_filter
+                )
+        if archive.stat().st_size > MAX_CHECKPOINT_BYTES:
+            raise RuntimeError("Compressed checkpoint exceeds the size limit")
+        return archive
+    except Exception:
+        archive.unlink(missing_ok=True)
+        raise
+
+
+def chown_tree(root: Path, username: str) -> None:
+    user = pwd.getpwnam(username)
+    os.chown(root, user.pw_uid, user.pw_gid, follow_symlinks=False)
+    for directory, directories, files in os.walk(root, topdown=True, followlinks=False):
+        for name in directories + files:
+            path = Path(directory) / name
+            os.chown(path, user.pw_uid, user.pw_gid, follow_symlinks=False)
+
+
+class HookHandler(BaseHTTPRequestHandler):
+    server_version = "claude-agentcore-agent"
+    sys_version = ""
+
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path == "/ping":
+            self._json_response(200, {"status": "Healthy"})
+            return
+        self._json_response(404, {"message": "Not found"})
+
+    def do_POST(self) -> None:  # noqa: N802
+        if self.path != "/invocations":
+            self._json_response(404, {"message": "Not found"})
+            return
+        try:
+            body = self._read_json_body()
+            command = body.get("command")
+            if command == "bootstrap":
+                result = RUNTIME.bootstrap(body.get("payload", ""))
+            elif command in ("suspend", "terminate"):
+                result = RUNTIME.checkpoint(command)
+            else:
+                self._json_response(400, {"message": "Unknown command"})
+                return
+            self._json_response(200, {"response": result, "status": "success"})
+        except (ValueError, TypeError, KeyError) as error:
+            LOG.warning("invalid invocation request: %s", error)
+            self._json_response(400, {"message": "Invalid request"})
+        except Exception:
+            LOG.exception("invocation failed")
+            self._json_response(500, {"message": "Invocation failed"})
+
+    def log_message(self, format_string: str, *args: object) -> None:
+        LOG.info("hook http: " + format_string, *args)
+
+    def _read_json_body(self) -> dict[str, Any]:
+        raw_length = self.headers.get("Content-Length", "0")
+        try:
+            length = int(raw_length)
+        except ValueError as error:
+            raise ValueError("Invalid Content-Length") from error
+        if length < 0 or length > MAX_RUN_HOOK_PAYLOAD_BYTES * 4:
+            raise ValueError("Request body is too large")
+        encoded = self.rfile.read(length)
+        if not encoded:
+            return {}
+        value = json.loads(encoded)
+        if not isinstance(value, dict):
+            raise ValueError("Request body must be an object")
+        return value
+
+    def _json_response(self, status: int, value: dict[str, Any]) -> None:
+        encoded = json.dumps(value, separators=(",", ":")).encode()
+        self.send_response(status)
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+
+class HookServer(ThreadingHTTPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+
+
+def serve_hooks() -> None:
+    STATE_DIRECTORY.mkdir(parents=True, exist_ok=True, mode=0o700)
+    server = HookServer(("0.0.0.0", 8080), HookHandler)
+    LOG.info("AgentCore Runtime HTTP contract server listening on port 8080")
+    server.serve_forever(poll_interval=0.5)
+
+
+logging.basicConfig(
+    level=os.environ.get("LOG_LEVEL", "INFO").upper(),
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+)
+
+
+if __name__ == "__main__":
+    launcher = Path(sys.argv[0]).name
+    if launcher == "developer-shell" or sys.argv[1:] == ["--shell"]:
+        launch_shell()
+    else:
+        serve_hooks()

--- a/claude-code-on-agentcore-runtime-microvm/agent-runtime/agent.py
+++ b/claude-code-on-agentcore-runtime-microvm/agent-runtime/agent.py
@@ -253,6 +253,7 @@ def session_environment(session: Session) -> dict[str, str]:
         "USER": "developer",
         "SHELL": "/bin/bash",
         "TERM": "xterm-256color",
+        "COLORTERM": "truecolor",
         "PATH": "/usr/local/bin:/usr/bin:/bin",
         "CLAUDE_CONFIG_DIR": str(CLAUDE_SETTINGS.parent),
         "DISABLE_AUTOUPDATER": "1",

--- a/claude-code-on-agentcore-runtime-microvm/agent-runtime/tool-versions.json
+++ b/claude-code-on-agentcore-runtime-microvm/agent-runtime/tool-versions.json
@@ -1,0 +1,11 @@
+{
+  "claudeCode": {
+    "version": "2.1.215",
+    "sha256": "2b43a3d5b0787217e5d7381fad42c7314292546fe9db9eb8b9b379de90509b30"
+  },
+  "vscodeCli": {
+    "version": "1.129.1",
+    "commit": "8a7abeba6e03ea3af87bfbce9a1b7e48fed567b8",
+    "sha256": "abd6e9ef317be8ecbbe255954bb76e5c174f15e1b37cf99d82a3d59b798812a6"
+  }
+}

--- a/claude-code-on-agentcore-runtime-microvm/cdk.json
+++ b/claude-code-on-agentcore-runtime-microvm/cdk.json
@@ -1,0 +1,10 @@
+{
+  "app": "npx tsx infra/bin/app.ts",
+  "context": {
+    "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
+    "@aws-cdk/core:checkSecretUsage": true,
+    "@aws-cdk/core:defaultCrossStackReferences": "strong",
+    "@aws-cdk/core:newStyleStackSynthesis": true,
+    "@aws-cdk/aws-ec2:restrictDefaultSecurityGroup": true
+  }
+}

--- a/claude-code-on-agentcore-runtime-microvm/client/src/api.ts
+++ b/claude-code-on-agentcore-runtime-microvm/client/src/api.ts
@@ -1,0 +1,252 @@
+import { Sha256 } from '@aws-crypto/sha256-js';
+import {
+  CloudFormationClient,
+  DescribeStacksCommand,
+} from '@aws-sdk/client-cloudformation';
+import { defaultProvider } from '@aws-sdk/credential-provider-node';
+import { HttpRequest } from '@smithy/protocol-http';
+import { SignatureV4 } from '@smithy/signature-v4';
+
+export interface SessionView {
+  sessionId: string;
+  workspaceId: string;
+  state: string;
+  createdAt: number;
+  updatedAt: number;
+  lastActivityAt: number;
+  runtimeStartedAt?: number;
+  runtimeExpiresAt?: number;
+  failureReason?: string;
+  accessMode?: SessionAccessMode;
+  inferenceMode?: ClaudeInferenceMode;
+}
+
+export type SessionAccessMode = 'terminal' | 'vscode';
+
+export type ClaudeInferenceMode = 'bedrock' | 'claude-ai' | 'claude-gateway';
+
+export interface StartSessionOptions {
+  accessMode?: SessionAccessMode;
+  inferenceMode?: ClaudeInferenceMode;
+}
+
+export interface ConnectResponse {
+  session: SessionView;
+  shellUrl: string;
+  runtimeSessionId: string;
+  shellId: string;
+  tokenExpiresAt: number;
+}
+
+export interface ControlApiOptions {
+  region: string;
+  profile: string;
+  apiUrl?: string;
+  stackName: string;
+}
+
+export interface ControlApi {
+  start(
+    workspaceId?: string,
+    options?: StartSessionOptions,
+  ): Promise<{ created: boolean; session: SessionView }>;
+  list(): Promise<SessionView[]>;
+  get(sessionId: string): Promise<SessionView>;
+  connect(sessionId: string): Promise<ConnectResponse>;
+  suspend(sessionId: string): Promise<SessionView>;
+  resume(sessionId: string): Promise<SessionView>;
+  terminate(sessionId: string): Promise<SessionView>;
+}
+
+export class ApiError extends Error {
+  public constructor(
+    public readonly statusCode: number,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+export class ControlApiClient implements ControlApi {
+  private readonly credentials;
+  private readonly signer;
+  private apiUrl?: URL;
+
+  public constructor(private readonly options: ControlApiOptions) {
+    this.credentials = defaultProvider({ profile: options.profile });
+    this.signer = new SignatureV4({
+      credentials: this.credentials,
+      region: options.region,
+      service: 'execute-api',
+      sha256: Sha256,
+    });
+    if (options.apiUrl) {
+      this.apiUrl = validateApiUrl(options.apiUrl);
+    }
+  }
+
+  public async start(
+    workspaceId?: string,
+    options: StartSessionOptions = {},
+  ): Promise<{ created: boolean; session: SessionView }> {
+    return this.request('POST', '/sessions', {
+      ...(workspaceId ? { workspaceId } : {}),
+      ...(options.accessMode ? { accessMode: options.accessMode } : {}),
+      ...(options.inferenceMode
+        ? { inferenceMode: options.inferenceMode }
+        : {}),
+    });
+  }
+
+  public async list(): Promise<SessionView[]> {
+    const result = await this.request<{ sessions: SessionView[] }>(
+      'GET',
+      '/sessions',
+    );
+    return result.sessions;
+  }
+
+  public async get(sessionId: string): Promise<SessionView> {
+    return this.request('GET', `/sessions/${encodeSessionId(sessionId)}`);
+  }
+
+  public async connect(sessionId: string): Promise<ConnectResponse> {
+    return this.request(
+      'POST',
+      `/sessions/${encodeSessionId(sessionId)}/connect`,
+      {},
+    );
+  }
+
+  public async suspend(sessionId: string): Promise<SessionView> {
+    return this.request(
+      'POST',
+      `/sessions/${encodeSessionId(sessionId)}/suspend`,
+      {},
+    );
+  }
+
+  public async resume(sessionId: string): Promise<SessionView> {
+    return this.request(
+      'POST',
+      `/sessions/${encodeSessionId(sessionId)}/resume`,
+      {},
+    );
+  }
+
+  public async terminate(sessionId: string): Promise<SessionView> {
+    return this.request(
+      'DELETE',
+      `/sessions/${encodeSessionId(sessionId)}`,
+    );
+  }
+
+  private async request<T>(
+    method: string,
+    path: string,
+    body?: Record<string, unknown>,
+  ): Promise<T> {
+    const base = await this.resolveApiUrl();
+    const url = new URL(`${base.pathname.replace(/\/+$/, '')}${path}`, base);
+    const encodedBody = body === undefined ? undefined : JSON.stringify(body);
+    const headers: Record<string, string> = {
+      accept: 'application/json',
+      host: url.host,
+    };
+    if (encodedBody !== undefined) {
+      headers['content-type'] = 'application/json';
+    }
+    const signed = await this.signer.sign(
+      new HttpRequest({
+        protocol: url.protocol,
+        hostname: url.hostname,
+        port: url.port ? Number.parseInt(url.port, 10) : undefined,
+        method,
+        path: url.pathname,
+        headers,
+        body: encodedBody,
+      }),
+    );
+    const requestHeaders = new Headers(signed.headers);
+    requestHeaders.delete('host');
+
+    const response = await fetch(url, {
+      method,
+      headers: requestHeaders,
+      body: encodedBody,
+      redirect: 'error',
+    });
+    return parseControlApiResponse<T>(response);
+  }
+
+  private async resolveApiUrl(): Promise<URL> {
+    if (this.apiUrl) {
+      return this.apiUrl;
+    }
+    const cloudFormation = new CloudFormationClient({
+      region: this.options.region,
+      credentials: this.credentials,
+    });
+    const result = await cloudFormation.send(
+      new DescribeStacksCommand({ StackName: this.options.stackName }),
+    );
+    const output = result.Stacks?.[0]?.Outputs?.find(
+      (candidate) => candidate.OutputKey === 'ControlApiUrl',
+    )?.OutputValue;
+    if (!output) {
+      throw new Error(
+        `Stack ${this.options.stackName} has no ControlApiUrl output`,
+      );
+    }
+    this.apiUrl = validateApiUrl(output);
+    return this.apiUrl;
+  }
+}
+
+async function parseControlApiResponse<T>(response: Response): Promise<T> {
+  const responseText = await response.text();
+  let responseBody: unknown = {};
+  if (responseText) {
+    try {
+      responseBody = JSON.parse(responseText);
+    } catch {
+      throw new ApiError(
+        response.status,
+        `Control API returned non-JSON HTTP ${response.status}`,
+      );
+    }
+  }
+  if (!response.ok) {
+    const message =
+      isRecord(responseBody) && typeof responseBody.message === 'string'
+        ? responseBody.message
+        : `Control API returned HTTP ${response.status}`;
+    throw new ApiError(response.status, message);
+  }
+  return responseBody as T;
+}
+
+function validateApiUrl(value: string): URL {
+  const url = new URL(value);
+  if (
+    url.protocol !== 'https:' ||
+    url.username ||
+    url.password ||
+    url.search ||
+    url.hash
+  ) {
+    throw new Error('Control API URL must be a plain HTTPS URL');
+  }
+  return url;
+}
+
+function encodeSessionId(sessionId: string): string {
+  if (!/^[A-Za-z0-9-]{1,128}$/.test(sessionId)) {
+    throw new Error('Invalid session ID');
+  }
+  return encodeURIComponent(sessionId);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}

--- a/claude-code-on-agentcore-runtime-microvm/client/src/cli.ts
+++ b/claude-code-on-agentcore-runtime-microvm/client/src/cli.ts
@@ -1,0 +1,258 @@
+import process from 'node:process';
+import {
+  ApiError,
+  type ClaudeInferenceMode,
+  ControlApiClient,
+  type SessionView,
+} from './api.js';
+import { attachTerminal } from './terminal.js';
+
+let region = 'us-east-1';
+let profile = 'default';
+let stackName = 'ClaudeAgentCoreRuntimeStack';
+let apiUrl: string | undefined;
+let jsonOutput = false;
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  region = takeOption(args, '--region') ?? 'us-east-1';
+  profile = takeOption(args, '--profile') ?? 'default';
+  stackName = takeOption(args, '--stack') ?? 'ClaudeAgentCoreRuntimeStack';
+  apiUrl =
+    takeOption(args, '--api-url') ?? process.env.CLAUDE_AGENTCORE_API_URL;
+  jsonOutput = takeFlag(args, '--json');
+  const command = args.shift() ?? 'help';
+
+  const client = new ControlApiClient({ region, profile, stackName, apiUrl });
+
+  switch (command) {
+    case 'start': {
+      const noConnect = takeFlag(args, '--no-connect');
+      const inferenceMode = takeClaudeProvider(args);
+      const workspaceId = args.shift();
+      assertNoArguments(args);
+      const result = await client.start(workspaceId, {
+        accessMode: 'terminal',
+        inferenceMode,
+      });
+      printStartResult(result);
+      if (!noConnect) {
+        await attachTerminal(await client.connect(result.session.sessionId));
+      }
+      break;
+    }
+    case 'connect': {
+      const sessionId = requiredArgument(args, 'session ID');
+      assertNoArguments(args);
+      await attachTerminal(await client.connect(sessionId));
+      break;
+    }
+    case 'list': {
+      assertNoArguments(args);
+      const sessions = await client.list();
+      if (jsonOutput) {
+        printJson({ sessions });
+      } else {
+        printSessions(sessions);
+      }
+      break;
+    }
+    case 'status': {
+      const session = await client.get(requiredArgument(args, 'session ID'));
+      assertNoArguments(args);
+      if (jsonOutput) {
+        printJson(session);
+      } else {
+        printSession(session);
+      }
+      break;
+    }
+    case 'suspend':
+      await lifecycleCommand(args, client.suspend.bind(client));
+      break;
+    case 'resume':
+      await lifecycleCommand(args, client.resume.bind(client));
+      break;
+    case 'terminate':
+    case 'delete':
+      await lifecycleCommand(args, client.terminate.bind(client));
+      break;
+    case 'help':
+    case '--help':
+    case '-h':
+      printHelp();
+      break;
+    default:
+      throw new Error(`Unknown command: ${command}`);
+  }
+}
+
+main().catch((error: unknown) => {
+  if (error instanceof ApiError) {
+    process.stderr.write(
+      `Control API error (${error.statusCode}): ${error.message}\n`,
+    );
+  } else {
+    process.stderr.write(
+      `${error instanceof Error ? error.message : 'Unknown error'}\n`,
+    );
+  }
+  process.exitCode = 1;
+});
+
+async function lifecycleCommand(
+  values: string[],
+  operation: (sessionId: string) => Promise<SessionView>,
+): Promise<void> {
+  const sessionId = requiredArgument(values, 'session ID');
+  assertNoArguments(values);
+  const session = await operation(sessionId);
+  if (jsonOutput) {
+    printJson(session);
+  } else {
+    printSession(session);
+  }
+}
+
+function printStartResult(result: {
+  created: boolean;
+  session: SessionView;
+}): void {
+  if (jsonOutput) {
+    printJson(result);
+    return;
+  }
+  process.stdout.write(
+    `${result.created ? 'Started' : 'Using'} terminal session ` +
+      `${result.session.sessionId} for workspace ` +
+      `${result.session.workspaceId} (${result.session.state})\n`,
+  );
+}
+
+function printSessions(sessions: SessionView[]): void {
+  if (sessions.length === 0) {
+    process.stdout.write('No sessions.\n');
+    return;
+  }
+  process.stdout.write(
+    'SESSION ID                            WORKSPACE       ACCESS    STATE         UPDATED\n',
+  );
+  for (const session of sessions) {
+    process.stdout.write(
+      `${session.sessionId.padEnd(37).slice(0, 37)} ` +
+        `${session.workspaceId.padEnd(15).slice(0, 15)} ` +
+        `${(session.accessMode ?? 'terminal').padEnd(9).slice(0, 9)} ` +
+        `${session.state.padEnd(13).slice(0, 13)} ` +
+        `${formatTimestamp(session.updatedAt)}\n`,
+    );
+  }
+}
+
+function printSession(session: SessionView): void {
+  process.stdout.write(
+    [
+      `Session:       ${session.sessionId}`,
+      `Workspace:     ${session.workspaceId}`,
+      `State:         ${session.state}`,
+      `Created:       ${formatTimestamp(session.createdAt)}`,
+      `Updated:       ${formatTimestamp(session.updatedAt)}`,
+      `Last activity: ${formatTimestamp(session.lastActivityAt)}`,
+      `Access:        ${session.accessMode ?? 'terminal'}`,
+      ...(session.inferenceMode
+        ? [`Claude:        ${session.inferenceMode}`]
+        : []),
+      ...(session.runtimeExpiresAt
+        ? [`Expires:       ${formatTimestamp(session.runtimeExpiresAt)}`]
+        : []),
+      ...(session.failureReason
+        ? [`Failure:       ${session.failureReason}`]
+        : []),
+    ].join('\n') + '\n',
+  );
+}
+
+function printHelp(): void {
+  process.stdout.write(`Usage: npm run client -- [global options] <command>
+
+Commands:
+  start [workspace] [options]       Start or reuse a terminal session
+  connect <session-id>              Attach the local terminal
+  list                              List sessions owned by this IAM principal
+  status <session-id>               Show one session
+  suspend <session-id>              Checkpoint (emulated suspend)
+  resume <session-id>               Resume a session
+  terminate <session-id>            Checkpoint and terminate
+
+Session options:
+  --claude-provider <provider>      bedrock, claude-ai, or claude-gateway
+  --no-connect                      Do not attach after terminal start
+
+Global options:
+  --region <region>                 AWS Region (default: us-east-1)
+  --profile <profile>               AWS profile (default: default)
+  --stack <name>                    CloudFormation stack name
+  --api-url <url>                   Skip stack-output discovery
+  --json                            Emit JSON for non-terminal commands
+
+This source-tree CLI is intended for IAM-authorized operator automation.
+`);
+}
+
+function takeClaudeProvider(
+  values: string[],
+): ClaudeInferenceMode | undefined {
+  const value = takeOption(values, '--claude-provider');
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value !== 'bedrock' && value !== 'claude-ai' && value !== 'claude-gateway') {
+    throw new Error(
+      '--claude-provider must be bedrock, claude-ai, or claude-gateway',
+    );
+  }
+  return value;
+}
+
+function takeOption(values: string[], name: string): string | undefined {
+  const index = values.indexOf(name);
+  if (index < 0) {
+    return undefined;
+  }
+  const value = values[index + 1];
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${name} requires a value`);
+  }
+  values.splice(index, 2);
+  return value;
+}
+
+function takeFlag(values: string[], name: string): boolean {
+  const index = values.indexOf(name);
+  if (index < 0) {
+    return false;
+  }
+  values.splice(index, 1);
+  return true;
+}
+
+function requiredArgument(values: string[], label: string): string {
+  const value = values.shift();
+  if (!value) {
+    throw new Error(`Missing ${label}`);
+  }
+  return value;
+}
+
+function assertNoArguments(values: string[]): void {
+  if (values.length > 0) {
+    throw new Error(`Unexpected argument: ${values[0]}`);
+  }
+}
+
+function formatTimestamp(value: number): string {
+  return new Date(value * 1000).toISOString();
+}
+
+function printJson(value: unknown): void {
+  process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+}

--- a/claude-code-on-agentcore-runtime-microvm/client/src/cli.ts
+++ b/claude-code-on-agentcore-runtime-microvm/client/src/cli.ts
@@ -5,7 +5,7 @@ import {
   ControlApiClient,
   type SessionView,
 } from './api.js';
-import { attachTerminal } from './terminal.js';
+import { attachTerminal, developerShellBootstrapCommand } from './terminal.js';
 
 let region = 'us-east-1';
 let profile = 'default';
@@ -37,14 +37,18 @@ async function main(): Promise<void> {
       });
       printStartResult(result);
       if (!noConnect) {
-        await attachTerminal(await client.connect(result.session.sessionId));
+        await attachTerminal(await client.connect(result.session.sessionId), {
+          bootstrapCommand: developerShellBootstrapCommand(),
+        });
       }
       break;
     }
     case 'connect': {
       const sessionId = requiredArgument(args, 'session ID');
       assertNoArguments(args);
-      await attachTerminal(await client.connect(sessionId));
+      await attachTerminal(await client.connect(sessionId), {
+        bootstrapCommand: developerShellBootstrapCommand(),
+      });
       break;
     }
     case 'list': {

--- a/claude-code-on-agentcore-runtime-microvm/client/src/shell-protocol.ts
+++ b/claude-code-on-agentcore-runtime-microvm/client/src/shell-protocol.ts
@@ -1,0 +1,92 @@
+// Binary channel-prefix framer for InvokeAgentRuntimeCommandShell.
+//
+// Wire format (identical to Kubernetes v5.channel.k8s.io, confirmed against
+// the bedrock_agentcore Python SDK's runtime/shell/protocol.py):
+//   [1-byte channel ID][payload bytes]
+//
+// Channels:
+//   0x00  STDIN      Raw bytes, client -> shell
+//   0x01  STDOUT     Raw bytes, shell -> client
+//   0x02  STDERR     UTF-8 text (platform diagnostics), shell -> client
+//   0x03  STATUS     metav1.Status JSON, shell -> client (connection
+//                     confirmation with metadata.shellId, or shell exit)
+//   0x04  RESIZE     JSON {"width":N,"height":N}, client -> shell
+//   0x05  HEARTBEAT  Empty payload, bidirectional keepalive
+//   0xFF  CLOSE      Empty payload, bidirectional graceful shutdown
+export enum ShellChannel {
+  Stdin = 0x00,
+  Stdout = 0x01,
+  Stderr = 0x02,
+  Status = 0x03,
+  Resize = 0x04,
+  Heartbeat = 0x05,
+  Close = 0xff,
+}
+
+const MAX_FRAME_SIZE = 64 * 1024;
+
+export interface ShellFrame {
+  channel: ShellChannel | undefined;
+  rawChannelByte: number;
+  payload: Buffer;
+}
+
+export function decodeShellFrame(frame: Buffer): ShellFrame {
+  if (frame.length === 0) {
+    throw new Error('Cannot decode an empty shell frame');
+  }
+  const rawChannelByte = frame[0]!;
+  const channel = isKnownChannel(rawChannelByte) ? rawChannelByte : undefined;
+  return { channel, rawChannelByte, payload: frame.subarray(1) };
+}
+
+export function encodeStdin(data: string | Buffer): Buffer {
+  const payload = Buffer.isBuffer(data) ? data : Buffer.from(data, 'utf8');
+  if (payload.length > MAX_FRAME_SIZE - 1) {
+    throw new Error(
+      `Payload ${payload.length} bytes exceeds the 64 KB shell frame limit`,
+    );
+  }
+  return Buffer.concat([Buffer.from([ShellChannel.Stdin]), payload]);
+}
+
+export function encodeResize(cols: number, rows: number): Buffer {
+  const payload = Buffer.from(
+    JSON.stringify({ width: cols, height: rows }),
+    'utf8',
+  );
+  return Buffer.concat([Buffer.from([ShellChannel.Resize]), payload]);
+}
+
+export function encodeHeartbeat(): Buffer {
+  return Buffer.from([ShellChannel.Heartbeat]);
+}
+
+export function encodeClose(): Buffer {
+  return Buffer.from([ShellChannel.Close]);
+}
+
+export interface ShellStatus {
+  kind?: string;
+  apiVersion?: string;
+  status?: 'Success' | 'Failure';
+  metadata?: { shellId?: string; reconnected?: boolean };
+  reason?: string;
+  message?: string;
+}
+
+export function parseShellStatus(payload: Buffer): ShellStatus {
+  return JSON.parse(payload.toString('utf8')) as ShellStatus;
+}
+
+function isKnownChannel(value: number): value is ShellChannel {
+  return (
+    value === ShellChannel.Stdin ||
+    value === ShellChannel.Stdout ||
+    value === ShellChannel.Stderr ||
+    value === ShellChannel.Status ||
+    value === ShellChannel.Resize ||
+    value === ShellChannel.Heartbeat ||
+    value === ShellChannel.Close
+  );
+}

--- a/claude-code-on-agentcore-runtime-microvm/client/src/terminal.ts
+++ b/claude-code-on-agentcore-runtime-microvm/client/src/terminal.ts
@@ -1,0 +1,471 @@
+import process from 'node:process';
+import WebSocket, { type RawData } from 'ws';
+import { SignatureV4 } from '@smithy/signature-v4';
+import { HttpRequest } from '@smithy/protocol-http';
+import { Sha256 } from '@aws-crypto/sha256-js';
+import { defaultProvider } from '@aws-sdk/credential-provider-node';
+import type { ConnectResponse } from './api.js';
+
+const DETACH_BYTE = 0x1d;
+const PING_INTERVAL_MILLISECONDS = 1_000;
+const PONG_TIMEOUT_MILLISECONDS = 5_000;
+// InvokeAgentRuntimeCommandShell connections have a documented 1-hour
+// maximum duration (close code 1008); the client must reconnect with the
+// same runtimeSessionId/shellId to continue. See docs/deployment-guide.md
+// ("Interactive shell reconnect") for the full behavior this implements.
+const SHELL_CONNECTION_TTL_MILLISECONDS = 60 * 60 * 1_000;
+const RECONNECT_GRACE_MILLISECONDS = 5_000;
+
+export interface AttachTerminalOptions {
+  bootstrapCommand?: Buffer;
+}
+
+// Reproduce Claude Code's terminal cleanup, same as
+// claude-code-on-lambda-microvm/client/src/terminal.ts.
+export const TERMINAL_RESTORE_SEQUENCE = [
+  '\x1b[?1006l',
+  '\x1b[?1003l',
+  '\x1b[?1002l',
+  '\x1b[?1000l',
+  '\x1b[?1005l',
+  '\x1b[?1015l',
+  '\x1b[?1016l',
+  '\x1b[>4m',
+  '\x1b[<u',
+  '\x1b[?1004l',
+  '\x1b[?2031l',
+  '\x1b[?2004l',
+  '\x1b[?1049l',
+  '\x1b(B\x0f',
+  '\x1b[0m',
+  '\x1b7\x1b[r\x1b8',
+  '\x1b[?25h',
+].join('');
+
+interface TerminalWritable {
+  write(chunk: string | Uint8Array): boolean;
+  once(event: 'drain', listener: () => void): unknown;
+  off(event: 'drain', listener: () => void): unknown;
+}
+
+interface PausableTerminalSource {
+  pause(): unknown;
+  resume(): unknown;
+}
+
+export function createTerminalModeRestorer(output: {
+  readonly isTTY: boolean | undefined;
+  write(chunk: string): unknown;
+}): () => void {
+  let restored = false;
+  return (): void => {
+    if (restored) return;
+    restored = true;
+    if (!output.isTTY) return;
+    try {
+      output.write(TERMINAL_RESTORE_SEQUENCE);
+    } catch {
+      // A closed terminal must not prevent the remaining local cleanup.
+    }
+  };
+}
+
+export class BackpressuredTerminalOutput {
+  private waitingForDrain = false;
+
+  public constructor(
+    private readonly output: TerminalWritable,
+    private readonly source: PausableTerminalSource,
+  ) {}
+
+  public write(chunk: string | Uint8Array): void {
+    if (this.output.write(chunk) || this.waitingForDrain) return;
+    this.waitingForDrain = true;
+    this.source.pause();
+    this.output.once('drain', this.onDrain);
+  }
+
+  public dispose(): void {
+    if (!this.waitingForDrain) return;
+    this.output.off('drain', this.onDrain);
+    this.waitingForDrain = false;
+  }
+
+  private readonly onDrain = (): void => {
+    this.waitingForDrain = false;
+    this.source.resume();
+  };
+}
+
+/**
+ * Attach a local terminal to an AgentCore Runtime interactive shell
+ * (`InvokeAgentRuntimeCommandShell`), transparently reconnecting on the
+ * documented 1-hour connection-duration limit using the same
+ * `runtimeSessionId`/`shellId` pair. Session identity, not the WebSocket
+ * connection, is the unit of continuity here -- see the AgentCore Runtime
+ * "Interactive Shells (Terminals)" docs.
+ */
+export async function attachTerminal(
+  connection: ConnectResponse,
+  options: AttachTerminalOptions = {},
+): Promise<void> {
+  const inputWasRaw = process.stdin.isRaw;
+  const restoreTerminalModes = createTerminalModeRestorer(process.stdout);
+  let bootstrapSent = false;
+
+  const detachRequested = { value: false };
+  process.stdin.resume();
+  if (process.stdin.isTTY) {
+    process.stdin.setRawMode(true);
+  }
+
+  try {
+    let attempt = 0;
+    let shouldReconnect = true;
+    while (shouldReconnect) {
+      attempt += 1;
+      shouldReconnect = await runOneConnection(connection, {
+        bootstrapCommand:
+          attempt === 1 ? options.bootstrapCommand : undefined,
+        alreadyBootstrapped: bootstrapSent,
+        detachRequested,
+        onBootstrapSent: () => {
+          bootstrapSent = true;
+        },
+      });
+    }
+  } finally {
+    restoreTerminalModes();
+    if (process.stdin.isTTY) {
+      process.stdin.setRawMode(Boolean(inputWasRaw));
+    }
+    process.stdin.pause();
+  }
+}
+
+interface RunConnectionOptions {
+  bootstrapCommand?: Buffer;
+  alreadyBootstrapped: boolean;
+  detachRequested: { value: boolean };
+  onBootstrapSent: () => void;
+}
+
+/**
+ * Runs one WebSocket connection to completion. Returns `true` when the
+ * caller should reconnect (TTL expiry / abnormal drop) and `false` when the
+ * session ended normally or the user detached.
+ */
+async function runOneConnection(
+  connection: ConnectResponse,
+  options: RunConnectionOptions,
+): Promise<boolean> {
+  const shellUrl = validateShellUrl(connection.shellUrl);
+  const signedRequest = await signShellUpgrade(
+    shellUrl,
+    connection.runtimeSessionId,
+  );
+
+  const socket = new WebSocket(shellUrl, {
+    headers: signedRequest.headers,
+    followRedirects: false,
+    maxPayload: 1024 * 1024,
+    perMessageDeflate: false,
+  });
+  const terminalOutput = new BackpressuredTerminalOutput(
+    process.stdout,
+    socket,
+  );
+
+  let inputListener: ((data: Buffer) => void) | undefined;
+  let resizeListener: (() => void) | undefined;
+  let outputListener:
+    | ((data: RawData, isBinary: boolean) => void)
+    | undefined;
+  let pingTimer: NodeJS.Timeout | undefined;
+  let ttlTimer: NodeJS.Timeout | undefined;
+  let lastReadAt = Date.now();
+  let terminalError: Error | undefined;
+  let closeCode = 1006;
+  let closeReason = Buffer.alloc(0);
+  let localCloseRequested = false;
+  let ttlReconnectScheduled = false;
+
+  const closed = new Promise<void>((resolve) => {
+    socket.on('error', (error: Error) => {
+      terminalError = error;
+    });
+    socket.once('close', (code: number, reason: Buffer) => {
+      closeCode = code;
+      closeReason = reason;
+      resolve();
+    });
+  });
+
+  outputListener = (data, isBinary): void => {
+    lastReadAt = Date.now();
+    const buffer = asBuffer(data);
+    if (isBinary) {
+      terminalOutput.write(buffer);
+      return;
+    }
+    const text = buffer.toString('utf8');
+    if (!isControlMessage(text)) {
+      terminalOutput.write(text);
+    }
+  };
+  socket.on('message', outputListener);
+  const stopTerminalOutput = (): void => {
+    if (outputListener) socket.off('message', outputListener);
+    terminalOutput.dispose();
+  };
+  const exitListener = (): void => stopTerminalOutput();
+  process.once('exit', exitListener);
+
+  try {
+    await waitForSessionInitialization(socket);
+
+    resizeListener = (): void => {
+      if (socket.readyState !== WebSocket.OPEN) return;
+      socket.send(
+        JSON.stringify({
+          type: 'resize',
+          rows: clampDimension(process.stdout.rows ?? 24),
+          cols: clampDimension(process.stdout.columns ?? 80),
+        }),
+      );
+    };
+    process.stdout.on('resize', resizeListener);
+    resizeListener();
+
+    inputListener = (data: Buffer): void => {
+      const detachAt = data.indexOf(DETACH_BYTE);
+      if (detachAt >= 0) {
+        if (detachAt > 0 && socket.readyState === WebSocket.OPEN) {
+          socket.send(data.subarray(0, detachAt), { binary: true });
+        }
+        localCloseRequested = true;
+        options.detachRequested.value = true;
+        socket.close(1000, 'Client detached');
+        return;
+      }
+      if (socket.readyState === WebSocket.OPEN) {
+        socket.send(data, { binary: true });
+      }
+    };
+    process.stdin.on('data', inputListener);
+
+    socket.on('pong', () => {
+      lastReadAt = Date.now();
+    });
+    pingTimer = setInterval(() => {
+      if (socket.readyState !== WebSocket.OPEN) return;
+      if (Date.now() - lastReadAt > PONG_TIMEOUT_MILLISECONDS) {
+        socket.terminate();
+        return;
+      }
+      socket.ping();
+    }, PING_INTERVAL_MILLISECONDS);
+    pingTimer.unref();
+
+    // Proactively reconnect slightly before the documented 1-hour TTL so
+    // the client controls the cutover instead of racing close code 1008.
+    ttlTimer = setTimeout(() => {
+      ttlReconnectScheduled = true;
+      socket.close(1000, 'Proactive TTL reconnect');
+    }, SHELL_CONNECTION_TTL_MILLISECONDS - RECONNECT_GRACE_MILLISECONDS);
+    ttlTimer.unref();
+
+    if (options.bootstrapCommand && !options.alreadyBootstrapped) {
+      socket.send(options.bootstrapCommand, { binary: true });
+      options.onBootstrapSent();
+    }
+    process.stderr.write(
+      '\r\n' +
+        `Connected to the AgentCore Runtime shell (session ` +
+        `${connection.runtimeSessionId}, shell ${connection.shellId}). ` +
+        'Press Ctrl-] to detach.\r\n',
+    );
+
+    await closed;
+    if (terminalError && !localCloseRequested && !ttlReconnectScheduled) {
+      throw terminalError;
+    }
+  } finally {
+    stopTerminalOutput();
+    if (pingTimer) clearInterval(pingTimer);
+    if (ttlTimer) clearTimeout(ttlTimer);
+    if (inputListener) process.stdin.off('data', inputListener);
+    if (resizeListener) process.stdout.off('resize', resizeListener);
+    process.off('exit', exitListener);
+    if (
+      socket.readyState === WebSocket.OPEN ||
+      socket.readyState === WebSocket.CONNECTING
+    ) {
+      socket.close(1000, 'Client closing');
+    }
+  }
+
+  if (options.detachRequested.value) {
+    return false;
+  }
+  // Close codes that mean "reconnect with the same shellId": normal TTL
+  // expiry (1008), our own proactive reconnect (1000 after ttlReconnectScheduled),
+  // and abnormal closure (1006).
+  if (ttlReconnectScheduled || closeCode === 1008 || closeCode === 1006) {
+    return true;
+  }
+  if (closeCode === 1000 || closeCode === 1001) {
+    return false;
+  }
+  throw new Error(
+    `AgentCore Runtime shell disconnected (${closeCode}): ${closeReason.toString()}`,
+  );
+}
+
+async function signShellUpgrade(
+  url: URL,
+  runtimeSessionId: string,
+): Promise<{ headers: Record<string, string> }> {
+  // Matches the real interactive-shell WebSocket contract (verified against
+  // the bedrock-agentcore Python SDK's AgentCoreRuntimeClient.connect_shell):
+  // the runtime session id travels as a signed header, not a query param.
+  const credentials = await defaultProvider()();
+  const signer = new SignatureV4({
+    credentials,
+    region: regionFromHost(url.hostname),
+    service: 'bedrock-agentcore',
+    sha256: Sha256,
+  });
+  const signed = await signer.sign(
+    new HttpRequest({
+      protocol: url.protocol,
+      hostname: url.hostname,
+      method: 'GET',
+      path: url.pathname,
+      query: Object.fromEntries(url.searchParams),
+      headers: {
+        host: url.hostname,
+        'X-Amzn-Bedrock-AgentCore-Runtime-Session-Id': runtimeSessionId,
+      },
+    }),
+  );
+  const headers: Record<string, string> = {};
+  for (const [key, value] of Object.entries(signed.headers)) {
+    if (key.toLowerCase() === 'host') continue;
+    headers[key] = value;
+  }
+  return { headers };
+}
+
+function regionFromHost(hostname: string): string {
+  const match = /^bedrock-agentcore\.([a-z0-9-]+)\.amazonaws\.com$/.exec(
+    hostname,
+  );
+  if (!match?.[1]) {
+    throw new Error(`Unable to derive region from shell host: ${hostname}`);
+  }
+  return match[1];
+}
+
+function waitForSessionInitialization(socket: WebSocket): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error('Timed out waiting for the AgentCore Runtime shell'));
+    }, 30_000);
+    timeout.unref();
+
+    let graceTimer: NodeJS.Timeout | undefined;
+    const onOpen = (): void => {
+      graceTimer = setTimeout(() => {
+        cleanup();
+        resolve();
+      }, 1_500);
+      graceTimer.unref();
+    };
+    const onMessage = (data: RawData, isBinary: boolean): void => {
+      if (isBinary) {
+        cleanup();
+        resolve();
+        return;
+      }
+      cleanup();
+      resolve();
+    };
+    const onClose = (): void => {
+      cleanup();
+      reject(new Error('AgentCore Runtime shell closed before initialization'));
+    };
+    const onError = (error: Error): void => {
+      cleanup();
+      reject(error);
+    };
+    const onUnexpectedResponse = (
+      _request: unknown,
+      response: { statusCode?: number },
+    ): void => {
+      cleanup();
+      reject(
+        new Error(
+          'AgentCore Runtime shell rejected the WebSocket with HTTP ' +
+            `${response.statusCode ?? 'unknown'}`,
+        ),
+      );
+    };
+    const cleanup = (): void => {
+      clearTimeout(timeout);
+      if (graceTimer) clearTimeout(graceTimer);
+      socket.off('open', onOpen);
+      socket.off('message', onMessage);
+      socket.off('close', onClose);
+      socket.off('error', onError);
+      socket.off('unexpected-response', onUnexpectedResponse);
+    };
+
+    socket.once('open', onOpen);
+    socket.on('message', onMessage);
+    socket.once('close', onClose);
+    socket.once('error', onError);
+    socket.once('unexpected-response', onUnexpectedResponse);
+  });
+}
+
+function isControlMessage(text: string): boolean {
+  if (!text.startsWith('{')) return false;
+  try {
+    const value = JSON.parse(text) as unknown;
+    return isRecord(value) && typeof value.type === 'string';
+  } catch {
+    return false;
+  }
+}
+
+export function developerShellBootstrapCommand(): Buffer {
+  const command =
+    'exec setpriv --reuid=1000 --regid=1000 --init-groups ' +
+    '/usr/local/bin/developer-shell\n';
+  return Buffer.from(command, 'utf8');
+}
+
+export function validateShellUrl(value: string): URL {
+  const url = new URL(value);
+  if (url.protocol !== 'wss:' || url.username || url.password) {
+    throw new Error('AgentCore Runtime shell URL is invalid');
+  }
+  return url;
+}
+
+function asBuffer(data: RawData): Buffer {
+  if (Buffer.isBuffer(data)) return data;
+  if (data instanceof ArrayBuffer) return Buffer.from(data);
+  if (Array.isArray(data)) return Buffer.concat(data);
+  throw new Error('Unsupported WebSocket frame type');
+}
+
+function clampDimension(value: number): number {
+  return Math.max(1, Math.min(1000, value));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}

--- a/claude-code-on-agentcore-runtime-microvm/client/src/terminal.ts
+++ b/claude-code-on-agentcore-runtime-microvm/client/src/terminal.ts
@@ -5,6 +5,14 @@ import { HttpRequest } from '@smithy/protocol-http';
 import { Sha256 } from '@aws-crypto/sha256-js';
 import { defaultProvider } from '@aws-sdk/credential-provider-node';
 import type { ConnectResponse } from './api.js';
+import {
+  decodeShellFrame,
+  encodeClose,
+  encodeResize,
+  encodeStdin,
+  parseShellStatus,
+  ShellChannel,
+} from './shell-protocol.js';
 
 const DETACH_BYTE = 0x1d;
 const PING_INTERVAL_MILLISECONDS = 1_000;
@@ -201,17 +209,27 @@ async function runOneConnection(
     });
   });
 
-  outputListener = (data, isBinary): void => {
+  outputListener = (data): void => {
     lastReadAt = Date.now();
-    const buffer = asBuffer(data);
-    if (isBinary) {
-      terminalOutput.write(buffer);
-      return;
+    const frame = decodeShellFrame(asBuffer(data));
+    if (frame.channel === ShellChannel.Stdout) {
+      terminalOutput.write(frame.payload);
+    } else if (frame.channel === ShellChannel.Stderr) {
+      terminalOutput.write(frame.payload);
+    } else if (frame.channel === ShellChannel.Status) {
+      const status = parseShellStatus(frame.payload);
+      if (status.status === 'Failure') {
+        process.stderr.write(
+          `\r\nAgentCore Runtime shell reported an error: ` +
+            `${status.message ?? status.reason ?? 'unknown failure'}\r\n`,
+        );
+      }
+    } else if (frame.channel === ShellChannel.Heartbeat) {
+      if (socket.readyState === WebSocket.OPEN) {
+        socket.send(frame.payload.length ? frame.payload : Buffer.from([ShellChannel.Heartbeat]));
+      }
     }
-    const text = buffer.toString('utf8');
-    if (!isControlMessage(text)) {
-      terminalOutput.write(text);
-    }
+    // CLOSE (0xFF) is handled by the WebSocket 'close' event, not here.
   };
   socket.on('message', outputListener);
   const stopTerminalOutput = (): void => {
@@ -227,11 +245,10 @@ async function runOneConnection(
     resizeListener = (): void => {
       if (socket.readyState !== WebSocket.OPEN) return;
       socket.send(
-        JSON.stringify({
-          type: 'resize',
-          rows: clampDimension(process.stdout.rows ?? 24),
-          cols: clampDimension(process.stdout.columns ?? 80),
-        }),
+        encodeResize(
+          clampDimension(process.stdout.columns ?? 80),
+          clampDimension(process.stdout.rows ?? 24),
+        ),
       );
     };
     process.stdout.on('resize', resizeListener);
@@ -241,15 +258,18 @@ async function runOneConnection(
       const detachAt = data.indexOf(DETACH_BYTE);
       if (detachAt >= 0) {
         if (detachAt > 0 && socket.readyState === WebSocket.OPEN) {
-          socket.send(data.subarray(0, detachAt), { binary: true });
+          socket.send(encodeStdin(data.subarray(0, detachAt)));
         }
         localCloseRequested = true;
         options.detachRequested.value = true;
+        if (socket.readyState === WebSocket.OPEN) {
+          socket.send(encodeClose());
+        }
         socket.close(1000, 'Client detached');
         return;
       }
       if (socket.readyState === WebSocket.OPEN) {
-        socket.send(data, { binary: true });
+        socket.send(encodeStdin(data));
       }
     };
     process.stdin.on('data', inputListener);
@@ -276,7 +296,7 @@ async function runOneConnection(
     ttlTimer.unref();
 
     if (options.bootstrapCommand && !options.alreadyBootstrapped) {
-      socket.send(options.bootstrapCommand, { binary: true });
+      socket.send(encodeStdin(options.bootstrapCommand));
       options.onBootstrapSent();
     }
     process.stderr.write(
@@ -375,22 +395,14 @@ function waitForSessionInitialization(socket: WebSocket): Promise<void> {
     }, 30_000);
     timeout.unref();
 
-    let graceTimer: NodeJS.Timeout | undefined;
-    const onOpen = (): void => {
-      graceTimer = setTimeout(() => {
+    const onMessage = (data: RawData): void => {
+      const frame = decodeShellFrame(asBuffer(data));
+      if (frame.channel !== ShellChannel.Status) return;
+      const status = parseShellStatus(frame.payload);
+      if (status.metadata?.shellId) {
         cleanup();
         resolve();
-      }, 1_500);
-      graceTimer.unref();
-    };
-    const onMessage = (data: RawData, isBinary: boolean): void => {
-      if (isBinary) {
-        cleanup();
-        resolve();
-        return;
       }
-      cleanup();
-      resolve();
     };
     const onClose = (): void => {
       cleanup();
@@ -414,30 +426,17 @@ function waitForSessionInitialization(socket: WebSocket): Promise<void> {
     };
     const cleanup = (): void => {
       clearTimeout(timeout);
-      if (graceTimer) clearTimeout(graceTimer);
-      socket.off('open', onOpen);
       socket.off('message', onMessage);
       socket.off('close', onClose);
       socket.off('error', onError);
       socket.off('unexpected-response', onUnexpectedResponse);
     };
 
-    socket.once('open', onOpen);
     socket.on('message', onMessage);
     socket.once('close', onClose);
     socket.once('error', onError);
     socket.once('unexpected-response', onUnexpectedResponse);
   });
-}
-
-function isControlMessage(text: string): boolean {
-  if (!text.startsWith('{')) return false;
-  try {
-    const value = JSON.parse(text) as unknown;
-    return isRecord(value) && typeof value.type === 'string';
-  } catch {
-    return false;
-  }
 }
 
 export function developerShellBootstrapCommand(): Buffer {

--- a/claude-code-on-agentcore-runtime-microvm/client/src/terminal.ts
+++ b/claude-code-on-agentcore-runtime-microvm/client/src/terminal.ts
@@ -1,10 +1,8 @@
 import process from 'node:process';
 import WebSocket, { type RawData } from 'ws';
-import { SignatureV4 } from '@smithy/signature-v4';
-import { HttpRequest } from '@smithy/protocol-http';
-import { Sha256 } from '@aws-crypto/sha256-js';
 import { defaultProvider } from '@aws-sdk/credential-provider-node';
 import type { ConnectResponse } from './api.js';
+import { signShellUpgrade } from '../../shared/shell-signing.js';
 import {
   decodeShellFrame,
   encodeClose,
@@ -171,6 +169,7 @@ async function runOneConnection(
   const signedRequest = await signShellUpgrade(
     shellUrl,
     connection.runtimeSessionId,
+    defaultProvider(),
   );
 
   const socket = new WebSocket(shellUrl, {
@@ -340,51 +339,6 @@ async function runOneConnection(
   throw new Error(
     `AgentCore Runtime shell disconnected (${closeCode}): ${closeReason.toString()}`,
   );
-}
-
-async function signShellUpgrade(
-  url: URL,
-  runtimeSessionId: string,
-): Promise<{ headers: Record<string, string> }> {
-  // Matches the real interactive-shell WebSocket contract (verified against
-  // the bedrock-agentcore Python SDK's AgentCoreRuntimeClient.connect_shell):
-  // the runtime session id travels as a signed header, not a query param.
-  const credentials = await defaultProvider()();
-  const signer = new SignatureV4({
-    credentials,
-    region: regionFromHost(url.hostname),
-    service: 'bedrock-agentcore',
-    sha256: Sha256,
-  });
-  const signed = await signer.sign(
-    new HttpRequest({
-      protocol: url.protocol,
-      hostname: url.hostname,
-      method: 'GET',
-      path: url.pathname,
-      query: Object.fromEntries(url.searchParams),
-      headers: {
-        host: url.hostname,
-        'X-Amzn-Bedrock-AgentCore-Runtime-Session-Id': runtimeSessionId,
-      },
-    }),
-  );
-  const headers: Record<string, string> = {};
-  for (const [key, value] of Object.entries(signed.headers)) {
-    if (key.toLowerCase() === 'host') continue;
-    headers[key] = value;
-  }
-  return { headers };
-}
-
-function regionFromHost(hostname: string): string {
-  const match = /^bedrock-agentcore\.([a-z0-9-]+)\.amazonaws\.com$/.exec(
-    hostname,
-  );
-  if (!match?.[1]) {
-    throw new Error(`Unable to derive region from shell host: ${hostname}`);
-  }
-  return match[1];
 }
 
 function waitForSessionInitialization(socket: WebSocket): Promise<void> {

--- a/claude-code-on-agentcore-runtime-microvm/control-plane/src/aws-adapters.ts
+++ b/claude-code-on-agentcore-runtime-microvm/control-plane/src/aws-adapters.ts
@@ -1,0 +1,514 @@
+import {
+  BedrockAgentCoreClient,
+  InvokeAgentRuntimeCommandCommand,
+  StopRuntimeSessionCommand,
+} from '@aws-sdk/client-bedrock-agentcore';
+import {
+  GetObjectCommand,
+  HeadObjectCommand,
+  PutObjectCommand,
+  type S3Client,
+} from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import {
+  DeleteCommand,
+  DynamoDBDocumentClient,
+  GetCommand,
+  QueryCommand,
+  TransactWriteCommand,
+  UpdateCommand,
+} from '@aws-sdk/lib-dynamodb';
+import type {
+  AgentRuntimeService,
+  CreateSessionResult,
+  RunResult,
+  RuntimeSessionDescription,
+  SessionRecord,
+  SessionRepository,
+  SessionState,
+  ShellConnection,
+  WorkspaceCheckpointAccess,
+  WorkspaceCheckpointService,
+  WorkspaceClaim,
+} from './model.js';
+import { ACTIVE_STATES } from './model.js';
+
+const CLAIM_ATTEMPTS = 5;
+const CHECKPOINT_URL_TTL_SECONDS = 10 * 60 * 60;
+const RUNTIME_SESSION_MAX_DURATION_SECONDS = 28_800;
+// InvokeAgentRuntimeCommandShell session IDs must be >= 33 characters (see
+// AWS docs: "the session ID is less than 33 characters" is a documented
+// ValidationException cause). A UUID (36 chars) already satisfies this, so
+// we reuse the control-plane sessionId directly rather than minting a
+// second identifier.
+const MIN_RUNTIME_SESSION_ID_LENGTH = 33;
+
+export class DynamoSessionRepository implements SessionRepository {
+  public constructor(
+    private readonly client: DynamoDBDocumentClient,
+    private readonly tableName: string,
+    private readonly claimTableName: string,
+  ) {}
+
+  public async get(sessionId: string): Promise<SessionRecord | undefined> {
+    const response = await this.client.send(
+      new GetCommand({
+        TableName: this.tableName,
+        Key: { sessionId },
+        ConsistentRead: true,
+      }),
+    );
+    return response.Item as SessionRecord | undefined;
+  }
+
+  public async create(record: SessionRecord): Promise<CreateSessionResult> {
+    const workspaceKey = claimKey(record.ownerHash, record.workspaceId);
+    for (let attempt = 0; attempt < CLAIM_ATTEMPTS; attempt += 1) {
+      const claim = await this.getClaim(workspaceKey);
+      if (claim) {
+        const existing = await this.get(claim.sessionId);
+        if (
+          existing &&
+          existing.ownerHash === record.ownerHash &&
+          existing.workspaceId === record.workspaceId &&
+          ACTIVE_STATES.includes(
+            existing.state as (typeof ACTIVE_STATES)[number],
+          )
+        ) {
+          return { created: false, record: existing };
+        }
+      }
+
+      try {
+        await this.client.send(
+          new TransactWriteCommand({
+            TransactItems: [
+              {
+                Put: {
+                  TableName: this.tableName,
+                  Item: record,
+                  ConditionExpression: 'attribute_not_exists(sessionId)',
+                },
+              },
+              {
+                Put: {
+                  TableName: this.claimTableName,
+                  Item: {
+                    workspaceKey,
+                    sessionId: record.sessionId,
+                    ownerHash: record.ownerHash,
+                    workspaceId: record.workspaceId,
+                    expiresAt: record.expiresAt,
+                  } satisfies WorkspaceClaim,
+                  ConditionExpression: claim
+                    ? 'sessionId = :claimedSessionId'
+                    : 'attribute_not_exists(workspaceKey)',
+                  ExpressionAttributeValues: claim
+                    ? { ':claimedSessionId': claim.sessionId }
+                    : undefined,
+                },
+              },
+            ],
+          }),
+        );
+        return { created: true };
+      } catch (error) {
+        if (!isTransactionConflict(error)) {
+          throw error;
+        }
+      }
+    }
+    throw new Error(
+      'Workspace is being started concurrently; retry the request',
+    );
+  }
+
+  public async releaseWorkspace(record: SessionRecord): Promise<void> {
+    try {
+      await this.client.send(
+        new DeleteCommand({
+          TableName: this.claimTableName,
+          Key: {
+            workspaceKey: claimKey(record.ownerHash, record.workspaceId),
+          },
+          ConditionExpression: 'sessionId = :sessionId',
+          ExpressionAttributeValues: { ':sessionId': record.sessionId },
+        }),
+      );
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.name === 'ConditionalCheckFailedException'
+      ) {
+        return;
+      }
+      throw error;
+    }
+  }
+
+  public async listForOwner(ownerHash: string): Promise<SessionRecord[]> {
+    const items: SessionRecord[] = [];
+    let exclusiveStartKey: Record<string, unknown> | undefined;
+    do {
+      const response = await this.client.send(
+        new QueryCommand({
+          TableName: this.tableName,
+          IndexName: 'owner-updated-index',
+          KeyConditionExpression: 'ownerHash = :owner',
+          ExpressionAttributeValues: { ':owner': ownerHash },
+          ScanIndexForward: false,
+          ExclusiveStartKey: exclusiveStartKey,
+        }),
+      );
+      items.push(...((response.Items ?? []) as SessionRecord[]));
+      exclusiveStartKey = response.LastEvaluatedKey;
+    } while (exclusiveStartKey);
+    return items;
+  }
+
+  public async listStateUpdatedBefore(
+    state: SessionState,
+    updatedBefore: number,
+  ): Promise<SessionRecord[]> {
+    const items: SessionRecord[] = [];
+    let exclusiveStartKey: Record<string, unknown> | undefined;
+    do {
+      const response = await this.client.send(
+        new QueryCommand({
+          TableName: this.tableName,
+          IndexName: 'state-updated-index',
+          KeyConditionExpression:
+            '#state = :state AND updatedAt <= :updatedBefore',
+          ExpressionAttributeNames: { '#state': 'state' },
+          ExpressionAttributeValues: {
+            ':state': state,
+            ':updatedBefore': updatedBefore,
+          },
+          ExclusiveStartKey: exclusiveStartKey,
+        }),
+      );
+      items.push(...((response.Items ?? []) as SessionRecord[]));
+      exclusiveStartKey = response.LastEvaluatedKey;
+    } while (exclusiveStartKey);
+    return items;
+  }
+
+  public async patch(
+    sessionId: string,
+    values: Partial<SessionRecord>,
+    expectedStates?: SessionState[],
+  ): Promise<boolean> {
+    const entries = Object.entries(values).filter(
+      ([key, value]) => key !== 'sessionId' && value !== undefined,
+    );
+    if (entries.length === 0) {
+      return true;
+    }
+
+    const names: Record<string, string> = {};
+    const expressionValues: Record<string, unknown> = {};
+    const assignments = entries.map(([key, value], index) => {
+      const name = `#field${index}`;
+      const valueName = `:value${index}`;
+      names[name] = key;
+      expressionValues[valueName] = value;
+      return `${name} = ${valueName}`;
+    });
+
+    let conditionExpression: string | undefined;
+    if (expectedStates && expectedStates.length > 0) {
+      names['#currentState'] = 'state';
+      const stateNames = expectedStates.map((state, index) => {
+        const valueName = `:expectedState${index}`;
+        expressionValues[valueName] = state;
+        return valueName;
+      });
+      conditionExpression = `#currentState IN (${stateNames.join(', ')})`;
+    }
+
+    try {
+      await this.client.send(
+        new UpdateCommand({
+          TableName: this.tableName,
+          Key: { sessionId },
+          UpdateExpression: `SET ${assignments.join(', ')}`,
+          ConditionExpression: conditionExpression,
+          ExpressionAttributeNames: names,
+          ExpressionAttributeValues: expressionValues,
+        }),
+      );
+      return true;
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.name === 'ConditionalCheckFailedException'
+      ) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  private async getClaim(
+    workspaceKey: string,
+  ): Promise<WorkspaceClaim | undefined> {
+    const response = await this.client.send(
+      new GetCommand({
+        TableName: this.claimTableName,
+        Key: { workspaceKey },
+        ConsistentRead: true,
+      }),
+    );
+    return response.Item as WorkspaceClaim | undefined;
+  }
+}
+
+/**
+ * Adapter over the AgentCore Runtime data-plane SDK (`InvokeAgentRuntime*`).
+ *
+ * Unlike Lambda MicroVMs, AgentCore Runtime has no `RunMicrovm`/
+ * `GetMicrovm`/`SuspendMicrovm` control-plane API per session, and no
+ * `ListSessions`/`GetSession` data-plane API either (`ListSessions` in the
+ * SDK is an AgentCore *Memory* API, unrelated to runtime sessions). This
+ * adapter emulates the richer Lambda MicroVM lifecycle (`run`/`suspend`/
+ * `resume`/`terminate`) on top of that narrower surface:
+ *
+ * - `run` performs a lightweight `InvokeAgentRuntimeCommand` (a fast no-op
+ *   shell command) against a fresh `runtimeSessionId` to force the
+ *   AgentCore Runtime service to provision a microVM for that session, and
+ *   records session metadata for later shell connections.
+ * - `get` has no direct "describe session" API to call; it re-probes
+ *   liveness with another fast `InvokeAgentRuntimeCommand` and maps a
+ *   `ResourceNotFoundException`/`ValidationException` response to
+ *   `TERMINATED`. This does issue a real (cheap) command invocation on
+ *   every reconciler tick -- documented as a known cost trade-off in
+ *   docs/deployment-guide.md pending a first-class AgentCore Runtime
+ *   session-describe API.
+ * - `suspend` has no direct AgentCore Runtime equivalent; the container's
+ *   own agent (agent-runtime/agent.py) checkpoints the workspace to S3 when
+ *   it receives a `suspend` command through `/invocations`, and the control
+ *   service tracks `SUSPENDED` purely as in-app state. The underlying
+ *   session keeps running until `terminate` or the 8h max lifetime elapses.
+ * - `resume` re-validates the session is still reachable via `get`.
+ * - `terminate` calls `StopRuntimeSession`.
+ */
+export class AwsAgentRuntimeService implements AgentRuntimeService {
+  public constructor(private readonly client: BedrockAgentCoreClient) {}
+
+  public async run(input: {
+    agentRuntimeArn: string;
+    runtimeSessionId: string;
+    executionRoleArn: string;
+    payload: string;
+    clientToken: string;
+  }): Promise<RunResult> {
+    if (input.runtimeSessionId.length < MIN_RUNTIME_SESSION_ID_LENGTH) {
+      throw new Error(
+        `runtimeSessionId must be at least ${MIN_RUNTIME_SESSION_ID_LENGTH} characters`,
+      );
+    }
+    const startedAt = Math.floor(Date.now() / 1_000);
+    await this.client.send(
+      new InvokeAgentRuntimeCommandCommand({
+        agentRuntimeArn: input.agentRuntimeArn,
+        runtimeSessionId: input.runtimeSessionId,
+        contentType: 'application/json',
+        accept: 'application/json',
+        body: {
+          command: `/opt/claude-agentcore/session-bootstrap.sh '${input.payload}'`,
+          timeout: 60,
+        },
+      }),
+    );
+    return {
+      runtimeSessionId: input.runtimeSessionId,
+      state: 'RUNNING',
+      startedAt,
+      maximumDurationInSeconds: RUNTIME_SESSION_MAX_DURATION_SECONDS,
+    };
+  }
+
+  public async get(
+    agentRuntimeArn: string,
+    runtimeSessionId: string,
+  ): Promise<RuntimeSessionDescription> {
+    try {
+      await this.client.send(
+        new InvokeAgentRuntimeCommandCommand({
+          agentRuntimeArn,
+          runtimeSessionId,
+          contentType: 'application/json',
+          accept: 'application/json',
+          body: { command: 'true', timeout: 5 },
+        }),
+      );
+      return {
+        runtimeSessionId,
+        state: 'RUNNING',
+        maximumDurationInSeconds: RUNTIME_SESSION_MAX_DURATION_SECONDS,
+      };
+    } catch (error) {
+      if (isNotFound(error)) {
+        return { runtimeSessionId, state: 'TERMINATED' };
+      }
+      throw error;
+    }
+  }
+
+  public async createShellConnection(
+    agentRuntimeArn: string,
+    runtimeSessionId: string,
+    shellId: string,
+  ): Promise<ShellConnection> {
+    // Real AgentCore Runtime interactive-shell WebSocket contract (verified
+    // against the bedrock-agentcore Python SDK's AgentCoreRuntimeClient.
+    // connect_shell / _build_shell_url):
+    //   host: bedrock-agentcore.<region>.amazonaws.com
+    //   path: /runtimes/<url-encoded-arn>/ws/shells
+    //   query: shellId=<shellId>
+    //   the runtime session id is NOT a query param -- it is sent as the
+    //   signed header X-Amzn-Bedrock-AgentCore-Runtime-Session-Id on the
+    //   WebSocket upgrade request (see client/src/terminal.ts, which signs
+    //   the request with SigV4 including that header).
+    const region = this.regionOf(agentRuntimeArn);
+    const endpoint =
+      `wss://bedrock-agentcore.${region}.amazonaws.com/runtimes/` +
+      `${encodeURIComponent(agentRuntimeArn)}/ws/shells?shellId=` +
+      `${encodeURIComponent(shellId)}`;
+    return {
+      endpoint,
+      runtimeSessionId,
+      shellId,
+      authToken: '',
+      expiresAt: Math.floor(Date.now() / 1_000) + 60 * 60,
+    };
+  }
+
+  public async suspend(_runtimeSessionId: string): Promise<void> {
+    // No control-plane suspend primitive; see class doc comment. The
+    // control service still transitions its own state machine and relies
+    // on the in-container agent to checkpoint on the next shell signal.
+  }
+
+  public async resume(
+    agentRuntimeArn: string,
+    runtimeSessionId: string,
+  ): Promise<void> {
+    const description = await this.get(agentRuntimeArn, runtimeSessionId);
+    if (description.state === 'TERMINATED') {
+      throw new Error('Cannot resume a terminated AgentCore Runtime session');
+    }
+  }
+
+  public async terminate(
+    agentRuntimeArn: string,
+    runtimeSessionId: string,
+  ): Promise<void> {
+    try {
+      await this.client.send(
+        new StopRuntimeSessionCommand({ agentRuntimeArn, runtimeSessionId }),
+      );
+    } catch (error) {
+      if (!isNotFound(error)) {
+        throw error;
+      }
+    }
+  }
+
+  private regionOf(arn: string): string {
+    const parts = arn.split(':');
+    const region = parts[3];
+    if (!region) {
+      throw new Error(`Unable to parse region from ARN: ${arn}`);
+    }
+    return region;
+  }
+}
+
+export class S3WorkspaceCheckpointService
+  implements WorkspaceCheckpointService
+{
+  public constructor(
+    private readonly client: S3Client,
+    private readonly bucketName: string,
+    private readonly expiresIn = CHECKPOINT_URL_TTL_SECONDS,
+  ) {}
+
+  public async createAccess(
+    ownerHash: string,
+    workspaceId: string,
+  ): Promise<WorkspaceCheckpointAccess> {
+    const key = workspaceCheckpointKey(ownerHash, workspaceId);
+    const exists = await this.exists(key);
+    const [downloadUrl, uploadUrl] = await Promise.all([
+      exists
+        ? getSignedUrl(
+            this.client,
+            new GetObjectCommand({ Bucket: this.bucketName, Key: key }),
+            { expiresIn: this.expiresIn },
+          )
+        : undefined,
+      getSignedUrl(
+        this.client,
+        new PutObjectCommand({
+          Bucket: this.bucketName,
+          Key: key,
+          ContentType: 'application/gzip',
+        }),
+        { expiresIn: this.expiresIn },
+      ),
+    ]);
+    return { downloadUrl, uploadUrl };
+  }
+
+  private async exists(key: string): Promise<boolean> {
+    try {
+      await this.client.send(
+        new HeadObjectCommand({ Bucket: this.bucketName, Key: key }),
+      );
+      return true;
+    } catch (error) {
+      if (
+        isNotFound(error) ||
+        (error instanceof Error && error.name === 'NotFound')
+      ) {
+        return false;
+      }
+      throw error;
+    }
+  }
+}
+
+export function workspaceCheckpointKey(
+  ownerHash: string,
+  workspaceId: string,
+): string {
+  return `workspaces/${ownerHash}/${encodeURIComponent(
+    workspaceId,
+  )}/checkpoint.tar.gz`;
+}
+
+function claimKey(ownerHash: string, workspaceId: string): string {
+  return `${ownerHash}#${workspaceId}`;
+}
+
+function isTransactionConflict(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    [
+      'TransactionCanceledException',
+      'ConditionalCheckFailedException',
+    ].includes(error.name)
+  );
+}
+
+function isNotFound(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    [
+      'ResourceNotFoundException',
+      'NoSuchKey',
+      'NotFoundException',
+    ].includes(error.name)
+  );
+}

--- a/claude-code-on-agentcore-runtime-microvm/control-plane/src/aws-adapters.ts
+++ b/claude-code-on-agentcore-runtime-microvm/control-plane/src/aws-adapters.ts
@@ -1,5 +1,6 @@
 import {
   BedrockAgentCoreClient,
+  InvokeAgentRuntimeCommand,
   InvokeAgentRuntimeCommandCommand,
   StopRuntimeSessionCommand,
 } from '@aws-sdk/client-bedrock-agentcore';
@@ -308,18 +309,27 @@ export class AwsAgentRuntimeService implements AgentRuntimeService {
       );
     }
     const startedAt = Math.floor(Date.now() / 1_000);
-    await this.client.send(
-      new InvokeAgentRuntimeCommandCommand({
-        agentRuntimeArn: input.agentRuntimeArn,
-        runtimeSessionId: input.runtimeSessionId,
-        contentType: 'application/json',
-        accept: 'application/json',
-        body: {
-          command: `/opt/claude-agentcore/session-bootstrap.sh '${input.payload}'`,
-          timeout: 60,
-        },
-      }),
-    );
+    // This must be a real /invocations POST (InvokeAgentRuntimeCommand,
+    // the *data-plane* "invoke the agent" API) carrying the
+    // `{"command":"bootstrap","payload":...}` JSON body that
+    // agent.py's HookHandler.do_POST expects. It is easy to confuse this
+    // with InvokeAgentRuntimeCommandCommand (the *shell-exec* API used by
+    // `get()` below for liveness probing, which runs an arbitrary shell
+    // command via a PTY-less exec channel and never reaches the
+    // /invocations HTTP handler at all). Sending the bootstrap payload
+    // through the shell-exec API -- as this code previously did, via a
+    // fictional `/opt/claude-agentcore/session-bootstrap.sh` script that
+    // the Dockerfile never installs -- means `Runtime.bootstrap()` in
+    // agent.py never runs: /workspace is never restored and
+    // /var/lib/claude-agentcore/session.json is never written, so every
+    // later shell connection fails with "Session configuration is
+    // unavailable".
+    await invokeLifecycleCommand(this.client, {
+      agentRuntimeArn: input.agentRuntimeArn,
+      runtimeSessionId: input.runtimeSessionId,
+      command: 'bootstrap',
+      payload: input.payload,
+    });
     return {
       runtimeSessionId: input.runtimeSessionId,
       state: 'RUNNING',
@@ -384,10 +394,23 @@ export class AwsAgentRuntimeService implements AgentRuntimeService {
     };
   }
 
-  public async suspend(_runtimeSessionId: string): Promise<void> {
-    // No control-plane suspend primitive; see class doc comment. The
-    // control service still transitions its own state machine and relies
-    // on the in-container agent to checkpoint on the next shell signal.
+  public async suspend(
+    agentRuntimeArn: string,
+    runtimeSessionId: string,
+  ): Promise<void> {
+    // No control-plane suspend primitive; see class doc comment. What we
+    // *can* do -- and previously did not -- is tell the in-container
+    // agent to checkpoint the workspace to S3 right now, via the same
+    // `/invocations` "suspend" command `Runtime.checkpoint()` in
+    // agent.py already knows how to handle. Without this call `suspend`
+    // was a pure no-op: the control service flipped its own DynamoDB
+    // record to SUSPENDED while the container never wrote a checkpoint,
+    // so a later `resume` had nothing real to resume into.
+    await invokeLifecycleCommand(this.client, {
+      agentRuntimeArn,
+      runtimeSessionId,
+      command: 'suspend',
+    });
   }
 
   public async resume(
@@ -404,6 +427,26 @@ export class AwsAgentRuntimeService implements AgentRuntimeService {
     agentRuntimeArn: string,
     runtimeSessionId: string,
   ): Promise<void> {
+    // Checkpoint before stopping the runtime session, same rationale as
+    // `suspend` above: previously this called StopRuntimeSession directly
+    // with no prior checkpoint command, so the workspace was discarded on
+    // every terminate. A checkpoint failure here (for example, the
+    // container already gone, or a transient network error) must not
+    // block termination -- the microVM still needs to be stopped so the
+    // session does not keep running (and billing) until the 8h max
+    // duration elapses. We log and continue rather than throw.
+    try {
+      await invokeLifecycleCommand(this.client, {
+        agentRuntimeArn,
+        runtimeSessionId,
+        command: 'terminate',
+      });
+    } catch (error) {
+      console.error('workspace checkpoint before termination failed', {
+        runtimeSessionId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
     try {
       await this.client.send(
         new StopRuntimeSessionCommand({ agentRuntimeArn, runtimeSessionId }),
@@ -490,6 +533,60 @@ export function workspaceCheckpointKey(
 
 function claimKey(ownerHash: string, workspaceId: string): string {
   return `${ownerHash}#${workspaceId}`;
+}
+
+/**
+ * Sends a real AgentCore Runtime session-lifecycle command
+ * (`bootstrap` | `suspend` | `terminate`) to the container's
+ * `/invocations` HTTP endpoint via the `InvokeAgentRuntimeCommand`
+ * data-plane API (not the shell-exec `InvokeAgentRuntimeCommandCommand`
+ * API), matching the JSON contract `HookHandler.do_POST` implements in
+ * agent-runtime/agent.py: request body `{"command": ..., "payload": ...}`,
+ * response body `{"status": "success", "response": {...}}` on success or
+ * `{"message": ...}` with a non-200 status on failure.
+ */
+async function invokeLifecycleCommand(
+  client: BedrockAgentCoreClient,
+  input: {
+    agentRuntimeArn: string;
+    runtimeSessionId: string;
+    command: 'bootstrap' | 'suspend' | 'terminate';
+    payload?: string;
+  },
+): Promise<void> {
+  const body: Record<string, unknown> = { command: input.command };
+  if (input.payload !== undefined) {
+    body.payload = input.payload;
+  }
+  const response = await client.send(
+    new InvokeAgentRuntimeCommand({
+      agentRuntimeArn: input.agentRuntimeArn,
+      runtimeSessionId: input.runtimeSessionId,
+      contentType: 'application/json',
+      accept: 'application/json',
+      payload: Buffer.from(JSON.stringify(body), 'utf8'),
+    }),
+  );
+  const rawResponse = await response.response?.transformToByteArray();
+  const text = rawResponse ? Buffer.from(rawResponse).toString('utf8') : '';
+  let parsed: { status?: string; message?: string } = {};
+  if (text) {
+    try {
+      parsed = JSON.parse(text) as { status?: string; message?: string };
+    } catch {
+      // Leave `parsed` empty; the status/message checks below will treat
+      // an unparseable body as a failure.
+    }
+  }
+  if (response.statusCode !== 200 || parsed.status !== 'success') {
+    throw new Error(
+      `AgentCore Runtime "${input.command}" command failed` +
+        (response.statusCode !== undefined
+          ? ` (HTTP ${response.statusCode})`
+          : '') +
+        (parsed.message ? `: ${parsed.message}` : ''),
+    );
+  }
 }
 
 function isTransactionConflict(error: unknown): boolean {

--- a/claude-code-on-agentcore-runtime-microvm/control-plane/src/handler.ts
+++ b/claude-code-on-agentcore-runtime-microvm/control-plane/src/handler.ts
@@ -1,0 +1,337 @@
+import { BedrockAgentCoreClient } from '@aws-sdk/client-bedrock-agentcore';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { S3Client } from '@aws-sdk/client-s3';
+import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import type {
+  APIGatewayProxyEvent,
+  APIGatewayProxyResult,
+  EventBridgeEvent,
+} from 'aws-lambda';
+import {
+  AwsAgentRuntimeService,
+  DynamoSessionRepository,
+  S3WorkspaceCheckpointService,
+} from './aws-adapters.js';
+import type {
+  AccessMode,
+  InferenceMode,
+  SessionRecord,
+  StartConfiguration,
+} from './model.js';
+import { ControlError, ControlService } from './service.js';
+
+type ControlEvent =
+  | APIGatewayProxyEvent
+  | EventBridgeEvent<string, unknown>;
+
+const region = process.env.AWS_REGION ?? 'us-east-1';
+const documentClient = DynamoDBDocumentClient.from(
+  new DynamoDBClient({ region }),
+  { marshallOptions: { removeUndefinedValues: true } },
+);
+const repository = new DynamoSessionRepository(
+  documentClient,
+  requiredEnvironment('SESSION_TABLE_NAME'),
+  requiredEnvironment('WORKSPACE_CLAIM_TABLE_NAME'),
+);
+const service = new ControlService({
+  repository,
+  agentRuntime: new AwsAgentRuntimeService(
+    new BedrockAgentCoreClient({ region }),
+  ),
+  checkpoints: new S3WorkspaceCheckpointService(
+    new S3Client({ region, requestChecksumCalculation: 'WHEN_REQUIRED' }),
+    requiredEnvironment('WORKSPACE_BUCKET_NAME'),
+  ),
+  loadConfiguration,
+});
+
+let configurationCache:
+  | { expiresAt: number; value: StartConfiguration }
+  | undefined;
+let observedApiUrl: string | undefined;
+
+export async function handler(
+  event: ControlEvent,
+): Promise<APIGatewayProxyResult | Record<string, number>> {
+  if (isReconcilerEvent(event)) {
+    return service.reconcile();
+  }
+  if (!isApiGatewayEvent(event)) {
+    return response(400, { message: 'Unsupported event' });
+  }
+  observeApiUrl(event);
+
+  try {
+    const ownerPrincipal = callerPrincipal(event);
+    const method = event.httpMethod.toUpperCase();
+    const path = event.resource;
+    const sessionId = event.pathParameters?.sessionId;
+
+    if (
+      method === 'POST' &&
+      path === '/sessions/{sessionId}/checkpoint-urls'
+    ) {
+      if (!sessionId) {
+        throw new ControlError(404, 'Route not found');
+      }
+      assertRuntimeExecutionCaller(ownerPrincipal);
+      const body = parseBody(event);
+      const runtimeSessionId = optionalString(body.runtimeSessionId);
+      if (!runtimeSessionId) {
+        throw new ControlError(400, 'runtimeSessionId is required');
+      }
+      const access = await service.checkpointUrls(
+        sessionId,
+        runtimeSessionId,
+      );
+      return response(200, {
+        downloadUrl: access.downloadUrl,
+        uploadUrl: access.uploadUrl,
+      });
+    }
+
+    if (method === 'GET' && path === '/sessions') {
+      const sessions = await service.list(ownerPrincipal, true);
+      return response(200, { sessions: sessions.map(publicSession) });
+    }
+    if (method === 'POST' && path === '/sessions') {
+      const body = parseBody(event);
+      const result = await service.start(
+        ownerPrincipal,
+        optionalString(body.workspaceId),
+        {
+          accessMode: optionalAccessMode(body.accessMode),
+          inferenceMode: optionalInferenceMode(body.inferenceMode),
+        },
+      );
+      return response(result.created ? 202 : 200, {
+        created: result.created,
+        session: publicSession(result.record),
+      });
+    }
+    if (!sessionId) {
+      throw new ControlError(404, 'Route not found');
+    }
+    if (method === 'GET' && path === '/sessions/{sessionId}') {
+      return response(
+        200,
+        publicSession(await service.get(ownerPrincipal, sessionId)),
+      );
+    }
+    if (method === 'POST' && path === '/sessions/{sessionId}/connect') {
+      const result = await service.connect(ownerPrincipal, sessionId);
+      return response(200, {
+        session: publicSession(result.record),
+        shellUrl: result.connection.endpoint,
+        runtimeSessionId: result.connection.runtimeSessionId,
+        shellId: result.connection.shellId,
+        tokenExpiresAt: result.connection.expiresAt,
+      });
+    }
+    if (method === 'POST' && path === '/sessions/{sessionId}/suspend') {
+      return response(
+        202,
+        publicSession(await service.suspend(ownerPrincipal, sessionId)),
+      );
+    }
+    if (method === 'POST' && path === '/sessions/{sessionId}/resume') {
+      return response(
+        202,
+        publicSession(await service.resume(ownerPrincipal, sessionId)),
+      );
+    }
+    if (method === 'DELETE' && path === '/sessions/{sessionId}') {
+      return response(
+        202,
+        publicSession(await service.terminate(ownerPrincipal, sessionId)),
+      );
+    }
+    throw new ControlError(404, 'Route not found');
+  } catch (error) {
+    if (error instanceof ControlError) {
+      return response(error.statusCode, { message: error.message });
+    }
+    console.error('control request failed', {
+      error: error instanceof Error ? error.message : 'Unknown error',
+    });
+    return response(500, { message: 'Internal server error' });
+  }
+}
+
+async function loadConfiguration(): Promise<StartConfiguration> {
+  const now = Date.now();
+  if (configurationCache && configurationCache.expiresAt > now) {
+    return configurationCache.value;
+  }
+  const value: StartConfiguration = {
+    region,
+    partition: process.env.AWS_PARTITION ?? 'aws',
+    agentRuntimeArn: requiredEnvironment('AGENT_RUNTIME_ARN'),
+    executionRoleArn: requiredEnvironment('RUNTIME_EXECUTION_ROLE_ARN'),
+    logGroup: requiredEnvironment('RUNTIME_LOG_GROUP'),
+    inferenceMode: 'bedrock',
+    allowClaudeAiSubscription:
+      process.env.ALLOW_CLAUDE_AI_SUBSCRIPTION === 'true',
+    bedrockModelId: requiredEnvironment('BEDROCK_MODEL_ID'),
+    controlApiUrl: process.env.CONTROL_API_URL || observedApiUrl,
+    idleAfterSeconds: positiveInteger('IDLE_AFTER_SECONDS'),
+    suspendedRetentionSeconds: 3_600,
+  };
+  configurationCache = { expiresAt: now + 60_000, value };
+  return value;
+}
+
+function observeApiUrl(event: APIGatewayProxyEvent): void {
+  const { apiId, stage } = event.requestContext;
+  if (apiId && stage) {
+    observedApiUrl = `https://${apiId}.execute-api.${region}.amazonaws.com/${stage}`;
+    if (configurationCache) {
+      configurationCache.value.controlApiUrl =
+        process.env.CONTROL_API_URL || observedApiUrl;
+    }
+  }
+}
+
+function assertRuntimeExecutionCaller(principal: string): void {
+  const executionRoleArn = requiredEnvironment('RUNTIME_EXECUTION_ROLE_ARN');
+  const roleName = executionRoleArn.split('/').pop();
+  const principalRoleName = principal.split('/').slice(-2, -1)[0];
+  if (
+    !roleName ||
+    !principal.includes(':assumed-role/') ||
+    principalRoleName !== roleName
+  ) {
+    throw new ControlError(
+      403,
+      'Caller is not the AgentCore Runtime execution role',
+    );
+  }
+}
+
+function callerPrincipal(event: APIGatewayProxyEvent): string {
+  const principal =
+    event.requestContext.identity.userArn ??
+    event.requestContext.identity.caller;
+  if (!principal || !principal.startsWith('arn:')) {
+    throw new ControlError(403, 'An IAM-authenticated caller is required');
+  }
+  return principal;
+}
+
+function parseBody(event: APIGatewayProxyEvent): Record<string, unknown> {
+  if (!event.body) {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(
+      event.isBase64Encoded
+        ? Buffer.from(event.body, 'base64').toString('utf8')
+        : event.body,
+    );
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error('not an object');
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    throw new ControlError(400, 'Request body must be a JSON object');
+  }
+}
+
+function optionalString(value: unknown): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value !== 'string') {
+    throw new ControlError(400, 'Expected a string value');
+  }
+  return value;
+}
+
+function optionalAccessMode(value: unknown): AccessMode | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (value !== 'terminal' && value !== 'vscode') {
+    throw new ControlError(400, 'accessMode must be terminal or vscode');
+  }
+  return value;
+}
+
+function optionalInferenceMode(value: unknown): InferenceMode | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (
+    value !== 'bedrock' &&
+    value !== 'claude-ai' &&
+    value !== 'claude-gateway'
+  ) {
+    throw new ControlError(
+      400,
+      'inferenceMode must be bedrock, claude-ai, or claude-gateway',
+    );
+  }
+  return value;
+}
+
+function publicSession(record: SessionRecord): Record<string, unknown> {
+  return {
+    sessionId: record.sessionId,
+    workspaceId: record.workspaceId,
+    state: record.state,
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+    lastActivityAt: record.lastActivityAt,
+    runtimeStartedAt: record.runtimeStartedAt,
+    runtimeExpiresAt: record.runtimeExpiresAt,
+    failureReason: record.failureReason || undefined,
+    inferenceMode: record.inferenceMode,
+    accessMode: record.accessMode ?? 'terminal',
+  };
+}
+
+function response(
+  statusCode: number,
+  body: Record<string, unknown>,
+): APIGatewayProxyResult {
+  return {
+    statusCode,
+    headers: {
+      'cache-control': 'no-store',
+      'content-type': 'application/json',
+      'strict-transport-security': 'max-age=31536000',
+    },
+    body: JSON.stringify(body),
+  };
+}
+
+function requiredEnvironment(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+function positiveInteger(name: string): number {
+  const value = Number.parseInt(requiredEnvironment(name), 10);
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return value;
+}
+
+function isReconcilerEvent(
+  event: ControlEvent,
+): event is EventBridgeEvent<string, unknown> & {
+  source: 'session-reconciler';
+} {
+  return 'source' in event && event.source === 'session-reconciler';
+}
+
+function isApiGatewayEvent(
+  event: ControlEvent,
+): event is APIGatewayProxyEvent {
+  return 'httpMethod' in event && typeof event.httpMethod === 'string';
+}

--- a/claude-code-on-agentcore-runtime-microvm/control-plane/src/handler.ts
+++ b/claude-code-on-agentcore-runtime-microvm/control-plane/src/handler.ts
@@ -1,7 +1,8 @@
 import { BedrockAgentCoreClient } from '@aws-sdk/client-bedrock-agentcore';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { S3Client } from '@aws-sdk/client-s3';
-import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import { DynamoDBDocumentClient, PutCommand } from '@aws-sdk/lib-dynamodb';
+import { randomBytes } from 'node:crypto';
 import type {
   APIGatewayProxyEvent,
   APIGatewayProxyResult,
@@ -129,9 +130,12 @@ export async function handler(
     }
     if (method === 'POST' && path === '/sessions/{sessionId}/connect') {
       const result = await service.connect(ownerPrincipal, sessionId);
+      const shellUrl = portal
+        ? await mintRelayShellUrl(event, result.connection)
+        : result.connection.endpoint;
       return response(200, {
         session: publicSession(result.record),
-        shellUrl: result.connection.endpoint,
+        shellUrl,
         runtimeSessionId: result.connection.runtimeSessionId,
         shellId: result.connection.shellId,
         tokenExpiresAt: result.connection.expiresAt,
@@ -320,6 +324,53 @@ function requiredEnvironment(name: string): string {
     throw new Error(`Missing required environment variable: ${name}`);
   }
   return value;
+}
+
+// Mints a short-lived, single-use token the browser terminal exchanges for
+// a signed shell connection at the relay (relay/src/index.ts). The real
+// AgentCore identifiers never reach the browser -- only this opaque token
+// does, and it is consumed atomically on first use (see the relay's
+// DeleteCommand-with-condition). Falls back to the raw endpoint if the
+// relay isn't deployed (RELAY_TOKENS_TABLE_NAME unset), so this sample
+// still degrades gracefully for anyone who deploys the portal without the
+// relay's additional manual ALB wiring (see README, "Public access").
+async function mintRelayShellUrl(
+  event: APIGatewayProxyEvent,
+  connection: { endpoint: string; runtimeSessionId: string; shellId: string },
+): Promise<string> {
+  const tableName = process.env.RELAY_TOKENS_TABLE_NAME;
+  const host = headerValue(event, 'host');
+  if (!tableName || !host) {
+    return connection.endpoint;
+  }
+  const config = await loadConfiguration();
+  const token = randomBytes(24).toString('base64url');
+  const ttl = Math.floor(Date.now() / 1_000) + 120;
+  await documentClient.send(
+    new PutCommand({
+      TableName: tableName,
+      Item: {
+        token,
+        runtimeSessionId: connection.runtimeSessionId,
+        shellId: connection.shellId,
+        agentRuntimeArn: config.agentRuntimeArn,
+        ttl,
+      },
+    }),
+  );
+  return `wss://${host}/shell?token=${token}`;
+}
+
+function headerValue(
+  event: APIGatewayProxyEvent,
+  name: string,
+): string | undefined {
+  for (const [key, value] of Object.entries(event.headers ?? {})) {
+    if (key.toLowerCase() === name && value) {
+      return value;
+    }
+  }
+  return undefined;
 }
 
 function positiveInteger(name: string): number {

--- a/claude-code-on-agentcore-runtime-microvm/control-plane/src/handler.ts
+++ b/claude-code-on-agentcore-runtime-microvm/control-plane/src/handler.ts
@@ -18,6 +18,7 @@ import type {
   SessionRecord,
   StartConfiguration,
 } from './model.js';
+import { isPortalRoute, portalCaller, portalRoutePath } from './portal.js';
 import { ControlError, ControlService } from './service.js';
 
 type ControlEvent =
@@ -63,13 +64,20 @@ export async function handler(
   observeApiUrl(event);
 
   try {
-    const ownerPrincipal = callerPrincipal(event);
+    // Portal routes accept Cognito browser tokens. Their owner is
+    // oidc:<sub> rather than an IAM caller ARN, so the two identity
+    // namespaces never collide.
+    const portal = isPortalRoute(event);
+    const ownerPrincipal = portal
+      ? portalCaller(event)
+      : callerPrincipal(event);
     const method = event.httpMethod.toUpperCase();
-    const path = event.resource;
+    const path = portal ? portalRoutePath(event.resource) : event.resource;
     const sessionId = event.pathParameters?.sessionId;
 
     if (
       method === 'POST' &&
+      !portal &&
       path === '/sessions/{sessionId}/checkpoint-urls'
     ) {
       if (!sessionId) {

--- a/claude-code-on-agentcore-runtime-microvm/control-plane/src/model.ts
+++ b/claude-code-on-agentcore-runtime-microvm/control-plane/src/model.ts
@@ -1,0 +1,169 @@
+export const ACTIVE_STATES = [
+  'PROVISIONING',
+  'STARTING',
+  'RUNNING',
+  'SUSPENDING',
+  'SUSPENDED',
+  'RESUMING',
+  'TERMINATING',
+] as const;
+
+export type SessionState =
+  | (typeof ACTIVE_STATES)[number]
+  | 'TERMINATED'
+  | 'FAILED';
+
+export type InferenceMode =
+  | 'claude-gateway'
+  | 'bedrock'
+  | 'claude-ai';
+
+export type AccessMode = 'terminal' | 'vscode';
+
+export type TunnelIdentityProvider = 'microsoft' | 'github';
+
+export interface SessionRecord {
+  sessionId: string;
+  ownerHash: string;
+  workspaceId: string;
+  state: SessionState;
+  createdAt: number;
+  updatedAt: number;
+  lastActivityAt: number;
+  expiresAt: number;
+  // AgentCore Runtime identifiers. `runtimeSessionId` is the data-plane
+  // session id passed to InvokeAgentRuntime* calls; it must be >= 33
+  // characters, so it is distinct from our own `sessionId` (a UUID we
+  // control end to end for DynamoDB keys and ownership checks).
+  runtimeArn?: string;
+  runtimeSessionId?: string;
+  shellId?: string;
+  agentRuntimeEndpoint?: string;
+  runtimeVersion?: string;
+  runtimeStartedAt?: number;
+  runtimeExpiresAt?: number;
+  failureReason?: string;
+  inferenceMode?: InferenceMode;
+  accessMode?: AccessMode;
+  tunnelName?: string;
+  tunnelProvider?: TunnelIdentityProvider;
+}
+
+export interface StartConfiguration {
+  region: string;
+  partition: string;
+  agentRuntimeArn: string;
+  executionRoleArn: string;
+  logGroup: string;
+  inferenceMode: InferenceMode;
+  allowClaudeAiSubscription?: boolean;
+  claudeGatewayUrl?: string;
+  bedrockModelId?: string;
+  agentCoreGatewayUrl?: string;
+  controlApiUrl?: string;
+  idleAfterSeconds: number;
+  suspendedRetentionSeconds: number;
+}
+
+export interface RunResult {
+  runtimeSessionId: string;
+  state: string;
+  startedAt: number;
+  maximumDurationInSeconds: number;
+  runtimeVersion?: string;
+}
+
+export interface RuntimeSessionDescription {
+  runtimeSessionId: string;
+  state: string;
+  stateReason?: string;
+  maximumDurationInSeconds?: number;
+  startedAt?: number;
+}
+
+export interface ShellConnection {
+  /**
+   * The InvokeAgentRuntimeCommandShell WebSocket endpoint. The client
+   * must reconnect with the same `runtimeSessionId`/`shellId` pair
+   * before the 1-hour connection-duration limit expires (see the
+   * AgentCore Runtime interactive-shell quotas).
+   */
+  endpoint: string;
+  runtimeSessionId: string;
+  shellId: string;
+  authToken: string;
+  expiresAt: number;
+}
+
+export interface WorkspaceCheckpointAccess {
+  downloadUrl?: string;
+  uploadUrl: string;
+}
+
+export type CreateSessionResult =
+  | { created: true }
+  | { created: false; record: SessionRecord };
+
+export interface WorkspaceClaim {
+  workspaceKey: string;
+  sessionId: string;
+  ownerHash: string;
+  workspaceId: string;
+  expiresAt: number;
+}
+
+export interface SessionRepository {
+  get(sessionId: string): Promise<SessionRecord | undefined>;
+  create(record: SessionRecord): Promise<CreateSessionResult>;
+  releaseWorkspace(record: SessionRecord): Promise<void>;
+  listForOwner(ownerHash: string): Promise<SessionRecord[]>;
+  listStateUpdatedBefore(
+    state: SessionState,
+    updatedBefore: number,
+  ): Promise<SessionRecord[]>;
+  patch(
+    sessionId: string,
+    values: Partial<SessionRecord>,
+    expectedStates?: SessionState[],
+  ): Promise<boolean>;
+}
+
+/**
+ * Adapter over the AgentCore Runtime control- and data-plane APIs.
+ * `run` starts a new runtime *session* against the already-deployed
+ * agent runtime (the CfnRuntime resource created once by CDK); it does
+ * not create a new runtime per developer. Session lifecycle
+ * (suspend/resume/terminate) is emulated with lifecycle signals sent
+ * over the shell channel plus session bookkeeping, because AgentCore
+ * Runtime microVM sessions do not have first-class suspend/resume
+ * control-plane APIs the way Lambda MicroVMs do -- see
+ * docs/deployment-guide.md for the mapping this sample uses.
+ */
+export interface AgentRuntimeService {
+  run(input: {
+    agentRuntimeArn: string;
+    runtimeSessionId: string;
+    executionRoleArn: string;
+    payload: string;
+    clientToken: string;
+  }): Promise<RunResult>;
+  get(
+    agentRuntimeArn: string,
+    runtimeSessionId: string,
+  ): Promise<RuntimeSessionDescription>;
+  createShellConnection(
+    agentRuntimeArn: string,
+    runtimeSessionId: string,
+    shellId: string,
+  ): Promise<ShellConnection>;
+  suspend(runtimeSessionId: string): Promise<void>;
+  resume(agentRuntimeArn: string, runtimeSessionId: string): Promise<void>;
+  terminate(agentRuntimeArn: string, runtimeSessionId: string): Promise<void>;
+}
+
+export interface WorkspaceCheckpointService {
+  createAccess(
+    ownerHash: string,
+    workspaceId: string,
+  ): Promise<WorkspaceCheckpointAccess>;
+}

--- a/claude-code-on-agentcore-runtime-microvm/control-plane/src/model.ts
+++ b/claude-code-on-agentcore-runtime-microvm/control-plane/src/model.ts
@@ -156,7 +156,7 @@ export interface AgentRuntimeService {
     runtimeSessionId: string,
     shellId: string,
   ): Promise<ShellConnection>;
-  suspend(runtimeSessionId: string): Promise<void>;
+  suspend(agentRuntimeArn: string, runtimeSessionId: string): Promise<void>;
   resume(agentRuntimeArn: string, runtimeSessionId: string): Promise<void>;
   terminate(agentRuntimeArn: string, runtimeSessionId: string): Promise<void>;
 }

--- a/claude-code-on-agentcore-runtime-microvm/control-plane/src/portal.ts
+++ b/claude-code-on-agentcore-runtime-microvm/control-plane/src/portal.ts
@@ -1,0 +1,38 @@
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+import { ControlError } from './service.js';
+
+// Cognito-authenticated portal sessions are owned by the token subject, not
+// an IAM caller ARN. The oidc: prefix keeps that namespace disjoint from the
+// IAM principals used by the source-tree operator CLI, so a portal user and
+// a CLI caller can never collide on the same owner key.
+export const PORTAL_OWNER_PREFIX = 'oidc:';
+
+export function isPortalRoute(
+  event: Pick<APIGatewayProxyEvent, 'resource'>,
+): boolean {
+  return (
+    event.resource === '/portal' || event.resource.startsWith('/portal/')
+  );
+}
+
+export function portalRoutePath(resource: string): string {
+  return resource.slice('/portal'.length);
+}
+
+export function portalCaller(
+  event: Pick<APIGatewayProxyEvent, 'requestContext'>,
+): string {
+  const claims: unknown = event.requestContext.authorizer?.claims;
+  const rawSub =
+    claims !== null &&
+    typeof claims === 'object' &&
+    'sub' in claims &&
+    typeof (claims as Record<string, unknown>).sub === 'string'
+      ? ((claims as Record<string, unknown>).sub as string)
+      : undefined;
+  const sub = rawSub?.trim();
+  if (!sub) {
+    throw new ControlError(403, 'A Cognito-authenticated caller is required');
+  }
+  return `${PORTAL_OWNER_PREFIX}${sub}`;
+}

--- a/claude-code-on-agentcore-runtime-microvm/control-plane/src/service.ts
+++ b/claude-code-on-agentcore-runtime-microvm/control-plane/src/service.ts
@@ -1,0 +1,636 @@
+import { createHash, randomUUID, timingSafeEqual } from 'node:crypto';
+import { gzipSync } from 'node:zlib';
+import type {
+  AccessMode,
+  AgentRuntimeService,
+  InferenceMode,
+  RuntimeSessionDescription,
+  SessionRecord,
+  SessionRepository,
+  SessionState,
+  ShellConnection,
+  StartConfiguration,
+  WorkspaceCheckpointAccess,
+  WorkspaceCheckpointService,
+} from './model.js';
+import { ACTIVE_STATES } from './model.js';
+
+const WORKSPACE_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$/;
+const RECORD_TTL_SECONDS = 30 * 24 * 60 * 60;
+const MAX_RUN_HOOK_PAYLOAD_BYTES = 4_096;
+const MAX_DECODED_RUN_HOOK_PAYLOAD_BYTES = 16_384;
+const COMPRESSED_RUN_HOOK_PAYLOAD_PREFIX = 'gzip-base64:';
+const RECONCILE_AFTER_SECONDS = 60;
+const PROVISIONING_TIMEOUT_SECONDS = 5 * 60;
+const DEFAULT_EXPIRATION_LEAD_SECONDS = 45 * 60;
+
+export class ControlError extends Error {
+  public constructor(
+    public readonly statusCode: number,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+export interface ControlServiceOptions {
+  repository: SessionRepository;
+  agentRuntime: AgentRuntimeService;
+  checkpoints: WorkspaceCheckpointService;
+  loadConfiguration: () => Promise<StartConfiguration>;
+  expirationLeadSeconds?: number;
+  now?: () => number;
+  newId?: () => string;
+}
+
+export interface StartOptions {
+  accessMode?: AccessMode;
+  inferenceMode?: InferenceMode;
+}
+
+/**
+ * Session-lifecycle service for the AgentCore Runtime sample. This mirrors
+ * `ControlService` from `claude-code-on-lambda-microvm/control-plane/src/
+ * service.ts` closely, but only the `terminal` access mode is implemented
+ * -- see docs/deployment-guide.md ("What is different") for VS Code tunnel
+ * parity status.
+ */
+export class ControlService {
+  private readonly now: () => number;
+  private readonly newId: () => string;
+  private readonly expirationLeadSeconds: number;
+
+  public constructor(private readonly options: ControlServiceOptions) {
+    this.now = options.now ?? (() => Math.floor(Date.now() / 1_000));
+    this.newId = options.newId ?? randomUUID;
+    this.expirationLeadSeconds =
+      options.expirationLeadSeconds ?? DEFAULT_EXPIRATION_LEAD_SECONDS;
+  }
+
+  public ownerHash(ownerPrincipal: string): string {
+    return createHash('sha256').update(ownerPrincipal).digest('hex');
+  }
+
+  public async start(
+    ownerPrincipal: string,
+    requestedWorkspaceId?: string,
+    options: StartOptions = {},
+  ): Promise<{ record: SessionRecord; created: boolean }> {
+    const config = await this.options.loadConfiguration();
+    const ownerHash = this.ownerHash(ownerPrincipal);
+    const workspaceId = requestedWorkspaceId ?? 'default';
+    const accessMode = options.accessMode ?? 'terminal';
+    const inferenceMode = options.inferenceMode ?? config.inferenceMode;
+    if (!WORKSPACE_ID_PATTERN.test(workspaceId)) {
+      throw new ControlError(
+        400,
+        'workspaceId must be 1-64 letters, numbers, dots, underscores, or hyphens',
+      );
+    }
+    if (accessMode !== 'terminal') {
+      throw new ControlError(
+        400,
+        'Only the terminal access mode is implemented in this sample',
+      );
+    }
+    if (inferenceMode === 'claude-ai') {
+      if (!config.allowClaudeAiSubscription) {
+        throw new ControlError(
+          403,
+          'Claude.ai subscription access is not enabled for this deployment',
+        );
+      }
+    } else if (inferenceMode !== config.inferenceMode) {
+      throw new ControlError(
+        400,
+        `This deployment is configured for ${config.inferenceMode}`,
+      );
+    }
+
+    const existing = (
+      await this.options.repository.listForOwner(ownerHash)
+    ).find(
+      (record) =>
+        record.workspaceId === workspaceId &&
+        ACTIVE_STATES.includes(
+          record.state as (typeof ACTIVE_STATES)[number],
+        ),
+    );
+    if (existing) {
+      const current = existing.runtimeSessionId
+        ? await this.refreshFromRuntime(existing)
+        : existing;
+      if (
+        ACTIVE_STATES.includes(
+          current.state as (typeof ACTIVE_STATES)[number],
+        )
+      ) {
+        return { record: current, created: false };
+      }
+    }
+
+    const now = this.now();
+    const sessionId = this.newId();
+    const record: SessionRecord = {
+      sessionId,
+      ownerHash,
+      workspaceId,
+      state: 'PROVISIONING',
+      createdAt: now,
+      updatedAt: now,
+      lastActivityAt: now,
+      expiresAt: now + RECORD_TTL_SECONDS,
+      inferenceMode,
+      accessMode,
+    };
+
+    let recordStored = false;
+    try {
+      const createResult = await this.options.repository.create(record);
+      if (!createResult.created) {
+        return { record: createResult.record, created: false };
+      }
+      recordStored = true;
+
+      const checkpoint = await this.options.checkpoints.createAccess(
+        ownerHash,
+        workspaceId,
+      );
+      const runPayload = encodeRunHookPayload({
+        version: 1,
+        sessionId,
+        ownerHash,
+        workspaceId,
+        awsRegion: config.region,
+        inferenceMode,
+        accessMode,
+        bedrockModelId:
+          inferenceMode === 'bedrock' ? config.bedrockModelId : undefined,
+        controlApiUrl: config.controlApiUrl || undefined,
+        checkpoint,
+      });
+
+      const run = await this.options.agentRuntime.run({
+        agentRuntimeArn: config.agentRuntimeArn,
+        runtimeSessionId: sessionId,
+        executionRoleArn: config.executionRoleArn,
+        payload: runPayload,
+        clientToken: sessionId,
+      });
+      const updatedAt = this.now();
+      const patch: Partial<SessionRecord> = {
+        state: normalizeRuntimeState(run.state),
+        updatedAt,
+        runtimeArn: config.agentRuntimeArn,
+        runtimeSessionId: run.runtimeSessionId,
+        runtimeStartedAt: run.startedAt,
+        runtimeExpiresAt: run.startedAt + run.maximumDurationInSeconds,
+      };
+      const updated = await this.options.repository.patch(
+        sessionId,
+        patch,
+        ['PROVISIONING'],
+      );
+      if (!updated) {
+        throw new Error(
+          'Session changed state while the runtime was launching',
+        );
+      }
+      return { record: { ...record, ...patch }, created: true };
+    } catch (error) {
+      if (error instanceof ControlError && !recordStored) {
+        throw error;
+      }
+      const reason = safeErrorMessage(error);
+      if (recordStored) {
+        await Promise.allSettled([
+          this.options.repository.patch(
+            sessionId,
+            { state: 'FAILED', updatedAt: this.now(), failureReason: reason },
+            ['PROVISIONING'],
+          ),
+          this.options.repository.releaseWorkspace(record),
+        ]);
+      }
+      throw new ControlError(502, `Unable to launch AgentCore Runtime session: ${reason}`);
+    }
+  }
+
+  public async list(
+    ownerPrincipal: string,
+    refreshActive = false,
+  ): Promise<SessionRecord[]> {
+    const records = await this.options.repository.listForOwner(
+      this.ownerHash(ownerPrincipal),
+    );
+    if (!refreshActive) {
+      return records;
+    }
+    return Promise.all(
+      records.map((record) =>
+        record.runtimeSessionId && isActive(record.state)
+          ? this.refreshFromRuntime(record)
+          : record,
+      ),
+    );
+  }
+
+  public async get(
+    ownerPrincipal: string,
+    sessionId: string,
+  ): Promise<SessionRecord> {
+    const record = await this.getOwned(ownerPrincipal, sessionId);
+    return record.runtimeSessionId && isActive(record.state)
+      ? this.refreshFromRuntime(record)
+      : record;
+  }
+
+  public async connect(
+    ownerPrincipal: string,
+    sessionId: string,
+  ): Promise<{ record: SessionRecord; connection: ShellConnection }> {
+    let record = await this.getOwned(ownerPrincipal, sessionId);
+    if (!record.runtimeSessionId) {
+      throw new ControlError(409, 'Session has no runtime assigned');
+    }
+    if (record.state === 'TERMINATED' || record.state === 'FAILED') {
+      throw new ControlError(
+        409,
+        'Session is no longer connectable; start the workspace again',
+      );
+    }
+    const config = await this.options.loadConfiguration();
+    const shellId = `shell-${record.sessionId.slice(0, 24)}`;
+    const connection = await this.options.agentRuntime.createShellConnection(
+      config.agentRuntimeArn,
+      record.runtimeSessionId,
+      shellId,
+    );
+    const now = this.now();
+    const patch: Partial<SessionRecord> = {
+      state: 'RUNNING',
+      shellId,
+      lastActivityAt: now,
+      updatedAt: now,
+      failureReason: '',
+    };
+    await this.options.repository.patch(sessionId, patch, [
+      'STARTING',
+      'RUNNING',
+      'RESUMING',
+    ]);
+    record = { ...record, ...patch };
+    return { record, connection };
+  }
+
+  /**
+   * Emulated suspend: AgentCore Runtime has no per-session pause
+   * primitive, so this only checkpoints application state; the microVM
+   * keeps running until `terminate` or the 8h max lifetime. See
+   * `AwsAgentRuntimeService` for the full rationale.
+   */
+  public async suspend(
+    ownerPrincipal: string,
+    sessionId: string,
+  ): Promise<SessionRecord> {
+    const record = await this.get(ownerPrincipal, sessionId);
+    if (!record.runtimeSessionId) {
+      throw new ControlError(409, 'Session has no runtime assigned');
+    }
+    if (record.state === 'SUSPENDED' || record.state === 'SUSPENDING') {
+      return record;
+    }
+    if (record.state !== 'RUNNING') {
+      throw new ControlError(
+        409,
+        `Cannot suspend a session in ${record.state} state`,
+      );
+    }
+    const updatedAt = this.now();
+    const claimed = await this.options.repository.patch(
+      sessionId,
+      { state: 'SUSPENDED', updatedAt },
+      ['RUNNING'],
+    );
+    if (!claimed) {
+      return (await this.options.repository.get(sessionId)) ?? record;
+    }
+    await this.options.agentRuntime.suspend(record.runtimeSessionId);
+    return { ...record, state: 'SUSPENDED', updatedAt };
+  }
+
+  public async resume(
+    ownerPrincipal: string,
+    sessionId: string,
+  ): Promise<SessionRecord> {
+    const record = await this.get(ownerPrincipal, sessionId);
+    if (!record.runtimeSessionId) {
+      throw new ControlError(409, 'Session has no runtime assigned');
+    }
+    if (record.state === 'RUNNING' || record.state === 'RESUMING') {
+      return record;
+    }
+    if (record.state !== 'SUSPENDED') {
+      throw new ControlError(
+        409,
+        `Cannot resume a session in ${record.state} state`,
+      );
+    }
+    const updatedAt = this.now();
+    const claimed = await this.options.repository.patch(
+      sessionId,
+      { state: 'RUNNING', updatedAt, lastActivityAt: updatedAt },
+      ['SUSPENDED'],
+    );
+    if (!claimed) {
+      return (await this.options.repository.get(sessionId)) ?? record;
+    }
+    const config = await this.options.loadConfiguration();
+    await this.options.agentRuntime.resume(
+      config.agentRuntimeArn,
+      record.runtimeSessionId,
+    );
+    return { ...record, state: 'RUNNING', updatedAt, lastActivityAt: updatedAt };
+  }
+
+  public async terminate(
+    ownerPrincipal: string,
+    sessionId: string,
+  ): Promise<SessionRecord> {
+    const record = await this.getOwned(ownerPrincipal, sessionId);
+    if (record.state === 'TERMINATED' || record.state === 'TERMINATING') {
+      return record;
+    }
+    if (!record.runtimeSessionId) {
+      const updatedAt = this.now();
+      await this.options.repository.patch(
+        sessionId,
+        { state: 'TERMINATED', updatedAt },
+        [record.state],
+      );
+      await this.options.repository.releaseWorkspace(record);
+      return { ...record, state: 'TERMINATED', updatedAt };
+    }
+
+    const updatedAt = this.now();
+    const claimed = await this.options.repository.patch(
+      sessionId,
+      { state: 'TERMINATING', updatedAt },
+      [
+        'PROVISIONING',
+        'STARTING',
+        'RUNNING',
+        'SUSPENDING',
+        'SUSPENDED',
+        'RESUMING',
+        'FAILED',
+      ],
+    );
+    if (!claimed) {
+      return (await this.options.repository.get(sessionId)) ?? record;
+    }
+    const config = await this.options.loadConfiguration();
+    await this.options.agentRuntime.terminate(
+      config.agentRuntimeArn,
+      record.runtimeSessionId,
+    );
+    const finalUpdatedAt = this.now();
+    await this.options.repository.patch(
+      sessionId,
+      { state: 'TERMINATED', updatedAt: finalUpdatedAt },
+      ['TERMINATING'],
+    );
+    await this.options.repository.releaseWorkspace(record);
+    return { ...record, state: 'TERMINATED', updatedAt: finalUpdatedAt };
+  }
+
+  public async checkpointUrls(
+    sessionId: string,
+    runtimeSessionId: string,
+  ): Promise<WorkspaceCheckpointAccess> {
+    const record = await this.options.repository.get(sessionId);
+    if (
+      !record ||
+      !record.runtimeSessionId ||
+      record.runtimeSessionId !== runtimeSessionId
+    ) {
+      throw new ControlError(404, 'Session not found');
+    }
+    if (!isActive(record.state)) {
+      throw new ControlError(409, 'Session is no longer active');
+    }
+    return this.options.checkpoints.createAccess(
+      record.ownerHash,
+      record.workspaceId,
+    );
+  }
+
+  public async reconcile(): Promise<{ reconciled: number; failures: number }> {
+    const now = this.now();
+    const result = { reconciled: 0, failures: 0 };
+    for (const state of ACTIVE_STATES) {
+      const records = await this.options.repository.listStateUpdatedBefore(
+        state,
+        now,
+      );
+      for (const record of records) {
+        if (record.updatedAt > now - RECONCILE_AFTER_SECONDS) {
+          continue;
+        }
+        try {
+          if (!record.runtimeSessionId) {
+            if (
+              record.state === 'PROVISIONING' &&
+              record.updatedAt <= now - PROVISIONING_TIMEOUT_SECONDS
+            ) {
+              await this.options.repository.patch(
+                record.sessionId,
+                {
+                  state: 'FAILED',
+                  updatedAt: now,
+                  failureReason: 'AgentCore Runtime provisioning timed out',
+                },
+                ['PROVISIONING'],
+              );
+              await this.options.repository.releaseWorkspace(record);
+              result.reconciled += 1;
+            }
+            continue;
+          }
+          await this.refreshFromRuntime(record);
+          if (await this.terminateBeforeExpiry(record, now)) {
+            result.reconciled += 1;
+            continue;
+          }
+          result.reconciled += 1;
+        } catch (error) {
+          result.failures += 1;
+          console.error('state reconciliation failed', {
+            sessionId: record.sessionId,
+            error: safeErrorMessage(error),
+          });
+        }
+      }
+    }
+    return result;
+  }
+
+  private async terminateBeforeExpiry(
+    record: SessionRecord,
+    now: number,
+  ): Promise<boolean> {
+    if (
+      !record.runtimeSessionId ||
+      !record.runtimeExpiresAt ||
+      !['RUNNING', 'SUSPENDED', 'STARTING'].includes(record.state) ||
+      record.runtimeExpiresAt - now > this.expirationLeadSeconds
+    ) {
+      return false;
+    }
+    const claimed = await this.options.repository.patch(
+      record.sessionId,
+      {
+        state: 'TERMINATING',
+        updatedAt: now,
+        failureReason:
+          'Checkpoint-terminated before the AgentCore Runtime session ' +
+          'duration limit',
+      },
+      [record.state],
+    );
+    if (!claimed) {
+      return false;
+    }
+    const config = await this.options.loadConfiguration();
+    await this.options.agentRuntime.terminate(
+      config.agentRuntimeArn,
+      record.runtimeSessionId,
+    );
+    return true;
+  }
+
+  private async getOwned(
+    ownerPrincipal: string,
+    sessionId: string,
+  ): Promise<SessionRecord> {
+    const record = await this.options.repository.get(sessionId);
+    if (!record) {
+      throw new ControlError(404, 'Session not found');
+    }
+    this.assertOwner(record, ownerPrincipal);
+    return record;
+  }
+
+  private async refreshFromRuntime(
+    record: SessionRecord,
+  ): Promise<SessionRecord> {
+    if (!record.runtimeSessionId) {
+      return record;
+    }
+    let description: RuntimeSessionDescription;
+    try {
+      description = await this.options.agentRuntime.get(
+        record.runtimeArn ?? (await this.options.loadConfiguration()).agentRuntimeArn,
+        record.runtimeSessionId,
+      );
+    } catch (error) {
+      console.error('runtime session lookup failed', {
+        sessionId: record.sessionId,
+        error: safeErrorMessage(error),
+      });
+      return record;
+    }
+    const state = normalizeRuntimeState(description.state);
+    if (
+      (record.state === 'SUSPENDED' && state === 'TERMINATED') ||
+      (record.state === 'TERMINATING' && state !== 'TERMINATED')
+    ) {
+      return record;
+    }
+    // Do not let a stale/looked-up "not found" state override an
+    // in-app-managed SUSPENDED record: AgentCore Runtime has no real
+    // suspend, so ListSessions may still report RUNNING or nothing at all
+    // depending on service-side idle handling.
+    if (record.state === 'SUSPENDED') {
+      return record;
+    }
+    const patch: Partial<SessionRecord> = {
+      state,
+      updatedAt: this.now(),
+      failureReason: description.stateReason ?? '',
+    };
+    const updated = await this.options.repository.patch(
+      record.sessionId,
+      patch,
+      [record.state],
+    );
+    const current = updated ? { ...record, ...patch } : record;
+    if (updated && (state === 'TERMINATED' || state === 'FAILED')) {
+      await this.options.repository.releaseWorkspace(current);
+    }
+    return current;
+  }
+
+  private assertOwner(record: SessionRecord, ownerPrincipal: string): void {
+    const expected = Buffer.from(record.ownerHash, 'hex');
+    const actual = Buffer.from(this.ownerHash(ownerPrincipal), 'hex');
+    if (
+      expected.length !== actual.length ||
+      !timingSafeEqual(expected, actual)
+    ) {
+      throw new ControlError(404, 'Session not found');
+    }
+  }
+}
+
+export function normalizeRuntimeState(state: string): SessionState {
+  switch (state.toUpperCase()) {
+    case 'PENDING':
+    case 'STARTING':
+      return 'STARTING';
+    case 'RUNNING':
+    case 'ACTIVE':
+      return 'RUNNING';
+    case 'STOPPING':
+    case 'TERMINATING':
+      return 'TERMINATING';
+    case 'STOPPED':
+    case 'TERMINATED':
+      return 'TERMINATED';
+    case 'FAILED':
+      return 'FAILED';
+    default:
+      return 'RUNNING';
+  }
+}
+
+function isActive(state: SessionState): boolean {
+  return ACTIVE_STATES.includes(state as (typeof ACTIVE_STATES)[number]);
+}
+
+function safeErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message.slice(0, 500);
+  }
+  return 'Unknown error';
+}
+
+function encodeRunHookPayload(value: Record<string, unknown>): string {
+  const decoded = JSON.stringify(value);
+  const decodedBytes = Buffer.byteLength(decoded, 'utf8');
+  if (decodedBytes > MAX_DECODED_RUN_HOOK_PAYLOAD_BYTES) {
+    throw new Error('Run hook payload exceeds the 16 KiB decoded limit');
+  }
+  if (decodedBytes <= MAX_RUN_HOOK_PAYLOAD_BYTES) {
+    return decoded;
+  }
+  const encoded =
+    COMPRESSED_RUN_HOOK_PAYLOAD_PREFIX +
+    gzipSync(Buffer.from(decoded, 'utf8'), { level: 9 }).toString('base64');
+  if (Buffer.byteLength(encoded, 'utf8') > MAX_RUN_HOOK_PAYLOAD_BYTES) {
+    throw new Error(
+      'Compressed run hook payload exceeds the 4 KiB service limit',
+    );
+  }
+  return encoded;
+}

--- a/claude-code-on-agentcore-runtime-microvm/control-plane/src/service.ts
+++ b/claude-code-on-agentcore-runtime-microvm/control-plane/src/service.ts
@@ -22,6 +22,7 @@ const MAX_DECODED_RUN_HOOK_PAYLOAD_BYTES = 16_384;
 const COMPRESSED_RUN_HOOK_PAYLOAD_PREFIX = 'gzip-base64:';
 const RECONCILE_AFTER_SECONDS = 60;
 const PROVISIONING_TIMEOUT_SECONDS = 5 * 60;
+const TERMINATING_TIMEOUT_SECONDS = 3 * 60;
 const DEFAULT_EXPIRATION_LEAD_SECONDS = 45 * 60;
 
 export class ControlError extends Error {
@@ -538,6 +539,24 @@ export class ControlService {
         record.runtimeSessionId,
       );
     } catch (error) {
+      // A session stuck in TERMINATING is a dead end for the owner: it
+      // stays in ACTIVE_STATES forever, so start() keeps "reusing" it and
+      // the owner can never create a new environment for this workspace
+      // again. This is not hypothetical -- confirmed live: a session
+      // whose container had already exited kept returning a non-404
+      // RuntimeClientError (400) on every lookup, which isNotFound()
+      // correctly does not treat as TERMINATED, so it never healed on
+      // its own. After a grace period (to avoid racing a lookup that's
+      // merely transient), force the record to TERMINATED rather than
+      // leaving it stuck; being wrong in the direction of "let the owner
+      // start a new environment" is far less harmful than blocking them
+      // indefinitely.
+      if (
+        record.state === 'TERMINATING' &&
+        this.now() - record.updatedAt >= TERMINATING_TIMEOUT_SECONDS
+      ) {
+        return this.forceTerminated(record, safeErrorMessage(error));
+      }
       console.error('runtime session lookup failed', {
         sessionId: record.sessionId,
         error: safeErrorMessage(error),
@@ -545,10 +564,20 @@ export class ControlService {
       return record;
     }
     const state = normalizeRuntimeState(description.state);
-    if (
-      (record.state === 'SUSPENDED' && state === 'TERMINATED') ||
-      (record.state === 'TERMINATING' && state !== 'TERMINATED')
-    ) {
+    if (record.state === 'TERMINATING' && state !== 'TERMINATED') {
+      // Same dead-end as above, but for the case where the lookup
+      // *succeeds* yet keeps reporting a state other than TERMINATED
+      // (e.g. AgentCore's default-to-RUNNING fallback for an
+      // unrecognized state string) instead of throwing.
+      if (this.now() - record.updatedAt >= TERMINATING_TIMEOUT_SECONDS) {
+        return this.forceTerminated(
+          record,
+          description.stateReason ?? `stuck reporting ${state}`,
+        );
+      }
+      return record;
+    }
+    if (record.state === 'SUSPENDED' && state === 'TERMINATED') {
       return record;
     }
     // Do not let a stale/looked-up "not found" state override an
@@ -570,6 +599,33 @@ export class ControlService {
     );
     const current = updated ? { ...record, ...patch } : record;
     if (updated && (state === 'TERMINATED' || state === 'FAILED')) {
+      await this.options.repository.releaseWorkspace(current);
+    }
+    return current;
+  }
+
+  // Called when a TERMINATING record has outlived TERMINATING_TIMEOUT_SECONDS
+  // without the runtime ever confirming TERMINATED -- see the call sites in
+  // refreshFromRuntime() for why this dead end is real, not hypothetical.
+  private async forceTerminated(
+    record: SessionRecord,
+    reason: string,
+  ): Promise<SessionRecord> {
+    const patch: Partial<SessionRecord> = {
+      state: 'TERMINATED',
+      updatedAt: this.now(),
+      failureReason:
+        `Runtime state could not be confirmed after ` +
+        `${TERMINATING_TIMEOUT_SECONDS}s in TERMINATING; forced to ` +
+        `TERMINATED (${reason})`,
+    };
+    const updated = await this.options.repository.patch(
+      record.sessionId,
+      patch,
+      [record.state],
+    );
+    const current = updated ? { ...record, ...patch } : record;
+    if (updated) {
       await this.options.repository.releaseWorkspace(current);
     }
     return current;

--- a/claude-code-on-agentcore-runtime-microvm/control-plane/src/service.ts
+++ b/claude-code-on-agentcore-runtime-microvm/control-plane/src/service.ts
@@ -315,7 +315,11 @@ export class ControlService {
     if (!claimed) {
       return (await this.options.repository.get(sessionId)) ?? record;
     }
-    await this.options.agentRuntime.suspend(record.runtimeSessionId);
+    const config = await this.options.loadConfiguration();
+    await this.options.agentRuntime.suspend(
+      record.runtimeArn ?? config.agentRuntimeArn,
+      record.runtimeSessionId,
+    );
     return { ...record, state: 'SUSPENDED', updatedAt };
   }
 

--- a/claude-code-on-agentcore-runtime-microvm/control-plane/test/aws-adapters.test.ts
+++ b/claude-code-on-agentcore-runtime-microvm/control-plane/test/aws-adapters.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { BedrockAgentCoreClient } from '@aws-sdk/client-bedrock-agentcore';
+import {
+  InvokeAgentRuntimeCommand,
+  InvokeAgentRuntimeCommandCommand,
+  StopRuntimeSessionCommand,
+} from '@aws-sdk/client-bedrock-agentcore';
+import { AwsAgentRuntimeService } from '../src/aws-adapters.js';
+
+const AGENT_RUNTIME_ARN =
+  'arn:aws:bedrock-agentcore:us-east-1:111122223333:runtime/test';
+// 33+ chars, matching the real runtimeSessionId length constraint.
+const RUNTIME_SESSION_ID = 'session-1'.padEnd(36, '0');
+
+function invocationResponse(status: number, body: unknown) {
+  const encoded = Buffer.from(JSON.stringify(body), 'utf8');
+  return {
+    statusCode: status,
+    contentType: 'application/json',
+    response: {
+      transformToByteArray: async () => new Uint8Array(encoded),
+    },
+  };
+}
+
+function fakeClient(
+  send: (command: unknown) => Promise<unknown>,
+): BedrockAgentCoreClient {
+  return { send } as unknown as BedrockAgentCoreClient;
+}
+
+describe('AwsAgentRuntimeService.run', () => {
+  it('sends a bootstrap command to /invocations, not a shell-exec command', async () => {
+    const send = vi.fn(async (command: unknown) => {
+      expect(command).toBeInstanceOf(InvokeAgentRuntimeCommand);
+      expect(command).not.toBeInstanceOf(InvokeAgentRuntimeCommandCommand);
+      const input = (command as InvokeAgentRuntimeCommand).input;
+      expect(input.agentRuntimeArn).toBe(AGENT_RUNTIME_ARN);
+      expect(input.runtimeSessionId).toBe(RUNTIME_SESSION_ID);
+      const body = JSON.parse(Buffer.from(input.payload as Uint8Array).toString('utf8'));
+      expect(body).toEqual({ command: 'bootstrap', payload: '{"version":1}' });
+      return invocationResponse(200, {
+        status: 'success',
+        response: { status: 'initialized' },
+      });
+    });
+    const service = new AwsAgentRuntimeService(fakeClient(send));
+
+    const result = await service.run({
+      agentRuntimeArn: AGENT_RUNTIME_ARN,
+      runtimeSessionId: RUNTIME_SESSION_ID,
+      executionRoleArn: 'arn:aws:iam::111122223333:role/agentcore-runtime',
+      payload: '{"version":1}',
+      clientToken: RUNTIME_SESSION_ID,
+    });
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(result.state).toBe('RUNNING');
+    expect(result.runtimeSessionId).toBe(RUNTIME_SESSION_ID);
+  });
+
+  it('fails run() when the container reports a bootstrap failure', async () => {
+    const send = vi.fn(async () =>
+      invocationResponse(400, { message: 'Invalid request' }),
+    );
+    const service = new AwsAgentRuntimeService(fakeClient(send));
+
+    await expect(
+      service.run({
+        agentRuntimeArn: AGENT_RUNTIME_ARN,
+        runtimeSessionId: RUNTIME_SESSION_ID,
+        executionRoleArn: 'arn:aws:iam::111122223333:role/agentcore-runtime',
+        payload: '{"version":1}',
+        clientToken: RUNTIME_SESSION_ID,
+      }),
+    ).rejects.toThrow(/bootstrap.*failed/i);
+  });
+
+  it('fails run() when the container returns 200 but a non-success status', async () => {
+    const send = vi.fn(async () =>
+      invocationResponse(200, { status: 'already-initialized' }),
+    );
+    const service = new AwsAgentRuntimeService(fakeClient(send));
+
+    await expect(
+      service.run({
+        agentRuntimeArn: AGENT_RUNTIME_ARN,
+        runtimeSessionId: RUNTIME_SESSION_ID,
+        executionRoleArn: 'arn:aws:iam::111122223333:role/agentcore-runtime',
+        payload: '{"version":1}',
+        clientToken: RUNTIME_SESSION_ID,
+      }),
+    ).rejects.toThrow(/bootstrap.*failed/i);
+  });
+
+  it('rejects a runtimeSessionId shorter than 33 characters before calling AWS', async () => {
+    const send = vi.fn();
+    const service = new AwsAgentRuntimeService(fakeClient(send));
+
+    await expect(
+      service.run({
+        agentRuntimeArn: AGENT_RUNTIME_ARN,
+        runtimeSessionId: 'too-short',
+        executionRoleArn: 'arn:aws:iam::111122223333:role/agentcore-runtime',
+        payload: '{"version":1}',
+        clientToken: 'too-short',
+      }),
+    ).rejects.toThrow(/33 characters/);
+    expect(send).not.toHaveBeenCalled();
+  });
+});
+
+describe('AwsAgentRuntimeService.suspend', () => {
+  it('sends a suspend command to /invocations so the container checkpoints', async () => {
+    const send = vi.fn(async (command: unknown) => {
+      expect(command).toBeInstanceOf(InvokeAgentRuntimeCommand);
+      const input = (command as InvokeAgentRuntimeCommand).input;
+      const body = JSON.parse(Buffer.from(input.payload as Uint8Array).toString('utf8'));
+      expect(body).toEqual({ command: 'suspend' });
+      return invocationResponse(200, {
+        status: 'success',
+        response: { status: 'checkpointed', operation: 'suspend' },
+      });
+    });
+    const service = new AwsAgentRuntimeService(fakeClient(send));
+
+    await service.suspend(AGENT_RUNTIME_ARN, RUNTIME_SESSION_ID);
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws when the container fails to checkpoint on suspend', async () => {
+    const send = vi.fn(async () =>
+      invocationResponse(500, { message: 'Invocation failed' }),
+    );
+    const service = new AwsAgentRuntimeService(fakeClient(send));
+
+    await expect(
+      service.suspend(AGENT_RUNTIME_ARN, RUNTIME_SESSION_ID),
+    ).rejects.toThrow(/suspend.*failed/i);
+  });
+});
+
+describe('AwsAgentRuntimeService.terminate', () => {
+  it('checkpoints via /invocations before stopping the runtime session', async () => {
+    const calls: unknown[] = [];
+    const send = vi.fn(async (command: unknown) => {
+      calls.push(command);
+      if (command instanceof InvokeAgentRuntimeCommand) {
+        const body = JSON.parse(
+          Buffer.from(
+            (command.input.payload as Uint8Array) ?? new Uint8Array(),
+          ).toString('utf8'),
+        );
+        expect(body).toEqual({ command: 'terminate' });
+        return invocationResponse(200, {
+          status: 'success',
+          response: { status: 'checkpointed', operation: 'terminate' },
+        });
+      }
+      if (command instanceof StopRuntimeSessionCommand) {
+        return {};
+      }
+      throw new Error(`Unexpected command: ${String(command)}`);
+    });
+    const service = new AwsAgentRuntimeService(fakeClient(send));
+
+    await service.terminate(AGENT_RUNTIME_ARN, RUNTIME_SESSION_ID);
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).toBeInstanceOf(InvokeAgentRuntimeCommand);
+    expect(calls[1]).toBeInstanceOf(StopRuntimeSessionCommand);
+  });
+
+  it('still stops the runtime session when the checkpoint fails', async () => {
+    const stopCalls: unknown[] = [];
+    const send = vi.fn(async (command: unknown) => {
+      if (command instanceof InvokeAgentRuntimeCommand) {
+        return invocationResponse(500, { message: 'boom' });
+      }
+      if (command instanceof StopRuntimeSessionCommand) {
+        stopCalls.push(command);
+        return {};
+      }
+      throw new Error(`Unexpected command: ${String(command)}`);
+    });
+    const service = new AwsAgentRuntimeService(fakeClient(send));
+
+    await expect(
+      service.terminate(AGENT_RUNTIME_ARN, RUNTIME_SESSION_ID),
+    ).resolves.toBeUndefined();
+    expect(stopCalls).toHaveLength(1);
+  });
+
+  it('treats a ResourceNotFoundException from StopRuntimeSession as already-terminated', async () => {
+    const send = vi.fn(async (command: unknown) => {
+      if (command instanceof InvokeAgentRuntimeCommand) {
+        return invocationResponse(200, { status: 'success', response: {} });
+      }
+      if (command instanceof StopRuntimeSessionCommand) {
+        const error = new Error('not found');
+        error.name = 'ResourceNotFoundException';
+        throw error;
+      }
+      throw new Error(`Unexpected command: ${String(command)}`);
+    });
+    const service = new AwsAgentRuntimeService(fakeClient(send));
+
+    await expect(
+      service.terminate(AGENT_RUNTIME_ARN, RUNTIME_SESSION_ID),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/claude-code-on-agentcore-runtime-microvm/control-plane/test/portal.test.ts
+++ b/claude-code-on-agentcore-runtime-microvm/control-plane/test/portal.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+import { isPortalRoute, portalCaller, portalRoutePath } from '../src/portal.js';
+import { ControlError } from '../src/service.js';
+
+describe('isPortalRoute', () => {
+  it('matches the portal root and nested resources', () => {
+    expect(isPortalRoute({ resource: '/portal' })).toBe(true);
+    expect(isPortalRoute({ resource: '/portal/sessions' })).toBe(true);
+    expect(
+      isPortalRoute({ resource: '/portal/sessions/{sessionId}' }),
+    ).toBe(true);
+  });
+
+  it('does not match the IAM-authorized operator routes', () => {
+    expect(isPortalRoute({ resource: '/sessions' })).toBe(false);
+    expect(isPortalRoute({ resource: '/sessions/{sessionId}' })).toBe(false);
+  });
+});
+
+describe('portalRoutePath', () => {
+  it('strips the /portal prefix so it matches the operator route table', () => {
+    expect(portalRoutePath('/portal/sessions')).toBe('/sessions');
+    expect(portalRoutePath('/portal/sessions/{sessionId}')).toBe(
+      '/sessions/{sessionId}',
+    );
+  });
+});
+
+describe('portalCaller', () => {
+  it('derives an oidc: owner from the Cognito authorizer claims', () => {
+    const requestContext = {
+      authorizer: { claims: { sub: 'user-123' } },
+    } as unknown as APIGatewayProxyEvent['requestContext'];
+    expect(portalCaller({ requestContext })).toBe('oidc:user-123');
+  });
+
+  it('rejects a request with no Cognito claims', () => {
+    const requestContext =
+      {} as unknown as APIGatewayProxyEvent['requestContext'];
+    expect(() => portalCaller({ requestContext })).toThrow(ControlError);
+    try {
+      portalCaller({ requestContext });
+    } catch (error) {
+      expect((error as ControlError).statusCode).toBe(403);
+    }
+  });
+
+  it('rejects a blank subject claim', () => {
+    const requestContext = {
+      authorizer: { claims: { sub: '   ' } },
+    } as unknown as APIGatewayProxyEvent['requestContext'];
+    expect(() => portalCaller({ requestContext })).toThrow(ControlError);
+  });
+});

--- a/claude-code-on-agentcore-runtime-microvm/control-plane/test/service.test.ts
+++ b/claude-code-on-agentcore-runtime-microvm/control-plane/test/service.test.ts
@@ -1,0 +1,396 @@
+import { createHash } from 'node:crypto';
+import { gunzipSync } from 'node:zlib';
+import { describe, expect, it } from 'vitest';
+import type {
+  AgentRuntimeService,
+  CreateSessionResult,
+  RunResult,
+  RuntimeSessionDescription,
+  SessionRecord,
+  SessionRepository,
+  SessionState,
+  ShellConnection,
+  StartConfiguration,
+  WorkspaceCheckpointAccess,
+  WorkspaceCheckpointService,
+} from '../src/model.js';
+import { ACTIVE_STATES } from '../src/model.js';
+import { ControlError, ControlService } from '../src/service.js';
+
+const OWNER = 'arn:aws:iam::111122223333:user/alice';
+const OTHER_OWNER = 'arn:aws:iam::111122223333:user/bob';
+const NOW = 10_000;
+
+const CONFIGURATION: StartConfiguration = {
+  region: 'us-east-1',
+  partition: 'aws',
+  agentRuntimeArn:
+    'arn:aws:bedrock-agentcore:us-east-1:111122223333:runtime/test',
+  executionRoleArn: 'arn:aws:iam::111122223333:role/agentcore-runtime',
+  logGroup: '/claude-agentcore/agentcore-runtime',
+  inferenceMode: 'bedrock',
+  bedrockModelId: 'anthropic.claude-sonnet-5',
+  idleAfterSeconds: 900,
+  suspendedRetentionSeconds: 3_600,
+};
+
+class MemoryRepository implements SessionRepository {
+  public readonly records = new Map<string, SessionRecord>();
+  public readonly claims = new Map<string, string>();
+  public failCreate = false;
+
+  public async get(sessionId: string): Promise<SessionRecord | undefined> {
+    return this.records.get(sessionId);
+  }
+
+  public async create(record: SessionRecord): Promise<CreateSessionResult> {
+    if (this.failCreate) {
+      throw new Error('storage unavailable');
+    }
+    const key = `${record.ownerHash}#${record.workspaceId}`;
+    const claimedSessionId = this.claims.get(key);
+    const claimed = claimedSessionId
+      ? this.records.get(claimedSessionId)
+      : undefined;
+    if (
+      claimed &&
+      ACTIVE_STATES.includes(claimed.state as (typeof ACTIVE_STATES)[number])
+    ) {
+      return { created: false, record: claimed };
+    }
+    this.records.set(record.sessionId, { ...record });
+    this.claims.set(key, record.sessionId);
+    return { created: true };
+  }
+
+  public async releaseWorkspace(record: SessionRecord): Promise<void> {
+    const key = `${record.ownerHash}#${record.workspaceId}`;
+    if (this.claims.get(key) === record.sessionId) {
+      this.claims.delete(key);
+    }
+  }
+
+  public async listForOwner(ownerHash: string): Promise<SessionRecord[]> {
+    return [...this.records.values()].filter(
+      (record) => record.ownerHash === ownerHash,
+    );
+  }
+
+  public async listStateUpdatedBefore(
+    state: SessionState,
+    updatedBefore: number,
+  ): Promise<SessionRecord[]> {
+    return [...this.records.values()].filter(
+      (record) => record.state === state && record.updatedAt <= updatedBefore,
+    );
+  }
+
+  public async patch(
+    sessionId: string,
+    values: Partial<SessionRecord>,
+    expectedStates?: SessionState[],
+  ): Promise<boolean> {
+    const record = this.records.get(sessionId);
+    if (!record) return false;
+    if (expectedStates && !expectedStates.includes(record.state)) {
+      return false;
+    }
+    this.records.set(sessionId, { ...record, ...values });
+    return true;
+  }
+}
+
+class FakeAgentRuntimeService implements AgentRuntimeService {
+  public readonly sessions = new Map<string, RuntimeSessionDescription>();
+  public runCalls = 0;
+  public terminateCalls: string[] = [];
+  public runPayloads: string[] = [];
+
+  public async run(input: {
+    agentRuntimeArn: string;
+    runtimeSessionId: string;
+    executionRoleArn: string;
+    payload: string;
+    clientToken: string;
+  }): Promise<RunResult> {
+    this.runCalls += 1;
+    this.runPayloads.push(input.payload);
+    this.sessions.set(input.runtimeSessionId, {
+      runtimeSessionId: input.runtimeSessionId,
+      state: 'RUNNING',
+      startedAt: NOW,
+      maximumDurationInSeconds: 28_800,
+    });
+    return {
+      runtimeSessionId: input.runtimeSessionId,
+      state: 'RUNNING',
+      startedAt: NOW,
+      maximumDurationInSeconds: 28_800,
+    };
+  }
+
+  public async get(
+    _agentRuntimeArn: string,
+    runtimeSessionId: string,
+  ): Promise<RuntimeSessionDescription> {
+    return (
+      this.sessions.get(runtimeSessionId) ?? {
+        runtimeSessionId,
+        state: 'TERMINATED',
+      }
+    );
+  }
+
+  public async createShellConnection(
+    _agentRuntimeArn: string,
+    runtimeSessionId: string,
+    shellId: string,
+  ): Promise<ShellConnection> {
+    return {
+      endpoint: 'wss://bedrock-agentcore.us-east-1.amazonaws.com/shell',
+      runtimeSessionId,
+      shellId,
+      authToken: '',
+      expiresAt: NOW + 3_600,
+    };
+  }
+
+  public async suspend(): Promise<void> {
+    // No-op: matches the real adapter's emulated suspend.
+  }
+
+  public async resume(
+    _agentRuntimeArn: string,
+    runtimeSessionId: string,
+  ): Promise<void> {
+    const session = this.sessions.get(runtimeSessionId);
+    if (!session || session.state === 'TERMINATED') {
+      throw new Error('Cannot resume a terminated AgentCore Runtime session');
+    }
+  }
+
+  public async terminate(
+    _agentRuntimeArn: string,
+    runtimeSessionId: string,
+  ): Promise<void> {
+    this.terminateCalls.push(runtimeSessionId);
+    this.sessions.set(runtimeSessionId, {
+      runtimeSessionId,
+      state: 'TERMINATED',
+    });
+  }
+}
+
+class FakeCheckpointService implements WorkspaceCheckpointService {
+  public async createAccess(): Promise<WorkspaceCheckpointAccess> {
+    return { uploadUrl: 'https://bucket.s3.us-east-1.amazonaws.com/key' };
+  }
+}
+
+function newService(overrides?: {
+  repository?: SessionRepository;
+  agentRuntime?: AgentRuntimeService;
+  now?: () => number;
+  newId?: () => string;
+}): {
+  service: ControlService;
+  repository: MemoryRepository;
+  agentRuntime: FakeAgentRuntimeService;
+} {
+  const repository =
+    (overrides?.repository as MemoryRepository) ?? new MemoryRepository();
+  const agentRuntime =
+    (overrides?.agentRuntime as FakeAgentRuntimeService) ??
+    new FakeAgentRuntimeService();
+  let counter = 0;
+  const service = new ControlService({
+    repository,
+    agentRuntime,
+    checkpoints: new FakeCheckpointService(),
+    loadConfiguration: async () => CONFIGURATION,
+    now: overrides?.now ?? (() => NOW),
+    newId:
+      overrides?.newId ??
+      (() => {
+        counter += 1;
+        // 33+ chars, matching the real runtimeSessionId length constraint.
+        return `session-${counter}`.padEnd(36, '0');
+      }),
+  });
+  return { service, repository, agentRuntime };
+}
+
+describe('ControlService.start', () => {
+  it('creates a new session and launches the AgentCore Runtime', async () => {
+    const { service, agentRuntime } = newService();
+    const result = await service.start(OWNER, 'my-workspace');
+    expect(result.created).toBe(true);
+    expect(result.record.state).toBe('RUNNING');
+    expect(result.record.workspaceId).toBe('my-workspace');
+    expect(result.record.runtimeArn).toBe(CONFIGURATION.agentRuntimeArn);
+    expect(agentRuntime.runCalls).toBe(1);
+  });
+
+  it('reuses an active session for the same owner and workspace', async () => {
+    const { service } = newService();
+    const first = await service.start(OWNER, 'default');
+    const second = await service.start(OWNER, 'default');
+    expect(second.created).toBe(false);
+    expect(second.record.sessionId).toBe(first.record.sessionId);
+  });
+
+  it('rejects unsupported access modes', async () => {
+    const { service } = newService();
+    await expect(
+      service.start(OWNER, 'default', { accessMode: 'vscode' }),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it('rejects claude-ai inference mode when not allowed', async () => {
+    const { service } = newService();
+    await expect(
+      service.start(OWNER, 'default', { inferenceMode: 'claude-ai' }),
+    ).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it('rolls back the workspace claim when the runtime launch fails', async () => {
+    class FailingAgentRuntime extends FakeAgentRuntimeService {
+      public override async run(): Promise<RunResult> {
+        throw new Error('boom');
+      }
+    }
+    const { service, repository } = newService({
+      agentRuntime: new FailingAgentRuntime(),
+    });
+    await expect(service.start(OWNER, 'default')).rejects.toMatchObject({
+      statusCode: 502,
+    });
+    const records = await repository.listForOwner(
+      service.ownerHash(OWNER),
+    );
+    expect(records[0]?.state).toBe('FAILED');
+  });
+
+  it('scopes workspaces per owner', async () => {
+    const { service } = newService();
+    const alice = await service.start(OWNER, 'default');
+    const bob = await service.start(OTHER_OWNER, 'default');
+    expect(alice.record.sessionId).not.toBe(bob.record.sessionId);
+  });
+});
+
+describe('ControlService.connect', () => {
+  it('returns a shell connection for a running session', async () => {
+    const { service } = newService();
+    const started = await service.start(OWNER, 'default');
+    const connected = await service.connect(OWNER, started.record.sessionId);
+    expect(connected.connection.runtimeSessionId).toBe(
+      started.record.runtimeSessionId,
+    );
+    expect(connected.connection.shellId).toMatch(/^shell-/);
+    expect(connected.record.state).toBe('RUNNING');
+  });
+
+  it('rejects a caller that does not own the session', async () => {
+    const { service } = newService();
+    const started = await service.start(OWNER, 'default');
+    await expect(
+      service.connect(OTHER_OWNER, started.record.sessionId),
+    ).rejects.toMatchObject({ statusCode: 404 });
+  });
+});
+
+describe('ControlService.suspend/resume', () => {
+  it('emulates suspend without a control-plane pause primitive', async () => {
+    const { service, agentRuntime } = newService();
+    const started = await service.start(OWNER, 'default');
+    const suspended = await service.suspend(OWNER, started.record.sessionId);
+    expect(suspended.state).toBe('SUSPENDED');
+    // No real pause call is made; the AgentCore Runtime session keeps
+    // running underneath the emulated SUSPENDED app state.
+    expect(agentRuntime.terminateCalls).toHaveLength(0);
+
+    const resumed = await service.resume(OWNER, started.record.sessionId);
+    expect(resumed.state).toBe('RUNNING');
+  });
+
+  it('rejects suspending a session that is not running', async () => {
+    const { service } = newService();
+    const started = await service.start(OWNER, 'default');
+    await service.suspend(OWNER, started.record.sessionId);
+    await expect(
+      service.suspend(OWNER, started.record.sessionId),
+    ).resolves.toMatchObject({ state: 'SUSPENDED' });
+  });
+});
+
+describe('ControlService.terminate', () => {
+  it('stops the AgentCore Runtime session and releases the workspace claim', async () => {
+    const { service, agentRuntime, repository } = newService();
+    const started = await service.start(OWNER, 'default');
+    const terminated = await service.terminate(
+      OWNER,
+      started.record.sessionId,
+    );
+    expect(terminated.state).toBe('TERMINATED');
+    expect(agentRuntime.terminateCalls).toEqual([
+      started.record.runtimeSessionId,
+    ]);
+    // Terminating releases the workspace claim so the same workspaceId can
+    // be started again immediately.
+    const restarted = await service.start(OWNER, 'default');
+    expect(restarted.created).toBe(true);
+    expect(restarted.record.sessionId).not.toBe(started.record.sessionId);
+    void repository;
+  });
+
+  it('is idempotent for an already-terminated session', async () => {
+    const { service } = newService();
+    const started = await service.start(OWNER, 'default');
+    await service.terminate(OWNER, started.record.sessionId);
+    const again = await service.terminate(OWNER, started.record.sessionId);
+    expect(again.state).toBe('TERMINATED');
+  });
+});
+
+describe('ControlService.checkpointUrls', () => {
+  it('rejects a mismatched runtimeSessionId', async () => {
+    const { service } = newService();
+    const started = await service.start(OWNER, 'default');
+    await expect(
+      service.checkpointUrls(started.record.sessionId, 'wrong-runtime-id'),
+    ).rejects.toMatchObject({ statusCode: 404 });
+  });
+
+  it('returns checkpoint access for the active session', async () => {
+    const { service } = newService();
+    const started = await service.start(OWNER, 'default');
+    const access = await service.checkpointUrls(
+      started.record.sessionId,
+      started.record.runtimeSessionId!,
+    );
+    expect(access.uploadUrl).toContain('https://');
+  });
+});
+
+describe('run hook payload compression', () => {
+  it('round-trips through the AwsAgentRuntimeService payload encoding path', async () => {
+    const { service, agentRuntime } = newService();
+    await service.start(OWNER, 'default');
+    const [payload] = agentRuntime.runPayloads;
+    expect(payload).toBeDefined();
+    let decoded: string;
+    if (payload!.startsWith('gzip-base64:')) {
+      decoded = gunzipSync(
+        Buffer.from(payload!.slice('gzip-base64:'.length), 'base64'),
+      ).toString('utf8');
+    } else {
+      decoded = payload!;
+    }
+    const value = JSON.parse(decoded) as Record<string, unknown>;
+    expect(value.version).toBe(1);
+    expect(value.ownerHash).toBe(
+      createHash('sha256').update(OWNER).digest('hex'),
+    );
+  });
+});

--- a/claude-code-on-agentcore-runtime-microvm/control-plane/test/service.test.ts
+++ b/claude-code-on-agentcore-runtime-microvm/control-plane/test/service.test.ts
@@ -277,6 +277,105 @@ describe('ControlService.start', () => {
     const bob = await service.start(OTHER_OWNER, 'default');
     expect(alice.record.sessionId).not.toBe(bob.record.sessionId);
   });
+
+  // Confirmed live against a real deployment: a session whose runtime had
+  // already died kept returning a non-"not found" error (a RuntimeClientError
+  // 400, not a 404) on every lookup, so it never satisfied the "lookup
+  // succeeded and reported TERMINATED" condition and stayed in TERMINATING
+  // in DynamoDB forever -- meaning it also stayed in ACTIVE_STATES forever,
+  // so start() kept "reusing" the dead session on every call and the owner
+  // could never create a new environment for that workspace again. Nothing
+  // in the test suite exercised this before; both variants (lookup throws,
+  // lookup succeeds but never reports TERMINATED) are covered here.
+  it('unsticks a TERMINATING session once the runtime lookup keeps failing past the timeout', async () => {
+    class ThrowingAgentRuntime extends FakeAgentRuntimeService {
+      public override async get(): Promise<RuntimeSessionDescription> {
+        throw new Error('RuntimeClientError: Received error (400) from runtime');
+      }
+    }
+    const repository = new MemoryRepository();
+    let clock = NOW;
+    const { service } = newService({
+      repository,
+      agentRuntime: new ThrowingAgentRuntime(),
+      now: () => clock,
+    });
+    repository.records.set('stuck-session', {
+      sessionId: 'stuck-session',
+      ownerHash: service.ownerHash(OWNER),
+      workspaceId: 'default',
+      state: 'TERMINATING',
+      createdAt: NOW,
+      updatedAt: NOW,
+      lastActivityAt: NOW,
+      expiresAt: NOW + 3_600,
+      inferenceMode: 'bedrock',
+      accessMode: 'terminal',
+      runtimeArn: CONFIGURATION.agentRuntimeArn,
+      runtimeSessionId: 'runtime-stuck-session',
+    });
+    repository.claims.set(
+      `${service.ownerHash(OWNER)}#default`,
+      'stuck-session',
+    );
+
+    // Still within the grace period: stays stuck rather than guessing.
+    clock = NOW + 60;
+    const stillStuck = await service.start(OWNER, 'default');
+    expect(stillStuck.created).toBe(false);
+    expect(stillStuck.record.sessionId).toBe('stuck-session');
+    expect(stillStuck.record.state).toBe('TERMINATING');
+
+    // Past the grace period: force-heals to TERMINATED and lets a new
+    // environment be created instead of blocking the owner forever.
+    clock = NOW + 4 * 60;
+    const healed = await service.start(OWNER, 'default');
+    expect(healed.created).toBe(true);
+    expect(healed.record.sessionId).not.toBe('stuck-session');
+    const stuckRecord = await repository.get('stuck-session');
+    expect(stuckRecord?.state).toBe('TERMINATED');
+  });
+
+  it('unsticks a TERMINATING session once the runtime keeps reporting a non-TERMINATED state past the timeout', async () => {
+    const repository = new MemoryRepository();
+    let clock = NOW;
+    const agentRuntime = new FakeAgentRuntimeService();
+    agentRuntime.sessions.set('runtime-stuck-session-2', {
+      runtimeSessionId: 'runtime-stuck-session-2',
+      state: 'RUNNING',
+      startedAt: NOW,
+      maximumDurationInSeconds: 28_800,
+    });
+    const { service } = newService({
+      repository,
+      agentRuntime,
+      now: () => clock,
+    });
+    repository.records.set('stuck-session-2', {
+      sessionId: 'stuck-session-2',
+      ownerHash: service.ownerHash(OWNER),
+      workspaceId: 'default',
+      state: 'TERMINATING',
+      createdAt: NOW,
+      updatedAt: NOW,
+      lastActivityAt: NOW,
+      expiresAt: NOW + 3_600,
+      inferenceMode: 'bedrock',
+      accessMode: 'terminal',
+      runtimeArn: CONFIGURATION.agentRuntimeArn,
+      runtimeSessionId: 'runtime-stuck-session-2',
+    });
+    repository.claims.set(
+      `${service.ownerHash(OWNER)}#default`,
+      'stuck-session-2',
+    );
+
+    clock = NOW + 4 * 60;
+    const healed = await service.start(OWNER, 'default');
+    expect(healed.created).toBe(true);
+    const stuckRecord = await repository.get('stuck-session-2');
+    expect(stuckRecord?.state).toBe('TERMINATED');
+  });
 });
 
 describe('ControlService.connect', () => {

--- a/claude-code-on-agentcore-runtime-microvm/deployment.example.json
+++ b/claude-code-on-agentcore-runtime-microvm/deployment.example.json
@@ -1,0 +1,10 @@
+{
+  "region": "us-east-1",
+  "vpcCidr": "10.43.0.0/16",
+  "projectName": "claude-agentcore",
+  "trustedClientCidr": "10.101.0.0/22",
+  "bedrockModelId": "anthropic.claude-sonnet-5",
+  "allowClaudeAiSubscription": false,
+  "enablePortal": false,
+  "idleAfterSeconds": 900
+}

--- a/claude-code-on-agentcore-runtime-microvm/deployment.example.json
+++ b/claude-code-on-agentcore-runtime-microvm/deployment.example.json
@@ -5,6 +5,6 @@
   "trustedClientCidr": "10.101.0.0/22",
   "bedrockModelId": "anthropic.claude-sonnet-5",
   "allowClaudeAiSubscription": false,
-  "enablePortal": false,
+  "enablePortal": true,
   "idleAfterSeconds": 900
 }

--- a/claude-code-on-agentcore-runtime-microvm/infra/bin/app.ts
+++ b/claude-code-on-agentcore-runtime-microvm/infra/bin/app.ts
@@ -1,0 +1,17 @@
+import { createRequire } from 'node:module';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as cdk from 'aws-cdk-lib';
+import { AwsSolutionsChecks } from 'cdk-nag';
+import { AgentCoreRuntimeStack } from '../lib/platform-stack.js';
+
+const app = new cdk.App();
+cdk.Aspects.of(app).add(new AwsSolutionsChecks({ verbose: true }));
+const region = app.node.tryGetContext('region') ?? 'us-east-1';
+
+new AgentCoreRuntimeStack(app, 'ClaudeAgentCoreRuntimeStack', {
+  env: { region },
+  description:
+    'Private Claude Code developer environments on Amazon Bedrock ' +
+    'AgentCore Runtime',
+});

--- a/claude-code-on-agentcore-runtime-microvm/infra/lib/nag-acks.ts
+++ b/claude-code-on-agentcore-runtime-microvm/infra/lib/nag-acks.ts
@@ -1,0 +1,223 @@
+import { IConstruct } from 'constructs';
+import * as cdk from 'aws-cdk-lib';
+import { ackNag } from './nag.js';
+
+/**
+ * cdk-nag acknowledgements for ClaudeAgentCoreRuntimeStack. Mirrors the
+ * structure of claude-code-on-lambda-microvm/infra/lib/nag-acks.ts; see
+ * that file's header comment for the general approach.
+ */
+export function applyNagAcknowledgements(
+  stack: cdk.Stack,
+  options: {
+    bedrockFoundationModelId: string;
+    bedrockUsesInferenceProfile: boolean;
+    projectName: string;
+  },
+): void {
+  const region = cdk.Stack.of(stack).region;
+  const projectName = options.projectName;
+  const at = (path: string): IConstruct | undefined => {
+    let node: IConstruct | undefined = stack;
+    for (const part of path.split('/')) {
+      node = node?.node.tryFindChild(part);
+      if (!node) return undefined;
+    }
+    return node;
+  };
+  const ack = (
+    path: string,
+    ...rules: Array<{ id: string; reason: string }>
+  ): void => {
+    const scope = at(path);
+    if (scope) ackNag(scope, ...rules);
+  };
+
+  ackNag(
+    stack,
+    {
+      id: 'AwsSolutions::AwsSolutions-COG4',
+      reason:
+        'The /sessions* routes require AWS_IAM (SigV4) by design for the ' +
+        'IAM-authorized operator CLI path; when enablePortal is set, the ' +
+        'portal mirrors these routes behind a Cognito user pool ' +
+        'authorizer instead. The private API is additionally pinned to ' +
+        'one VPC endpoint by resource policy.',
+    },
+    {
+      id: 'AwsSolutions::AwsSolutions-L1',
+      reason:
+        'Runtime is intentionally pinned to NODEJS_22_X, the newest ' +
+        'Node.js LTS runtime the used aws-cdk-lib release models; the ' +
+        'sample pins versions deliberately for reproducibility.',
+    },
+    {
+      id: 'AwsSolutions-IAM4[Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole]',
+      reason:
+        'AWS-managed basic execution role grants only CloudWatch Logs ' +
+        'write for the function log group — the standard, minimal Lambda ' +
+        'logging policy.',
+    },
+    {
+      id: 'AwsSolutions::AwsSolutions-DDB3',
+      reason:
+        'WorkspaceClaims holds only short-TTL coordination records ' +
+        '(session locks) that are valueless after expiry; the durable ' +
+        'Sessions table has point-in-time recovery enabled.',
+    },
+  );
+
+  ack('Vpc/Resource', {
+    id: 'AwsSolutions::AwsSolutions-VPC7',
+    reason:
+      'Flow Logs are listed as customer production hardening in the ' +
+      'deployment guide; the sample omits them to keep baseline cost low.',
+  });
+  ack('ApiEndpointSecurityGroup/Resource', {
+    id: 'AwsSolutions::AwsSolutions-EC23',
+    reason:
+      'The rule cannot resolve the CfnParameter-driven trusted client ' +
+      'CIDR. The ingress source is the deployment-scoped routed private ' +
+      'CIDR and the runtime security group, never 0.0.0.0/0.',
+  });
+
+  ack('WorkspaceBucket/Resource', {
+    id: 'AwsSolutions::AwsSolutions-S1',
+    reason:
+      'Server access logging is deferred to customer production ' +
+      'hardening. The bucket is KMS-encrypted, SSL-enforced, private, and ' +
+      'object access is only via short-lived presigned URLs minted by ' +
+      'the control plane.',
+  });
+
+  ack('ControlApi/Resource', {
+    id: 'AwsSolutions::AwsSolutions-APIG2',
+    reason:
+      'Request bodies are validated in the handler (strict shape, ' +
+      'length, and enum checks with unit tests) where richer validation ' +
+      'than API Gateway basic validators is required anyway.',
+  });
+  ack('ControlApi/DeploymentStage.v1', {
+    id: 'AwsSolutions::AwsSolutions-APIG3',
+    reason:
+      'WAF is not attachable to private REST APIs; exposure is bounded ' +
+      'by the VPC-endpoint-pinned resource policy instead.',
+  });
+  ack('ControlApi/CloudWatchRole/Resource', {
+    id: 'AwsSolutions-IAM4[Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs]',
+    reason:
+      'AWS-managed policy required by API Gateway account settings to ' +
+      'deliver execution and access logs to CloudWatch.',
+  });
+
+  if (options.bedrockUsesInferenceProfile) {
+    ack('ControlFunction/ServiceRole/DefaultPolicy/Resource', {
+      id: `AwsSolutions-IAM5[Resource::arn:<AWS::Partition>:bedrock:*::foundation-model/${options.bedrockFoundationModelId}]`,
+      reason:
+        'Cross-region inference profiles require the foundation-model ' +
+        'ARN in every fan-out region (region segment wildcard); the ' +
+        'model identifier itself is pinned to the one approved Claude ' +
+        'model and the grant is limited to bedrock:InvokeModel and ' +
+        'InvokeModelWithResponseStream.',
+    });
+  }
+
+  ack('ControlFunction/ServiceRole/DefaultPolicy/Resource', {
+    id: 'AwsSolutions-IAM5[Action::s3:GetObject*]',
+    reason:
+      'CDK grantReadWrite action expansion scoped to the workspace ' +
+      'bucket, used only for per-session checkpoint object keys.',
+  });
+  ack('ControlFunction/ServiceRole/DefaultPolicy/Resource', {
+    id: 'AwsSolutions-IAM5[Action::s3:GetBucket*]',
+    reason:
+      'CDK grantReadWrite action expansion scoped to the workspace ' +
+      'bucket.',
+  });
+  ack('ControlFunction/ServiceRole/DefaultPolicy/Resource', {
+    id: 'AwsSolutions-IAM5[Action::s3:List*]',
+    reason:
+      'CDK grantReadWrite action expansion scoped to the workspace ' +
+      'bucket.',
+  });
+  ack('ControlFunction/ServiceRole/DefaultPolicy/Resource', {
+    id: 'AwsSolutions-IAM5[Action::s3:DeleteObject*]',
+    reason:
+      'CDK grantReadWrite action expansion scoped to the workspace ' +
+      'bucket.',
+  });
+  ack('ControlFunction/ServiceRole/DefaultPolicy/Resource', {
+    id: 'AwsSolutions-IAM5[Action::s3:Abort*]',
+    reason:
+      'CDK grantReadWrite action expansion scoped to the workspace ' +
+      'bucket.',
+  });
+  ack('ControlFunction/ServiceRole/DefaultPolicy/Resource', {
+    id: 'AwsSolutions-IAM5[Resource::<WorkspaceBucket53E30B92.Arn>/*]',
+    reason:
+      'CDK grantReadWrite action expansion scoped to the workspace ' +
+      'bucket object prefix.',
+  });
+  ack('ControlFunction/ServiceRole/DefaultPolicy/Resource', {
+    id: 'AwsSolutions-IAM5[Action::kms:GenerateDataKey*]',
+    reason:
+      'CDK grant API KMS action expansion scoped to the single ' +
+      'customer-managed data key.',
+  });
+  ack('ControlFunction/ServiceRole/DefaultPolicy/Resource', {
+    id: 'AwsSolutions-IAM5[Action::kms:ReEncrypt*]',
+    reason:
+      'CDK grant API KMS action expansion scoped to the single ' +
+      'customer-managed data key.',
+  });
+  ack('ControlFunction/ServiceRole/DefaultPolicy/Resource', {
+    id: 'AwsSolutions-IAM5[Resource::<Sessions8896A56D.Arn>/index/*]',
+    reason:
+      'CDK grant wildcard over the Sessions table GSIs (owner-updated ' +
+      'and state-updated indexes) used by list and reconcile queries.',
+  });
+  ack('ControlFunction/ServiceRole/DefaultPolicy/Resource', {
+    id: 'AwsSolutions-IAM5[Resource::*]',
+    reason:
+      'AgentCore Runtime data-plane APIs (InvokeAgentRuntime*, ' +
+      'ListSessions, StopRuntimeSession) require the agentRuntimeArn ' +
+      'wildcard suffix for session-scoped calls; per-session ownership ' +
+      'is enforced in application code with unit tests.',
+  });
+  ack('ControlFunction/ServiceRole/DefaultPolicy/Resource', {
+    id: 'AwsSolutions-IAM5[Resource::<AgentRuntime.AgentRuntimeArn>/*]',
+    reason:
+      'AgentCore Runtime data-plane APIs require the agentRuntimeArn ' +
+      'wildcard suffix for session-scoped calls; per-session ownership ' +
+      'is enforced in application code with unit tests.',
+  });
+
+  ack('RuntimeExecutionRole/DefaultPolicy/Resource', {
+    id: 'AwsSolutions-IAM5[Resource::*]',
+    reason:
+      'ecr:GetAuthorizationToken supports no resource-level ARNs; image ' +
+      'pull access itself is scoped to the one agent image repository.',
+  });
+  ack('RuntimeExecutionRole/DefaultPolicy/Resource', {
+    id: `AwsSolutions-IAM5[Resource::arn:<AWS::Partition>:execute-api:${region}:<AWS::AccountId>:<ControlApiAC3A38A3>/<ControlApiDeploymentStagev10C21D0B1>/POST/sessions/*/checkpoint-urls]`,
+    reason:
+      'Session-id path wildcard on exactly one route (checkpoint URL ' +
+      'refresh); the handler additionally verifies the caller is the ' +
+      'execution role and owns the session.',
+  });
+  ack('RuntimeExecutionRole/DefaultPolicy/Resource', {
+    id: `AwsSolutions-IAM5[Resource::arn:<AWS::Partition>:logs:${region}:<AWS::AccountId>:log-group:/${projectName}/agentcore-runtime:*]`,
+    reason:
+      'Log-stream wildcard beneath the single dedicated AgentCore ' +
+      'Runtime log group; stream names are runtime-generated.',
+  });
+  ack('RuntimeExecutionRole/DefaultPolicy/Resource', {
+    id: `AwsSolutions-IAM5[Resource::arn:<AWS::Partition>:logs:${region}:<AWS::AccountId>:log-group:/aws/bedrock-agentcore/runtimes/*]`,
+    reason:
+      'AgentCore Runtime writes container output to a service-managed ' +
+      'log group named after the generated agent runtime ID and ' +
+      'endpoint, which is not known until deploy time; the wildcard is ' +
+      'scoped to the AWS-owned /aws/bedrock-agentcore/runtimes/ prefix, ' +
+      'not customer resources.',
+  });
+}

--- a/claude-code-on-agentcore-runtime-microvm/infra/lib/nag-acks.ts
+++ b/claude-code-on-agentcore-runtime-microvm/infra/lib/nag-acks.ts
@@ -262,4 +262,38 @@ export function applyNagAcknowledgements(
       'scoped to the AWS-owned /aws/bedrock-agentcore/runtimes/ prefix, ' +
       'not customer resources.',
   });
+
+  ack('ShellRelayCluster/Resource', {
+    id: 'AwsSolutions-ECS4',
+    reason:
+      'Not applicable: Container Insights is explicitly enabled on this ' +
+      'cluster (containerInsightsV2: ENABLED).',
+  });
+  ack('ShellRelayTaskDefinition/Resource', {
+    id: 'AwsSolutions-ECS2',
+    reason:
+      'The two environment variables (AWS_REGION, RELAY_TOKENS_TABLE_NAME) ' +
+      'are non-sensitive configuration, not secrets -- the relay never ' +
+      'receives credentials, tokens, or session identifiers via its own ' +
+      'environment; those arrive per-connection from the browser and are ' +
+      'looked up in RelayTokens.',
+  });
+  ack('ShellRelayTaskDefinition/TaskRole/DefaultPolicy/Resource', {
+    id: 'AwsSolutions-IAM5[Resource::<AgentRuntime.AgentRuntimeArn>/*]',
+    reason:
+      'Matches the identical, already-acknowledged wildcard on ' +
+      'RuntimeExecutionRole: AgentCore Runtime data-plane APIs require ' +
+      'the agentRuntimeArn wildcard suffix for session-scoped calls. The ' +
+      'relay additionally only ever acts on a runtimeSessionId/shellId ' +
+      'pair it received via a single-use RelayTokens token that the ' +
+      'control plane minted after its own ownership check.',
+  });
+  ack('ShellRelayTaskDefinition/ExecutionRole/DefaultPolicy/Resource', {
+    id: 'AwsSolutions-IAM5[Resource::*]',
+    reason:
+      'CDK-generated Fargate execution role policy for ' +
+      'ecs.ContainerImage.fromAsset (ECR image pull authorization token, ' +
+      'which supports no resource-level ARN) and the CloudWatch Logs ' +
+      'stream this task writes to.',
+  });
 }

--- a/claude-code-on-agentcore-runtime-microvm/infra/lib/nag-acks.ts
+++ b/claude-code-on-agentcore-runtime-microvm/infra/lib/nag-acks.ts
@@ -145,24 +145,33 @@ export function applyNagAcknowledgements(
       'deliver execution and access logs to CloudWatch.',
   });
 
-  if (options.bedrockUsesInferenceProfile) {
-    // The wildcard is on RuntimeExecutionRole (the AgentCore Runtime
-    // microVM's role, which actually calls bedrock:InvokeModel), not
-    // ControlFunction (the control-plane Lambda, which never calls
-    // Bedrock directly) -- this suppression previously targeted the
-    // wrong construct path and cdk-nag flagged the finding as
-    // unsuppressed the first time this deployment actually exercised the
-    // inference-profile branch end to end.
-    ack('RuntimeExecutionRole/DefaultPolicy/Resource', {
-      id: `AwsSolutions-IAM5[Resource::arn:<AWS::Partition>:bedrock:*::foundation-model/${options.bedrockFoundationModelId}]`,
-      reason:
-        'Cross-region inference profiles require the foundation-model ' +
-        'ARN in every fan-out region (region segment wildcard); the ' +
-        'model identifier itself is pinned to the one approved Claude ' +
-        'model and the grant is limited to bedrock:InvokeModel and ' +
-        'InvokeModelWithResponseStream.',
-    });
-  }
+  // The wildcard is on RuntimeExecutionRole (the AgentCore Runtime
+  // microVM's role, which actually calls bedrock:InvokeModel), not
+  // ControlFunction (the control-plane Lambda, which never calls
+  // Bedrock directly). Scoped to all Bedrock foundation models and
+  // inference profiles in this account/region -- rather than the one
+  // model this deployment happens to be configured for -- because the
+  // Claude Code CLI's model shorthands ("sonnet", "opus", etc.) and
+  // users switching models at runtime need more than a single
+  // allow-listed ARN; the previous single-ARN scoping caused a
+  // confusing 403 the moment anything other than the exact configured
+  // model was invoked (confirmed live). The grant is still limited to
+  // bedrock:InvokeModel and InvokeModelWithResponseStream, and this
+  // role has no other permissions of consequence (see its own doc
+  // comment: deliberately no workspace S3 access).
+  ack('RuntimeExecutionRole/DefaultPolicy/Resource', {
+    id: 'AwsSolutions-IAM5[Resource::arn:<AWS::Partition>:bedrock:*::foundation-model/*]',
+    reason:
+      'Runtime role is intentionally allowed to invoke any Bedrock ' +
+      'foundation model (see Claude Code model-shorthand note above); ' +
+      'invocation is limited to InvokeModel/InvokeModelWithResponseStream.',
+  });
+  ack('RuntimeExecutionRole/DefaultPolicy/Resource', {
+    id: 'AwsSolutions-IAM5[Resource::arn:<AWS::Partition>:bedrock:us-west-2:<AWS::AccountId>:inference-profile/*]',
+    reason:
+      'Same rationale as the foundation-model wildcard above, for ' +
+      'cross-region inference profiles.',
+  });
 
   ack('ControlFunction/ServiceRole/DefaultPolicy/Resource', {
     id: 'AwsSolutions-IAM5[Action::s3:GetObject*]',

--- a/claude-code-on-agentcore-runtime-microvm/infra/lib/nag-acks.ts
+++ b/claude-code-on-agentcore-runtime-microvm/infra/lib/nag-acks.ts
@@ -81,6 +81,41 @@ export function applyNagAcknowledgements(
       'CIDR and the runtime security group, never 0.0.0.0/0.',
   });
 
+  ack('PortalUserPool/Resource', {
+    id: 'AwsSolutions::AwsSolutions-COG8',
+    reason:
+      'Advanced security / plus tier is a paid Cognito feature deferred ' +
+      'to customer production hardening, same as other cost-optional ' +
+      'controls in this sample; the user pool otherwise enforces a ' +
+      'strong password policy and email verification.',
+  }, {
+    id: 'AwsSolutions::AwsSolutions-COG2',
+    reason:
+      'MFA is deferred to customer production hardening, matching the ' +
+      'baseline-cost posture of this sample; the portal is additionally ' +
+      'gated behind admin-provisioned users (no self-signup) and the ' +
+      'deployment-scoped TrustedClientCidr on the underlying API.',
+  });
+
+  for (const assetPath of [
+    'portal/GET/Resource',
+    'portal/app.js/GET/Resource',
+    'portal/terminal-vendor.js/GET/Resource',
+    'portal/xterm.css/GET/Resource',
+    'portal/config.json/GET/Resource',
+  ]) {
+    ack(`ControlApi/Default/${assetPath}`, {
+      id: 'AwsSolutions::AwsSolutions-APIG4',
+      reason:
+        'These GET routes serve only the static, unauthenticated portal ' +
+        'SPA shell (HTML/CSS/JS) a browser must load before it can ' +
+        'obtain a Cognito token — the standard public-bootstrap-asset ' +
+        'pattern for a browser-based SPA. Every route that returns ' +
+        'session data or control-plane access (/portal/sessions*) ' +
+        'requires the Cognito user pool authorizer (PortalAuthorizer).',
+    });
+  }
+
   ack('WorkspaceBucket/Resource', {
     id: 'AwsSolutions::AwsSolutions-S1',
     reason:

--- a/claude-code-on-agentcore-runtime-microvm/infra/lib/nag-acks.ts
+++ b/claude-code-on-agentcore-runtime-microvm/infra/lib/nag-acks.ts
@@ -146,7 +146,14 @@ export function applyNagAcknowledgements(
   });
 
   if (options.bedrockUsesInferenceProfile) {
-    ack('ControlFunction/ServiceRole/DefaultPolicy/Resource', {
+    // The wildcard is on RuntimeExecutionRole (the AgentCore Runtime
+    // microVM's role, which actually calls bedrock:InvokeModel), not
+    // ControlFunction (the control-plane Lambda, which never calls
+    // Bedrock directly) -- this suppression previously targeted the
+    // wrong construct path and cdk-nag flagged the finding as
+    // unsuppressed the first time this deployment actually exercised the
+    // inference-profile branch end to end.
+    ack('RuntimeExecutionRole/DefaultPolicy/Resource', {
       id: `AwsSolutions-IAM5[Resource::arn:<AWS::Partition>:bedrock:*::foundation-model/${options.bedrockFoundationModelId}]`,
       reason:
         'Cross-region inference profiles require the foundation-model ' +

--- a/claude-code-on-agentcore-runtime-microvm/infra/lib/nag.ts
+++ b/claude-code-on-agentcore-runtime-microvm/infra/lib/nag.ts
@@ -1,0 +1,37 @@
+import { IConstruct } from 'constructs';
+import { Stack } from 'aws-cdk-lib';
+import { NagSuppressions, type NagPackSuppression } from 'cdk-nag';
+
+/**
+ * Apply cdk-nag suppressions through its public API. See the identical
+ * helper in claude-code-on-lambda-microvm/infra/lib/nag.ts for the full
+ * rationale (cdk-nag v2 pinned until cdklabs/cdk-nag#2359 is fixed).
+ */
+export function ackNag(
+  scope: IConstruct,
+  ...rules: Array<{ id: string; reason: string }>
+): void {
+  const suppressions = rules.map(toSuppression);
+  if (Stack.isStack(scope)) {
+    NagSuppressions.addStackSuppressions(scope, suppressions);
+  } else {
+    NagSuppressions.addResourceSuppressions(scope, suppressions);
+  }
+}
+
+function toSuppression(rule: {
+  id: string;
+  reason: string;
+}): NagPackSuppression {
+  const id = rule.id.replace(/^AwsSolutions::/, '');
+  const findingStart = id.indexOf('[');
+  if (findingStart < 0) return { id, reason: rule.reason };
+  if (!id.endsWith(']')) {
+    throw new Error(`Malformed cdk-nag finding ID: ${rule.id}`);
+  }
+  return {
+    id: id.slice(0, findingStart),
+    reason: rule.reason,
+    appliesTo: [id.slice(findingStart + 1, -1)],
+  };
+}

--- a/claude-code-on-agentcore-runtime-microvm/infra/lib/platform-stack.ts
+++ b/claude-code-on-agentcore-runtime-microvm/infra/lib/platform-stack.ts
@@ -1,0 +1,816 @@
+import { createRequire } from 'node:module';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as cdk from 'aws-cdk-lib';
+import * as apigateway from 'aws-cdk-lib/aws-apigateway';
+import * as bedrockagentcore from 'aws-cdk-lib/aws-bedrockagentcore';
+import * as cognito from 'aws-cdk-lib/aws-cognito';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as ecr from 'aws-cdk-lib/aws-ecr';
+import * as events from 'aws-cdk-lib/aws-events';
+import * as eventTargets from 'aws-cdk-lib/aws-events-targets';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as kms from 'aws-cdk-lib/aws-kms';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as lambdaNode from 'aws-cdk-lib/aws-lambda-nodejs';
+import * as logs from 'aws-cdk-lib/aws-logs';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import { Construct } from 'constructs';
+import { applyNagAcknowledgements } from './nag-acks.js';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(here, '../..');
+const require = createRequire(import.meta.url);
+const BEDROCK_INFERENCE_PROFILE_PREFIX = /^(?:us|eu|au|global)\./;
+const BEDROCK_MODEL_ID_PATTERN =
+  /^(?:(?:us|eu|au|global)\.)?anthropic\.claude-[A-Za-z0-9._:-]{1,180}$/;
+
+/**
+ * AgentCore-Runtime-native platform stack.
+ *
+ * This is the AgentCore Runtime equivalent of `ClaudeMicrovmStack` from the
+ * `claude-code-on-lambda-microvm` sample: same VPC/KMS/S3/DynamoDB/Cognito
+ * shape, but the developer sandbox compute is one `AWS::BedrockAgentCore::
+ * Runtime` (microVM compute type, container artifact) instead of a Lambda
+ * MicroVM image + Network Connector. See docs/deployment-guide.md for the
+ * full comparison and the reasons a few lifecycle operations are emulated
+ * rather than mapped 1:1 onto an AgentCore Runtime control-plane API.
+ */
+export class AgentCoreRuntimeStack extends cdk.Stack {
+  public constructor(
+    scope: Construct,
+    id: string,
+    props?: cdk.StackProps,
+  ) {
+    super(scope, id, props);
+    assertLocalEsbuild();
+
+    const projectName: string =
+      this.node.tryGetContext('projectName') ?? 'claude-agentcore';
+    if (!/^[a-z][a-z0-9-]{2,30}$/.test(projectName)) {
+      throw new Error(
+        'projectName context must be lowercase letters, numbers, or ' +
+          'hyphens, 3-31 characters, starting with a letter',
+      );
+    }
+    const vpcCidr =
+      this.node.tryGetContext('vpcCidr') ?? '10.43.0.0/16';
+    const bedrockModelId =
+      this.node.tryGetContext('bedrockModelId') ??
+      'anthropic.claude-sonnet-5';
+    if (!isApprovedBedrockModelId(bedrockModelId)) {
+      throw new Error('bedrockModelId is not an approved Claude model ID');
+    }
+    const bedrockUsesInferenceProfile =
+      BEDROCK_INFERENCE_PROFILE_PREFIX.test(bedrockModelId);
+    const bedrockFoundationModelId = bedrockModelId.replace(
+      BEDROCK_INFERENCE_PROFILE_PREFIX,
+      '',
+    );
+    const enablePortal = contextBoolean(
+      this.node.tryGetContext('enablePortal'),
+      false,
+    );
+    const idleAfterSeconds = new cdk.CfnParameter(
+      this,
+      'IdleAfterSeconds',
+      {
+        type: 'Number',
+        default: 900,
+        minValue: 60,
+        maxValue: 7200,
+        description:
+          'Seconds without shell traffic before a runtime session is ' +
+          'checkpoint-terminated by the reconciler.',
+      },
+    );
+    const trustedClientCidr = new cdk.CfnParameter(
+      this,
+      'TrustedClientCidr',
+      {
+        type: 'String',
+        default: '10.101.0.0/22',
+        description:
+          'Routed private CIDR allowed to call the control API from ' +
+          'developer devices.',
+      },
+    );
+
+    const vpc = new ec2.Vpc(this, 'Vpc', {
+      ipAddresses: ec2.IpAddresses.cidr(vpcCidr),
+      maxAzs: 2,
+      natGateways: 1,
+      restrictDefaultSecurityGroup: true,
+      subnetConfiguration: [
+        {
+          cidrMask: 24,
+          name: 'isolated',
+          subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
+        },
+        {
+          cidrMask: 28,
+          name: 'public-egress',
+          subnetType: ec2.SubnetType.PUBLIC,
+        },
+      ],
+    });
+
+    const dataKey = new kms.Key(this, 'DataKey', {
+      alias: `alias/${projectName}-data`,
+      description:
+        'Encrypts Claude AgentCore Runtime workspace archives and session ' +
+        'data.',
+      enableKeyRotation: true,
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+    });
+    const workspaceBucket = new s3.Bucket(this, 'WorkspaceBucket', {
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      bucketKeyEnabled: true,
+      encryption: s3.BucketEncryption.KMS,
+      encryptionKey: dataKey,
+      enforceSSL: true,
+      versioned: true,
+      lifecycleRules: [
+        {
+          abortIncompleteMultipartUploadAfter: cdk.Duration.days(1),
+          noncurrentVersionExpiration: cdk.Duration.days(90),
+        },
+      ],
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+    });
+
+    const sessions = new dynamodb.Table(this, 'Sessions', {
+      partitionKey: {
+        name: 'sessionId',
+        type: dynamodb.AttributeType.STRING,
+      },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      encryption: dynamodb.TableEncryption.CUSTOMER_MANAGED,
+      encryptionKey: dataKey,
+      pointInTimeRecoverySpecification: {
+        pointInTimeRecoveryEnabled: true,
+      },
+      timeToLiveAttribute: 'expiresAt',
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+    });
+    const workspaceClaims = new dynamodb.Table(this, 'WorkspaceClaims', {
+      partitionKey: {
+        name: 'workspaceKey',
+        type: dynamodb.AttributeType.STRING,
+      },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      encryption: dynamodb.TableEncryption.CUSTOMER_MANAGED,
+      encryptionKey: dataKey,
+      timeToLiveAttribute: 'expiresAt',
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+    sessions.addGlobalSecondaryIndex({
+      indexName: 'owner-updated-index',
+      partitionKey: {
+        name: 'ownerHash',
+        type: dynamodb.AttributeType.STRING,
+      },
+      sortKey: { name: 'updatedAt', type: dynamodb.AttributeType.NUMBER },
+      projectionType: dynamodb.ProjectionType.ALL,
+    });
+    sessions.addGlobalSecondaryIndex({
+      indexName: 'state-updated-index',
+      partitionKey: { name: 'state', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'updatedAt', type: dynamodb.AttributeType.NUMBER },
+      projectionType: dynamodb.ProjectionType.ALL,
+    });
+
+    // --- AgentCore Runtime container image ---------------------------------
+    // Container-based deployment (custom tooling: Claude Code + VS Code
+    // Server) instead of the direct-code deployment path. Unlike most CDK
+    // resources in this stack, the ECR repository and its image are NOT
+    // created by CDK: `CfnRuntime.agentRuntimeArtifact.containerConfiguration
+    // .containerUri` must resolve to an existing image at stack-create time,
+    // so there is a bootstrap ordering problem if CDK also owns the (empty)
+    // repository. `scripts/provision-agent-image.ts` creates the repository
+    // and pushes the first image *before* `cdk deploy` runs (mirroring how
+    // claude-code-on-lambda-microvm's scripts/provision-microvm.ts owns the
+    // MicroVM image outside CDK). CDK only references the repository by
+    // name here; day-2 image rebuilds use the same provisioning script and
+    // do not require a CDK deploy.
+    const repositoryName = `${projectName}-agent`;
+    const repository = ecr.Repository.fromRepositoryName(
+      this,
+      'AgentImageRepository',
+      repositoryName,
+    );
+
+    const runtimeSecurityGroup = new ec2.SecurityGroup(
+      this,
+      'RuntimeSecurityGroup',
+      {
+        vpc,
+        allowAllOutbound: false,
+        description:
+          'Egress allowed from the AgentCore Runtime microVM to approved ' +
+          'private services.',
+      },
+    );
+    const endpointSg = new ec2.SecurityGroup(this, 'EndpointSecurityGroup', {
+      vpc,
+      allowAllOutbound: false,
+      description:
+        'Workload interface endpoints: TLS from the AgentCore Runtime.',
+    });
+    const apiEndpointSg = new ec2.SecurityGroup(
+      this,
+      'ApiEndpointSecurityGroup',
+      {
+        vpc,
+        allowAllOutbound: false,
+        description:
+          'Private execute-api endpoint: TLS from trusted private clients.',
+      },
+    );
+    endpointSg.addIngressRule(
+      runtimeSecurityGroup,
+      ec2.Port.tcp(443),
+      'AgentCore Runtime sessions',
+    );
+    apiEndpointSg.addIngressRule(
+      ec2.Peer.ipv4(trustedClientCidr.valueAsString),
+      ec2.Port.tcp(443),
+      'Trusted private clients calling the control API',
+    );
+    apiEndpointSg.addIngressRule(
+      runtimeSecurityGroup,
+      ec2.Port.tcp(443),
+      'AgentCore Runtime refreshing checkpoint URLs',
+    );
+    runtimeSecurityGroup.addEgressRule(
+      ec2.Peer.anyIpv4(),
+      ec2.Port.tcp(443),
+      'HTTPS through private endpoints, peering, or the managed NAT gateway',
+    );
+
+    const s3Endpoint = vpc.addGatewayEndpoint('S3Endpoint', {
+      service: ec2.GatewayVpcEndpointAwsService.S3,
+      subnets: [{ subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS }],
+    });
+    s3Endpoint.addToPolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        principals: [new iam.AnyPrincipal()],
+        actions: ['s3:GetObject', 's3:PutObject'],
+        resources: [workspaceBucket.arnForObjects('*')],
+      }),
+    );
+    // ECR image layers are stored in an AWS-managed S3 bucket and fetched
+    // over this same gateway endpoint when pulling through a VPC (see AWS's
+    // ECR-in-a-VPC docs); without this statement, private ECR image pulls
+    // fail even though the ecr.api/ecr.dkr interface endpoints below are
+    // reachable.
+    s3Endpoint.addToPolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        principals: [new iam.AnyPrincipal()],
+        actions: ['s3:GetObject'],
+        resources: [
+          `arn:${this.partition}:s3:::prod-${this.region}-starport-layer-bucket/*`,
+        ],
+      }),
+    );
+    const addInterfaceEndpoint = (
+      idName: string,
+      service: ec2.IInterfaceVpcEndpointService,
+      securityGroup = endpointSg,
+    ): ec2.InterfaceVpcEndpoint =>
+      vpc.addInterfaceEndpoint(idName, {
+        service,
+        open: false,
+        privateDnsEnabled: true,
+        securityGroups: [securityGroup],
+        subnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
+      });
+    addInterfaceEndpoint(
+      'LogsEndpoint',
+      ec2.InterfaceVpcEndpointAwsService.CLOUDWATCH_LOGS,
+    );
+    addInterfaceEndpoint(
+      'EcrApiEndpoint',
+      ec2.InterfaceVpcEndpointAwsService.ECR,
+    );
+    addInterfaceEndpoint(
+      'EcrDkrEndpoint',
+      ec2.InterfaceVpcEndpointAwsService.ECR_DOCKER,
+    );
+    const executeApiEndpoint = addInterfaceEndpoint(
+      'ExecuteApiEndpoint',
+      ec2.InterfaceVpcEndpointAwsService.APIGATEWAY,
+      apiEndpointSg,
+    );
+    const bedrockRuntimeEndpoint = addInterfaceEndpoint(
+      'BedrockRuntimeEndpoint',
+      new ec2.InterfaceVpcEndpointService(
+        `com.amazonaws.${this.region}.bedrock-runtime`,
+        443,
+      ),
+    );
+    const bedrockAgentCoreDataEndpoint = addInterfaceEndpoint(
+      'BedrockAgentCoreDataEndpoint',
+      new ec2.InterfaceVpcEndpointService(
+        `com.amazonaws.${this.region}.bedrock-agentcore`,
+        443,
+      ),
+    );
+
+    // Execution role assumed by the AgentCore Runtime microVM. Deliberately
+    // has no direct workspace S3 access -- the control plane mints
+    // short-lived presigned URLs, mirroring the Lambda MicroVM sample.
+    const runtimeExecutionRole = new iam.Role(
+      this,
+      'RuntimeExecutionRole',
+      {
+        assumedBy: new iam.ServicePrincipal(
+          'bedrock-agentcore.amazonaws.com',
+        ),
+        description:
+          'Runtime role assumed by AgentCore Runtime sessions; ' +
+          'deliberately has no workspace S3 access.',
+      },
+    );
+    runtimeExecutionRole.addToPolicy(
+      new iam.PolicyStatement({
+        actions: [
+          'logs:CreateLogStream',
+          'logs:PutLogEvents',
+          'logs:DescribeLogStreams',
+          'logs:CreateLogGroup',
+        ],
+        resources: [
+          `arn:${this.partition}:logs:${this.region}:${this.account}:` +
+            `log-group:/${projectName}/agentcore-runtime:*`,
+          // AgentCore Runtime writes container stdout/stderr to its own
+          // service-managed log group (/aws/bedrock-agentcore/runtimes/
+          // <agentRuntimeId>-<endpoint>), not the custom log group above.
+          // Without this grant the container's own crash/error output never
+          // reaches CloudWatch, which makes InvokeAgentRuntime 400s
+          // undiagnosable from the client side.
+          `arn:${this.partition}:logs:${this.region}:${this.account}:` +
+            'log-group:/aws/bedrock-agentcore/runtimes/*',
+        ],
+      }),
+    );
+    runtimeExecutionRole.addToPolicy(
+      new iam.PolicyStatement({
+        actions: ['ecr:GetAuthorizationToken'],
+        resources: ['*'],
+      }),
+    );
+    repository.grantPull(runtimeExecutionRole);
+
+    const bedrockResources = [
+      `arn:${this.partition}:bedrock:*::foundation-model/${bedrockFoundationModelId}`,
+    ];
+    if (bedrockUsesInferenceProfile) {
+      bedrockResources.unshift(
+        this.formatArn({
+          service: 'bedrock',
+          resource: 'inference-profile',
+          resourceName: bedrockModelId,
+        }),
+      );
+    } else {
+      bedrockResources[0] =
+        `arn:${this.partition}:bedrock:${this.region}::` +
+        `foundation-model/${bedrockFoundationModelId}`;
+    }
+    const invokeBedrock = new iam.PolicyStatement({
+      actions: ['bedrock:InvokeModel', 'bedrock:InvokeModelWithResponseStream'],
+      resources: bedrockResources,
+    });
+    runtimeExecutionRole.addToPolicy(invokeBedrock);
+    bedrockRuntimeEndpoint.addToPolicy(
+      new iam.PolicyStatement({
+        actions: [
+          'bedrock:InvokeModel',
+          'bedrock:InvokeModelWithResponseStream',
+        ],
+        principals: [runtimeExecutionRole],
+        resources: bedrockResources,
+      }),
+    );
+
+    const runtimeLogGroup = new logs.LogGroup(this, 'RuntimeLogGroup', {
+      logGroupName: `/${projectName}/agentcore-runtime`,
+      retention: logs.RetentionDays.THREE_MONTHS,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+
+    // The AgentCore Runtime resource itself. `containerUri` must resolve
+    // to an image already pushed to `repository`; scripts/deploy.ts builds
+    // and pushes the image *before* `cdk deploy` runs for a first-time
+    // deployment, and CfnRuntime.agentRuntimeArtifact tracks the `:latest`
+    // tag so day-2 image rebuilds (scripts/provision-agent-image.ts) do not
+    // require a CDK deploy -- see docs/deployment-guide.md.
+    const agentRuntime = new bedrockagentcore.CfnRuntime(
+      this,
+      'AgentRuntime',
+      {
+        agentRuntimeName: `${projectName.replace(/-/g, '_')}_agent`,
+        agentRuntimeArtifact: {
+          containerConfiguration: {
+            containerUri: `${repository.repositoryUri}:latest`,
+          },
+        },
+        roleArn: runtimeExecutionRole.roleArn,
+        description:
+          'Private Claude Code developer environments on Amazon Bedrock ' +
+          'AgentCore Runtime',
+        networkConfiguration: {
+          networkMode: 'VPC',
+          networkModeConfig: {
+            securityGroups: [runtimeSecurityGroup.securityGroupId],
+            subnets: vpc.privateSubnets.map((subnet) => subnet.subnetId),
+          },
+        },
+        protocolConfiguration: 'HTTP',
+        environmentVariables: {
+          BEDROCK_MODEL_ID: bedrockModelId,
+          WORKSPACE_BUCKET_NAME: workspaceBucket.bucketName,
+        },
+        lifecycleConfiguration: {
+          // AgentCore Runtime microVM sessions cap at 8h, matching the
+          // Lambda MicroVM sample's maximumDurationInSeconds.
+          maxLifetime: 28_800,
+          idleRuntimeSessionTimeout: idleAfterSeconds.valueAsNumber,
+        },
+      },
+    );
+    // No node dependency on `repository` -- it is not a CDK-managed
+    // resource (see the comment above), so CDK cannot express "wait for the
+    // image to exist" as a dependency. `scripts/deploy.ts` runs
+    // provision-agent-image.ts before `cdk deploy` to guarantee ordering.
+
+    const controlLogGroup = new logs.LogGroup(this, 'ControlLogGroup', {
+      logGroupName: `/${projectName}/control-plane`,
+      retention: logs.RetentionDays.THREE_MONTHS,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+    const controlFunction = new lambdaNode.NodejsFunction(
+      this,
+      'ControlFunction',
+      {
+        runtime: lambda.Runtime.NODEJS_22_X,
+        architecture: lambda.Architecture.ARM_64,
+        entry: path.join(repositoryRoot, 'control-plane/src/handler.ts'),
+        handler: 'handler',
+        timeout: cdk.Duration.seconds(30),
+        memorySize: 512,
+        logGroup: controlLogGroup,
+        environment: {
+          AGENT_RUNTIME_ARN: agentRuntime.attrAgentRuntimeArn,
+          BEDROCK_MODEL_ID: bedrockModelId,
+          IDLE_AFTER_SECONDS: idleAfterSeconds.valueAsString,
+          RUNTIME_EXECUTION_ROLE_ARN: runtimeExecutionRole.roleArn,
+          RUNTIME_LOG_GROUP: runtimeLogGroup.logGroupName,
+          SESSION_TABLE_NAME: sessions.tableName,
+          WORKSPACE_BUCKET_NAME: workspaceBucket.bucketName,
+          WORKSPACE_CLAIM_TABLE_NAME: workspaceClaims.tableName,
+        },
+        bundling: { minify: true, sourceMap: true, externalModules: [] },
+      },
+    );
+    sessions.grantReadWriteData(controlFunction);
+    workspaceClaims.grantReadWriteData(controlFunction);
+    workspaceBucket.grantReadWrite(controlFunction);
+    dataKey.grantEncryptDecrypt(controlFunction);
+    controlFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ['dynamodb:TransactWriteItems'],
+        resources: [sessions.tableArn, workspaceClaims.tableArn],
+      }),
+    );
+    controlFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: [
+          'bedrock-agentcore:InvokeAgentRuntime',
+          'bedrock-agentcore:InvokeAgentRuntimeCommand',
+          'bedrock-agentcore:InvokeAgentRuntimeCommandShell',
+          'bedrock-agentcore:StopRuntimeSession',
+          'bedrock-agentcore:ListSessions',
+        ],
+        resources: [agentRuntime.attrAgentRuntimeArn, `${agentRuntime.attrAgentRuntimeArn}/*`],
+      }),
+    );
+    controlFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ['iam:PassRole'],
+        resources: [runtimeExecutionRole.roleArn],
+      }),
+    );
+    bedrockAgentCoreDataEndpoint.addToPolicy(
+      new iam.PolicyStatement({
+        actions: [
+          'bedrock-agentcore:InvokeAgentRuntime',
+          'bedrock-agentcore:InvokeAgentRuntimeCommand',
+          'bedrock-agentcore:InvokeAgentRuntimeCommandShell',
+          'bedrock-agentcore:StopRuntimeSession',
+          'bedrock-agentcore:ListSessions',
+        ],
+        principals: [controlFunction.grantPrincipal],
+        resources: [agentRuntime.attrAgentRuntimeArn, `${agentRuntime.attrAgentRuntimeArn}/*`],
+      }),
+    );
+
+    new events.Rule(this, 'IdleReaperSchedule', {
+      description:
+        'Reconciles stored session state with AgentCore Runtime session ' +
+        'state.',
+      schedule: events.Schedule.rate(cdk.Duration.minutes(1)),
+      targets: [
+        new eventTargets.LambdaFunction(controlFunction, {
+          event: events.RuleTargetInput.fromObject({
+            source: 'session-reconciler',
+          }),
+        }),
+      ],
+    });
+
+    const api = new apigateway.RestApi(this, 'ControlApi', {
+      restApiName: `${projectName}-control`,
+      description:
+        'Private IAM-authenticated lifecycle API for Claude AgentCore ' +
+        'Runtime sessions.',
+      endpointConfiguration: {
+        types: [apigateway.EndpointType.PRIVATE],
+        vpcEndpoints: [executeApiEndpoint],
+      },
+      cloudWatchRole: true,
+      deployOptions: {
+        stageName: 'v1',
+        loggingLevel: apigateway.MethodLoggingLevel.INFO,
+        dataTraceEnabled: false,
+        metricsEnabled: true,
+        accessLogDestination: new apigateway.LogGroupLogDestination(
+          new logs.LogGroup(this, 'ApiAccessLogGroup', {
+            retention: logs.RetentionDays.THREE_MONTHS,
+            removalPolicy: cdk.RemovalPolicy.DESTROY,
+          }),
+        ),
+        accessLogFormat: apigateway.AccessLogFormat.jsonWithStandardFields({
+          caller: true,
+          httpMethod: true,
+          ip: true,
+          protocol: true,
+          requestTime: true,
+          resourcePath: true,
+          responseLength: true,
+          status: true,
+          user: true,
+        }),
+      },
+      policy: new iam.PolicyDocument({
+        statements: [
+          new iam.PolicyStatement({
+            effect: iam.Effect.ALLOW,
+            actions: ['execute-api:Invoke'],
+            principals: [new iam.AnyPrincipal()],
+            resources: ['execute-api:/*'],
+            conditions: {
+              StringEquals: {
+                'aws:SourceVpce': executeApiEndpoint.vpcEndpointId,
+              },
+            },
+          }),
+          new iam.PolicyStatement({
+            effect: iam.Effect.DENY,
+            actions: ['execute-api:Invoke'],
+            principals: [new iam.AnyPrincipal()],
+            resources: ['execute-api:/*'],
+            conditions: {
+              StringNotEquals: {
+                'aws:SourceVpce': executeApiEndpoint.vpcEndpointId,
+              },
+            },
+          }),
+        ],
+      }),
+    });
+    const integration = new apigateway.LambdaIntegration(controlFunction, {
+      proxy: true,
+    });
+    const methodOptions: apigateway.MethodOptions = {
+      authorizationType: apigateway.AuthorizationType.IAM,
+    };
+    const sessionResource = api.root.addResource('sessions');
+    sessionResource.addMethod('GET', integration, methodOptions);
+    sessionResource.addMethod('POST', integration, methodOptions);
+    const byId = sessionResource.addResource('{sessionId}');
+    byId.addMethod('GET', integration, methodOptions);
+    byId.addMethod('DELETE', integration, methodOptions);
+    byId.addResource('connect').addMethod('POST', integration, methodOptions);
+    byId.addResource('suspend').addMethod('POST', integration, methodOptions);
+    byId.addResource('resume').addMethod('POST', integration, methodOptions);
+    byId
+      .addResource('checkpoint-urls')
+      .addMethod('POST', integration, methodOptions);
+    runtimeExecutionRole.addToPolicy(
+      new iam.PolicyStatement({
+        actions: ['execute-api:Invoke'],
+        resources: [
+          api.arnForExecuteApi(
+            'POST',
+            '/sessions/*/checkpoint-urls',
+            api.deploymentStage.stageName,
+          ),
+        ],
+      }),
+    );
+
+    if (enablePortal) {
+      const portalUrl =
+        `https://${api.restApiId}.execute-api.${this.region}.` +
+        `${this.urlSuffix}/v1/portal`;
+      const portalUserPool = new cognito.UserPool(this, 'PortalUserPool', {
+        selfSignUpEnabled: false,
+        signInAliases: { email: true },
+        autoVerify: { email: true },
+        accountRecovery: cognito.AccountRecovery.EMAIL_ONLY,
+        passwordPolicy: {
+          minLength: 12,
+          requireLowercase: true,
+          requireUppercase: true,
+          requireDigits: true,
+          requireSymbols: true,
+        },
+        removalPolicy: cdk.RemovalPolicy.DESTROY,
+      });
+      const portalDomainSuffix = cdk.Fn.select(
+        0,
+        cdk.Fn.split('-', cdk.Fn.select(2, cdk.Fn.split('/', this.stackId))),
+      );
+      const portalUserPoolDomain = portalUserPool.addDomain(
+        'PortalUserPoolDomain',
+        {
+          cognitoDomain: {
+            domainPrefix: `claude-agentcore-${portalDomainSuffix}`,
+          },
+        },
+      );
+      const portalUserPoolClient = portalUserPool.addClient(
+        'PortalUserPoolClient',
+        {
+          generateSecret: false,
+          authFlows: { userSrp: true },
+          oAuth: {
+            flows: { authorizationCodeGrant: true },
+            scopes: [
+              cognito.OAuthScope.OPENID,
+              cognito.OAuthScope.EMAIL,
+              cognito.OAuthScope.PROFILE,
+            ],
+            callbackUrls: [portalUrl],
+            logoutUrls: [portalUrl],
+          },
+          preventUserExistenceErrors: true,
+        },
+      );
+      const portalAuthorizer = new apigateway.CognitoUserPoolsAuthorizer(
+        this,
+        'PortalAuthorizer',
+        {
+          cognitoUserPools: [portalUserPool],
+          resultsCacheTtl: cdk.Duration.seconds(0),
+        },
+      );
+      const portalMethodOptions: apigateway.MethodOptions = {
+        authorizationType: apigateway.AuthorizationType.COGNITO,
+        authorizer: portalAuthorizer,
+      };
+      const portalSiteFunction = new lambdaNode.NodejsFunction(
+        this,
+        'PortalSiteFunction',
+        {
+          runtime: lambda.Runtime.NODEJS_22_X,
+          architecture: lambda.Architecture.ARM_64,
+          entry: path.join(repositoryRoot, 'portal/handler.ts'),
+          handler: 'handler',
+          timeout: cdk.Duration.seconds(10),
+          memorySize: 128,
+          logGroup: new logs.LogGroup(this, 'PortalLogGroup', {
+            logGroupName: `/${projectName}/portal`,
+            retention: logs.RetentionDays.THREE_MONTHS,
+            removalPolicy: cdk.RemovalPolicy.DESTROY,
+          }),
+          environment: {
+            PORTAL_CLIENT_ID: portalUserPoolClient.userPoolClientId,
+            PORTAL_USER_POOL_DOMAIN:
+              `${portalUserPoolDomain.domainName}.auth.` +
+              `${this.region}.amazoncognito.com`,
+          },
+          bundling: {
+            minify: true,
+            sourceMap: true,
+            externalModules: [],
+            nodeModules: ['@xterm/addon-fit', '@xterm/xterm'],
+          },
+        },
+      );
+      const portalSiteIntegration = new apigateway.LambdaIntegration(
+        portalSiteFunction,
+        { proxy: true },
+      );
+      const siteMethodOptions: apigateway.MethodOptions = {
+        authorizationType: apigateway.AuthorizationType.NONE,
+      };
+      const portal = api.root.addResource('portal');
+      portal.addMethod('GET', portalSiteIntegration, siteMethodOptions);
+      portal
+        .addResource('app.js')
+        .addMethod('GET', portalSiteIntegration, siteMethodOptions);
+      portal
+        .addResource('terminal-vendor.js')
+        .addMethod('GET', portalSiteIntegration, siteMethodOptions);
+      portal
+        .addResource('xterm.css')
+        .addMethod('GET', portalSiteIntegration, siteMethodOptions);
+      portal
+        .addResource('config.json')
+        .addMethod('GET', portalSiteIntegration, siteMethodOptions);
+      const portalSessions = portal.addResource('sessions');
+      portalSessions.addMethod('GET', integration, portalMethodOptions);
+      portalSessions.addMethod('POST', integration, portalMethodOptions);
+      const portalById = portalSessions.addResource('{sessionId}');
+      portalById.addMethod('GET', integration, portalMethodOptions);
+      portalById.addMethod('DELETE', integration, portalMethodOptions);
+      for (const actionPath of ['connect', 'suspend', 'resume']) {
+        portalById
+          .addResource(actionPath)
+          .addMethod('POST', integration, portalMethodOptions);
+      }
+      new cdk.CfnOutput(this, 'PortalUrl', { value: portalUrl });
+      new cdk.CfnOutput(this, 'PortalUserPoolId', {
+        value: portalUserPool.userPoolId,
+      });
+    }
+
+    new cdk.CfnOutput(this, 'AgentRuntimeArn', {
+      value: agentRuntime.attrAgentRuntimeArn,
+    });
+    new cdk.CfnOutput(this, 'AgentImageRepositoryUri', {
+      value: repository.repositoryUri,
+    });
+    new cdk.CfnOutput(this, 'ProjectNameOutput', { value: projectName })
+      .overrideLogicalId('ProjectName');
+    new cdk.CfnOutput(this, 'ControlApiUrl', {
+      value:
+        `https://${api.restApiId}.execute-api.${this.region}.` +
+        `${this.urlSuffix}/${api.deploymentStage.stageName}`,
+    });
+    new cdk.CfnOutput(this, 'DataKeyArn', { value: dataKey.keyArn });
+    new cdk.CfnOutput(this, 'IsolatedSubnetIds', {
+      value: vpc.privateSubnets.map((subnet) => subnet.subnetId).join(','),
+    });
+    new cdk.CfnOutput(this, 'RuntimeExecutionRoleArn', {
+      value: runtimeExecutionRole.roleArn,
+    });
+    new cdk.CfnOutput(this, 'RuntimeLogGroupName', {
+      value: runtimeLogGroup.logGroupName,
+    });
+    new cdk.CfnOutput(this, 'SessionsTableName', {
+      value: sessions.tableName,
+    });
+    new cdk.CfnOutput(this, 'VpcId', { value: vpc.vpcId });
+    new cdk.CfnOutput(this, 'WorkspaceBucketName', {
+      value: workspaceBucket.bucketName,
+    });
+    new cdk.CfnOutput(this, 'WorkspaceClaimsTableName', {
+      value: workspaceClaims.tableName,
+    });
+
+    applyNagAcknowledgements(this, {
+      bedrockFoundationModelId,
+      bedrockUsesInferenceProfile,
+      projectName,
+    });
+  }
+}
+
+function assertLocalEsbuild(): void {
+  try {
+    require.resolve('esbuild');
+  } catch {
+    throw new Error(
+      'Local esbuild is required for CDK synthesis. Run npm ci; ' +
+        'Docker fallback is intentionally disabled for this repository.',
+    );
+  }
+}
+
+function contextBoolean(value: unknown, defaultValue: boolean): boolean {
+  if (value === undefined) return defaultValue;
+  if (value === true || value === 'true') return true;
+  if (value === false || value === 'false') return false;
+  throw new Error('Boolean CDK context values must be true or false');
+}
+
+export function isApprovedBedrockModelId(value: unknown): value is string {
+  return typeof value === 'string' && BEDROCK_MODEL_ID_PATTERN.test(value);
+}

--- a/claude-code-on-agentcore-runtime-microvm/infra/lib/platform-stack.ts
+++ b/claude-code-on-agentcore-runtime-microvm/infra/lib/platform-stack.ts
@@ -80,6 +80,31 @@ export class AgentCoreRuntimeStack extends cdk.Stack {
     const portalPublicUrls = parsePortalPublicUrls(
       this.node.tryGetContext('portalPublicUrls'),
     );
+    // Security group of the external ALB fronting this deployment (see
+    // README, "Public access") -- that ALB is created outside this stack,
+    // so its security group can't be a construct we own. Needed so the
+    // shell relay's own security group can allow inbound 8080 from the
+    // ALB's *real* identity. A previous version of this code allowed
+    // ingress from apiEndpointSg instead (the private execute-api VPC
+    // endpoint's security group) -- a different security group entirely
+    // from the one ALB-to-target traffic actually carries, so that rule
+    // never worked. It was "fixed" by hand with a raw `aws ec2
+    // authorize-security-group-ingress` call outside of CDK, which is not
+    // durable: the next `cdk deploy` doesn't know about it, and depending
+    // on how the security group's rule set gets reconciled it can
+    // silently disappear, leaving the relay unreachable again with no
+    // code change to explain why (confirmed live, more than once).
+    const albSecurityGroupId = this.node.tryGetContext(
+      'albSecurityGroupId',
+    ) as string | undefined;
+    const albSecurityGroup = albSecurityGroupId
+      ? ec2.SecurityGroup.fromSecurityGroupId(
+          this,
+          'ExternalAlbSecurityGroup',
+          albSecurityGroupId,
+          { mutable: false },
+        )
+      : undefined;
     const idleAfterSeconds = new cdk.CfnParameter(
       this,
       'IdleAfterSeconds',
@@ -373,22 +398,23 @@ export class AgentCoreRuntimeStack extends cdk.Stack {
     );
     repository.grantPull(runtimeExecutionRole);
 
+    // Scoped to all Bedrock foundation models and inference profiles in
+    // this account/region rather than pinning to the one model ID this
+    // deployment happens to be configured for: the Claude Code CLI's model
+    // shorthands ("sonnet", "opus", etc.) and users switching models at
+    // runtime need more than a single allow-listed ARN, and the earlier
+    // single-ARN scoping caused a confusing 403 the moment anything other
+    // than the exact configured model was invoked (confirmed live -- see
+    // README "Public access" section). InvokeModel/
+    // InvokeModelWithResponseStream are still the only actions granted.
     const bedrockResources = [
-      `arn:${this.partition}:bedrock:*::foundation-model/${bedrockFoundationModelId}`,
+      `arn:${this.partition}:bedrock:*::foundation-model/*`,
+      this.formatArn({
+        service: 'bedrock',
+        resource: 'inference-profile',
+        resourceName: '*',
+      }),
     ];
-    if (bedrockUsesInferenceProfile) {
-      bedrockResources.unshift(
-        this.formatArn({
-          service: 'bedrock',
-          resource: 'inference-profile',
-          resourceName: bedrockModelId,
-        }),
-      );
-    } else {
-      bedrockResources[0] =
-        `arn:${this.partition}:bedrock:${this.region}::` +
-        `foundation-model/${bedrockFoundationModelId}`;
-    }
     const invokeBedrock = new iam.PolicyStatement({
       actions: ['bedrock:InvokeModel', 'bedrock:InvokeModelWithResponseStream'],
       resources: bedrockResources,
@@ -786,9 +812,10 @@ export class AgentCoreRuntimeStack extends cdk.Stack {
         },
       );
       relaySecurityGroup.addIngressRule(
-        apiEndpointSg,
+        albSecurityGroup ?? apiEndpointSg,
         ec2.Port.tcp(8080),
-        'Internal ALB routes /shell* here for the browser terminal',
+        'Internal ALB /shell traffic (see README Public access; ' +
+          'falls back to apiEndpointSg when albSecurityGroupId unset)',
       );
       // The relay task needs to reach the ECR interface endpoints (to pull
       // its own image) and the bedrock-agentcore data-plane endpoint (to
@@ -892,20 +919,71 @@ export class AgentCoreRuntimeStack extends cdk.Stack {
           healthCheck: { path: '/health' },
         },
       );
-      // Deliberately NOT relayService.attachToApplicationTargetGroup(...):
-      // the ECS::Service resource's LoadBalancers property requires the
-      // target group to already have an associated ALB listener at
-      // service-creation time ("target group ... does not have an
-      // associated load balancer", confirmed live) -- but the ALB this
-      // sample's private API and portal already run behind is created
-      // outside this stack (see README, "Public access"), so that
-      // ordering can't be satisfied from inside one `cdk deploy`. Instead,
-      // the task's ENI IP is registered into this (otherwise-standalone)
-      // target group by hand after deploy, and the target group is wired
-      // to the existing ALB with an `elbv2 create-rule` CLI call -- same
-      // pattern already used for the private API's own target group. This
-      // does mean the registration is static: a task replacement (crash,
-      // redeploy) needs the new IP re-registered by hand. Acceptable for a
+      // The relay's task IP is registered into this (otherwise-standalone)
+      // target group by hand once, and the target group is wired to the
+      // existing ALB with an `elbv2 create-rule` CLI call -- see README,
+      // "Public access". The ALB itself lives outside this stack, so
+      // attaching the target group to the ECS service directly at
+      // deploy time isn't possible (the ECS::Service resource's
+      // LoadBalancers property requires the target group to already
+      // have an associated ALB listener at service-creation time --
+      // "target group ... does not have an associated load balancer",
+      // confirmed live).
+      //
+      // What IS handled automatically from here on: every task
+      // replacement (deploy, crash, circuit-breaker rollback) used to
+      // leave the relay silently unreachable until someone manually
+      // re-ran `elbv2 register-targets` -- confirmed live, repeatedly,
+      // during end-to-end testing. The EventBridge rule + Lambda below
+      // registers/deregisters the task's IP automatically on every ECS
+      // Task State Change event for this cluster, so only the one-time
+      // target-group-to-ALB wiring above needs to happen by hand.
+      const registerTargetFunction = new lambdaNode.NodejsFunction(
+        this,
+        'RelayTargetRegistrarFunction',
+        {
+          runtime: lambda.Runtime.NODEJS_20_X,
+          architecture: lambda.Architecture.ARM_64,
+          entry: path.join(repositoryRoot, 'relay/register-target-handler.ts'),
+          handler: 'handler',
+          timeout: cdk.Duration.seconds(15),
+          memorySize: 128,
+          logGroup: new logs.LogGroup(
+            this,
+            'RelayTargetRegistrarLogGroup',
+            {
+              logGroupName: `/${projectName}/relay-target-registrar`,
+              retention: logs.RetentionDays.TWO_WEEKS,
+              removalPolicy: cdk.RemovalPolicy.DESTROY,
+            },
+          ),
+          environment: {
+            RELAY_TARGET_GROUP_ARN: relayTargetGroup.targetGroupArn,
+            RELAY_TARGET_PORT: '8080',
+          },
+          bundling: { minify: true, sourceMap: true },
+        },
+      );
+      registerTargetFunction.addToRolePolicy(
+        new iam.PolicyStatement({
+          actions: [
+            'elasticloadbalancing:RegisterTargets',
+            'elasticloadbalancing:DeregisterTargets',
+          ],
+          resources: [relayTargetGroup.targetGroupArn],
+        }),
+      );
+      new events.Rule(this, 'RelayTaskStateChangeRule', {
+        eventPattern: {
+          source: ['aws.ecs'],
+          detailType: ['ECS Task State Change'],
+          detail: {
+            clusterArn: [relayCluster.clusterArn],
+            lastStatus: ['RUNNING', 'STOPPED'],
+          },
+        },
+        targets: [new eventTargets.LambdaFunction(registerTargetFunction)],
+      });
       // single-task relay; a follow-up could add a small EventBridge rule
       // on ECS task state-change events to re-register automatically.
       new cdk.CfnOutput(this, 'ShellRelayServiceName', {

--- a/claude-code-on-agentcore-runtime-microvm/infra/lib/platform-stack.ts
+++ b/claude-code-on-agentcore-runtime-microvm/infra/lib/platform-stack.ts
@@ -802,6 +802,27 @@ export class AgentCoreRuntimeStack extends cdk.Stack {
         relayTokens.tableName,
       );
 
+      // Durable, server-side record of which AgentCore sessions have
+      // already had their developer-shell bootstrap sent -- written and
+      // read exclusively by the relay itself (relay/src/index.ts), which
+      // is the one component present for every real connection to a
+      // given session's shell regardless of browser tab, device, or
+      // client. See that file's maybeBootstrapSession() for the full
+      // rationale and the three client-side approaches that were tried
+      // and failed live re-testing before landing here.
+      const bootstrappedSessions = new dynamodb.Table(
+        this,
+        'BootstrappedSessions',
+        {
+          partitionKey: {
+            name: 'runtimeSessionId',
+            type: dynamodb.AttributeType.STRING,
+          },
+          billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+          removalPolicy: cdk.RemovalPolicy.DESTROY,
+        },
+      );
+
       const relaySecurityGroup = new ec2.SecurityGroup(
         this,
         'ShellRelaySecurityGroup',
@@ -862,6 +883,7 @@ export class AgentCoreRuntimeStack extends cdk.Stack {
         environment: {
           AWS_REGION: this.region,
           RELAY_TOKENS_TABLE_NAME: relayTokens.tableName,
+          BOOTSTRAPPED_SESSIONS_TABLE_NAME: bootstrappedSessions.tableName,
         },
         logging: ecs.LogDrivers.awsLogs({
           streamPrefix: 'shell-relay',
@@ -873,6 +895,7 @@ export class AgentCoreRuntimeStack extends cdk.Stack {
         }),
       });
       relayTokens.grantReadWriteData(relayTaskDefinition.taskRole);
+      bootstrappedSessions.grantWriteData(relayTaskDefinition.taskRole);
       relayTaskDefinition.taskRole.addToPrincipalPolicy(
         new iam.PolicyStatement({
           actions: ['bedrock-agentcore:InvokeAgentRuntimeCommandShell'],

--- a/claude-code-on-agentcore-runtime-microvm/infra/lib/platform-stack.ts
+++ b/claude-code-on-agentcore-runtime-microvm/infra/lib/platform-stack.ts
@@ -72,6 +72,12 @@ export class AgentCoreRuntimeStack extends cdk.Stack {
       this.node.tryGetContext('enablePortal'),
       false,
     );
+    // Extra absolute portal URLs to register as Cognito callback/logout URLs,
+      // for deployments that front the private API with a CDN or proxy (e.g. a
+    // CloudFront VPC origin). Comma-separated https URLs.
+    const portalPublicUrls = parsePortalPublicUrls(
+      this.node.tryGetContext('portalPublicUrls'),
+    );
     const idleAfterSeconds = new cdk.CfnParameter(
       this,
       'IdleAfterSeconds',
@@ -666,8 +672,8 @@ export class AgentCoreRuntimeStack extends cdk.Stack {
               cognito.OAuthScope.EMAIL,
               cognito.OAuthScope.PROFILE,
             ],
-            callbackUrls: [portalUrl],
-            logoutUrls: [portalUrl],
+            callbackUrls: [portalUrl, ...portalPublicUrls],
+            logoutUrls: [portalUrl, ...portalPublicUrls],
           },
           preventUserExistenceErrors: true,
         },
@@ -802,6 +808,27 @@ function assertLocalEsbuild(): void {
         'Docker fallback is intentionally disabled for this repository.',
     );
   }
+}
+
+function parsePortalPublicUrls(value: unknown): string[] {
+  if (value === undefined || value === '') {
+    return [];
+  }
+  if (typeof value !== 'string') {
+    throw new Error('portalPublicUrls must be a comma-separated string');
+  }
+  const urls = value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+  for (const url of urls) {
+    if (!url.startsWith('https://')) {
+      throw new Error(
+        `portalPublicUrls entries must be https URLs, got: ${url}`,
+      );
+    }
+  }
+  return urls;
 }
 
 function contextBoolean(value: unknown, defaultValue: boolean): boolean {

--- a/claude-code-on-agentcore-runtime-microvm/infra/lib/platform-stack.ts
+++ b/claude-code-on-agentcore-runtime-microvm/infra/lib/platform-stack.ts
@@ -8,6 +8,8 @@ import * as cognito from 'aws-cdk-lib/aws-cognito';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as ecr from 'aws-cdk-lib/aws-ecr';
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+import * as elbv2 from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 import * as events from 'aws-cdk-lib/aws-events';
 import * as eventTargets from 'aws-cdk-lib/aws-events-targets';
 import * as iam from 'aws-cdk-lib/aws-iam';
@@ -754,6 +756,170 @@ export class AgentCoreRuntimeStack extends cdk.Stack {
       new cdk.CfnOutput(this, 'PortalUrl', { value: portalUrl });
       new cdk.CfnOutput(this, 'PortalUserPoolId', {
         value: portalUserPool.userPoolId,
+      });
+
+      // Signing relay for the browser terminal. InvokeAgentRuntimeCommandShell
+      // requires a SigV4-signed WebSocket upgrade with a custom header;
+      // browsers can do neither. This ECS Fargate service terminates a plain
+      // WebSocket from the browser and opens a second, properly signed one
+      // to the real shell endpoint, piping bytes between them -- see
+      // relay/src/index.ts for the full design rationale.
+      const relayTokens = new dynamodb.Table(this, 'RelayTokens', {
+        partitionKey: { name: 'token', type: dynamodb.AttributeType.STRING },
+        billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+        timeToLiveAttribute: 'ttl',
+        removalPolicy: cdk.RemovalPolicy.DESTROY,
+      });
+      relayTokens.grantWriteData(controlFunction);
+      controlFunction.addEnvironment(
+        'RELAY_TOKENS_TABLE_NAME',
+        relayTokens.tableName,
+      );
+
+      const relaySecurityGroup = new ec2.SecurityGroup(
+        this,
+        'ShellRelaySecurityGroup',
+        {
+          vpc,
+          description: 'Browser-terminal signing relay (Fargate task)',
+          allowAllOutbound: true,
+        },
+      );
+      relaySecurityGroup.addIngressRule(
+        apiEndpointSg,
+        ec2.Port.tcp(8080),
+        'Internal ALB routes /shell* here for the browser terminal',
+      );
+      // The relay task needs to reach the ECR interface endpoints (to pull
+      // its own image) and the bedrock-agentcore data-plane endpoint (to
+      // open the signed upstream shell connection); both endpoints' shared
+      // security group only allowed the main AgentCore Runtime security
+      // group in until now -- confirmed live: without this, Fargate task
+      // placement fails with "unable to pull registry auth... i/o timeout"
+      // trying to reach the ECR VPC endpoint.
+      endpointSg.addIngressRule(
+        relaySecurityGroup,
+        ec2.Port.tcp(443),
+        'Shell relay pulling its image and reaching interface endpoints',
+      );
+
+      const relayCluster = new ecs.Cluster(this, 'ShellRelayCluster', {
+        vpc,
+        containerInsightsV2: ecs.ContainerInsights.ENABLED,
+      });
+      const relayTaskDefinition = new ecs.FargateTaskDefinition(
+        this,
+        'ShellRelayTaskDefinition',
+        {
+          cpu: 256,
+          memoryLimitMiB: 512,
+          // The relay image is built locally by `cdk deploy`
+          // (ecs.ContainerImage.fromAsset), which builds for the CDK
+          // CLI's host architecture rather than cross-compiling; on an
+          // arm64 build host that produces an arm64 image, which crashes
+          // with "exec format error" on Fargate's default x86_64
+          // platform (confirmed live). Pinning arm64/Graviton here makes
+          // the platform match whatever the build host actually
+          // produced, and is also the cheaper Fargate option.
+          runtimePlatform: {
+            cpuArchitecture: ecs.CpuArchitecture.ARM64,
+            operatingSystemFamily: ecs.OperatingSystemFamily.LINUX,
+          },
+        },
+      );
+      relayTaskDefinition.addContainer('relay', {
+        image: ecs.ContainerImage.fromAsset(repositoryRoot, {
+          file: 'relay/Dockerfile',
+        }),
+        portMappings: [{ containerPort: 8080 }],
+        environment: {
+          AWS_REGION: this.region,
+          RELAY_TOKENS_TABLE_NAME: relayTokens.tableName,
+        },
+        logging: ecs.LogDrivers.awsLogs({
+          streamPrefix: 'shell-relay',
+          logGroup: new logs.LogGroup(this, 'ShellRelayLogGroup', {
+            logGroupName: `/${projectName}/shell-relay`,
+            retention: logs.RetentionDays.THREE_MONTHS,
+            removalPolicy: cdk.RemovalPolicy.DESTROY,
+          }),
+        }),
+      });
+      relayTokens.grantReadWriteData(relayTaskDefinition.taskRole);
+      relayTaskDefinition.taskRole.addToPrincipalPolicy(
+        new iam.PolicyStatement({
+          actions: ['bedrock-agentcore:InvokeAgentRuntimeCommandShell'],
+          resources: [
+            agentRuntime.attrAgentRuntimeArn,
+            `${agentRuntime.attrAgentRuntimeArn}/*`,
+          ],
+        }),
+      );
+      bedrockAgentCoreDataEndpoint.addToPolicy(
+        new iam.PolicyStatement({
+          actions: ['bedrock-agentcore:InvokeAgentRuntimeCommandShell'],
+          principals: [relayTaskDefinition.taskRole],
+          resources: [
+            agentRuntime.attrAgentRuntimeArn,
+            `${agentRuntime.attrAgentRuntimeArn}/*`,
+          ],
+        }),
+      );
+
+      const relayService = new ecs.FargateService(
+        this,
+        'ShellRelayService',
+        {
+          cluster: relayCluster,
+          taskDefinition: relayTaskDefinition,
+          desiredCount: 1,
+          securityGroups: [relaySecurityGroup],
+          vpcSubnets: { subnets: vpc.privateSubnets },
+          assignPublicIp: false,
+          circuitBreaker: { enable: true, rollback: true },
+          minHealthyPercent: 0,
+          maxHealthyPercent: 200,
+        },
+      );
+      const relayTargetGroup = new elbv2.ApplicationTargetGroup(
+        this,
+        'ShellRelayTargetGroup',
+        {
+          vpc,
+          port: 8080,
+          protocol: elbv2.ApplicationProtocol.HTTP,
+          targetType: elbv2.TargetType.IP,
+          healthCheck: { path: '/health' },
+        },
+      );
+      // Deliberately NOT relayService.attachToApplicationTargetGroup(...):
+      // the ECS::Service resource's LoadBalancers property requires the
+      // target group to already have an associated ALB listener at
+      // service-creation time ("target group ... does not have an
+      // associated load balancer", confirmed live) -- but the ALB this
+      // sample's private API and portal already run behind is created
+      // outside this stack (see README, "Public access"), so that
+      // ordering can't be satisfied from inside one `cdk deploy`. Instead,
+      // the task's ENI IP is registered into this (otherwise-standalone)
+      // target group by hand after deploy, and the target group is wired
+      // to the existing ALB with an `elbv2 create-rule` CLI call -- same
+      // pattern already used for the private API's own target group. This
+      // does mean the registration is static: a task replacement (crash,
+      // redeploy) needs the new IP re-registered by hand. Acceptable for a
+      // single-task relay; a follow-up could add a small EventBridge rule
+      // on ECS task state-change events to re-register automatically.
+      new cdk.CfnOutput(this, 'ShellRelayServiceName', {
+        value: relayService.serviceName,
+      });
+      new cdk.CfnOutput(this, 'ShellRelayClusterName', {
+        value: relayCluster.clusterName,
+      });
+      new cdk.CfnOutput(this, 'ShellRelayTargetGroupArn', {
+        value: relayTargetGroup.targetGroupArn,
+        description:
+          'Register the running task\'s IP into this target group, then ' +
+          'create a listener rule on your ALB forwarding \'/shell*\' to ' +
+          'it -- see README, "Public access".',
       });
     }
 

--- a/claude-code-on-agentcore-runtime-microvm/infra/test/stacks.test.ts
+++ b/claude-code-on-agentcore-runtime-microvm/infra/test/stacks.test.ts
@@ -1,0 +1,260 @@
+import * as cdk from 'aws-cdk-lib';
+import { Match, Template } from 'aws-cdk-lib/assertions';
+import { beforeAll, describe, expect, it } from 'vitest';
+import {
+  AgentCoreRuntimeStack,
+  isApprovedBedrockModelId,
+} from '../lib/platform-stack.js';
+
+let template: Template;
+let portalTemplate: Template;
+let bedrockProfileTemplate: Template;
+
+beforeAll(() => {
+  const env = { account: '111122223333', region: 'us-east-1' };
+  template = Template.fromStack(
+    new AgentCoreRuntimeStack(
+      new cdk.App({
+        context: {
+          '@aws-cdk/aws-ec2:restrictDefaultSecurityGroup': true,
+          vpcCidr: '10.43.0.0/16',
+        },
+      }),
+      'DefaultPlatform',
+      { env },
+    ),
+  );
+  portalTemplate = Template.fromStack(
+    new AgentCoreRuntimeStack(
+      new cdk.App({
+        context: {
+          '@aws-cdk/aws-ec2:restrictDefaultSecurityGroup': true,
+          enablePortal: true,
+          vpcCidr: '10.43.0.0/16',
+        },
+      }),
+      'PortalPlatform',
+      { env },
+    ),
+  );
+  bedrockProfileTemplate = Template.fromStack(
+    new AgentCoreRuntimeStack(
+      new cdk.App({
+        context: {
+          '@aws-cdk/aws-ec2:restrictDefaultSecurityGroup': true,
+          bedrockModelId: 'eu.anthropic.claude-sonnet-5',
+          vpcCidr: '10.43.0.0/16',
+        },
+      }),
+      'BedrockProfilePlatform',
+      { env },
+    ),
+  );
+}, 60_000);
+
+describe('AgentCore Runtime resource', () => {
+  it('creates exactly one BedrockAgentCore Runtime with a container artifact', () => {
+    template.resourceCountIs('AWS::BedrockAgentCore::Runtime', 1);
+    template.hasResourceProperties('AWS::BedrockAgentCore::Runtime', {
+      AgentRuntimeArtifact: Match.objectLike({
+        ContainerConfiguration: Match.objectLike({
+          ContainerUri: Match.anyValue(),
+        }),
+      }),
+      NetworkConfiguration: Match.objectLike({
+        NetworkMode: 'VPC',
+        NetworkModeConfig: Match.objectLike({
+          SecurityGroups: Match.anyValue(),
+          Subnets: Match.anyValue(),
+        }),
+      }),
+      ProtocolConfiguration: 'HTTP',
+      LifecycleConfiguration: Match.objectLike({
+        MaxLifetime: 28_800,
+      }),
+    });
+  });
+
+  it('references the agent image repository by name without CDK owning it', () => {
+    // The ECR repository is provisioned by scripts/provision-agent-image.ts
+    // *before* cdk deploy (see infra/lib/platform-stack.ts for why: CfnRuntime
+    // needs an existing image at stack-create time). CDK must not also try
+    // to create the repository.
+    template.resourceCountIs('AWS::ECR::Repository', 0);
+    template.hasOutput('AgentImageRepositoryUri', {});
+  });
+
+  it('has no Lambda MicroVM service resources or network-connector infrastructure', () => {
+    const serialized = JSON.stringify(template.toJSON()).toLowerCase();
+    // AgentCore Runtime's compute type is itself called "microVM", so the
+    // word legitimately appears in this stack's own resource descriptions.
+    // What must NOT appear is anything from the Lambda MicroVM *service*
+    // (client-lambda-microvms resource types / network connectors) that
+    // claude-code-on-lambda-microvm depends on.
+    expect(serialized).not.toContain('networkconnector');
+    expect(serialized).not.toContain('lambda::microvmimage');
+    expect(serialized).not.toContain('microvm-image');
+  });
+
+  it('has no ECS, ALB, or relay infrastructure', () => {
+    for (const resourceType of [
+      'AWS::ECS::Cluster',
+      'AWS::ECS::Service',
+      'AWS::ElasticLoadBalancingV2::LoadBalancer',
+      'AWS::CertificateManager::Certificate',
+      'AWS::SecretsManager::Secret',
+    ]) {
+      template.resourceCountIs(resourceType, 0);
+    }
+  });
+});
+
+describe('network boundaries', () => {
+  it('routes private subnets through one managed NAT gateway', () => {
+    template.resourceCountIs('AWS::EC2::NatGateway', 1);
+    template.resourceCountIs('AWS::EC2::Instance', 0);
+  });
+
+  it('has no world-open security group ingress', () => {
+    const resources = Object.values(
+      template.toJSON().Resources,
+    ) as CloudFormationResource[];
+    const ingressCidrs = resources.flatMap((resource) => {
+      if (resource.Type === 'AWS::EC2::SecurityGroupIngress') {
+        return [resource.Properties?.CidrIp];
+      }
+      if (resource.Type === 'AWS::EC2::SecurityGroup') {
+        return (resource.Properties?.SecurityGroupIngress ?? []).map(
+          (rule) => rule.CidrIp,
+        );
+      }
+      return [];
+    });
+    expect(ingressCidrs).not.toContain('0.0.0.0/0');
+  });
+
+  it('keeps the bedrock-agentcore data-plane VPC endpoint', () => {
+    template.hasResourceProperties('AWS::EC2::VPCEndpoint', {
+      ServiceName: 'com.amazonaws.us-east-1.bedrock-agentcore',
+      VpcEndpointType: 'Interface',
+    });
+    template.hasResourceProperties('AWS::EC2::VPCEndpoint', {
+      ServiceName: 'com.amazonaws.us-east-1.bedrock-runtime',
+      VpcEndpointType: 'Interface',
+    });
+  });
+});
+
+describe('control and runtime permissions', () => {
+  it('keeps the control API private and IAM-authorized', () => {
+    template.hasResourceProperties('AWS::ApiGateway::RestApi', {
+      EndpointConfiguration: Match.objectLike({ Types: ['PRIVATE'] }),
+    });
+    template.allResourcesProperties(
+      'AWS::ApiGateway::Method',
+      Match.objectLike({ AuthorizationType: 'AWS_IAM' }),
+    );
+  });
+
+  it('grants the control function the AgentCore Runtime data-plane actions', () => {
+    const actions = iamActions(template);
+    expect(actions).toEqual(
+      expect.arrayContaining([
+        'bedrock-agentcore:InvokeAgentRuntime',
+        'bedrock-agentcore:InvokeAgentRuntimeCommand',
+        'bedrock-agentcore:InvokeAgentRuntimeCommandShell',
+        'bedrock-agentcore:StopRuntimeSession',
+        'bedrock-agentcore:ListSessions',
+      ]),
+    );
+  });
+
+  it('routes direct and inference-profile Bedrock model IDs to their required permissions', () => {
+    const direct = JSON.stringify(template.toJSON());
+    expect(direct).toContain(
+      ':bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-5',
+    );
+    const profile = JSON.stringify(bedrockProfileTemplate.toJSON());
+    expect(profile).toContain(
+      ':bedrock:us-east-1:111122223333:' +
+        'inference-profile/eu.anthropic.claude-sonnet-5',
+    );
+  });
+
+  it.each([
+    'anthropic.claude-sonnet-5',
+    'us.anthropic.claude-sonnet-5',
+    'eu.anthropic.claude-opus-5',
+    'global.anthropic.claude-sonnet-5',
+  ])('accepts supported Bedrock model ID %s', (modelId) => {
+    expect(isApprovedBedrockModelId(modelId)).toBe(true);
+  });
+
+  it.each([
+    'amazon.nova-pro',
+    'apac.anthropic.claude-sonnet-5',
+    'anthropic.not-claude-sonnet-5',
+  ])('rejects unsupported Bedrock model ID %s', (modelId) => {
+    expect(isApprovedBedrockModelId(modelId)).toBe(false);
+  });
+
+  it('keeps direct workspace S3 access out of the runtime execution role', () => {
+    const policies = template.findResources('AWS::IAM::Policy');
+    const runtimeActions = Object.entries(policies)
+      .filter(([logicalId]) => logicalId.includes('RuntimeExecutionRole'))
+      .flatMap(([, policy]) => policyActions(policy));
+    expect(runtimeActions.filter((action) => action.startsWith('s3:'))).toEqual(
+      [],
+    );
+  });
+
+  it('reconciles session state on an EventBridge schedule', () => {
+    template.hasResourceProperties('AWS::Events::Rule', {
+      ScheduleExpression: 'rate(1 minute)',
+      State: 'ENABLED',
+      Targets: Match.arrayWith([
+        Match.objectLike({
+          Input: '{"source":"session-reconciler"}',
+        }),
+      ]),
+    });
+  });
+});
+
+describe('optional browser portal', () => {
+  it('is absent unless enablePortal is set', () => {
+    template.resourceCountIs('AWS::ApiGateway::Authorizer', 0);
+  });
+
+  it('adds an uncached Cognito user pool authorizer when enabled', () => {
+    portalTemplate.hasResourceProperties('AWS::ApiGateway::Authorizer', {
+      Type: 'COGNITO_USER_POOLS',
+      AuthorizerResultTtlInSeconds: 0,
+    });
+    portalTemplate.resourceCountIs('AWS::Cognito::UserPool', 1);
+  });
+});
+
+interface CloudFormationResource {
+  Type?: string;
+  Properties?: {
+    CidrIp?: unknown;
+    SecurityGroupIngress?: { CidrIp?: unknown }[];
+    PolicyDocument?: { Statement?: { Action?: string | string[] }[] };
+  };
+}
+
+function iamActions(value: Template): string[] {
+  return Object.values(value.findResources('AWS::IAM::Policy')).flatMap(
+    (policy) => policyActions(policy),
+  );
+}
+
+function policyActions(policy: CloudFormationResource): string[] {
+  return (policy.Properties?.PolicyDocument?.Statement ?? []).flatMap(
+    (statement) => {
+      if (Array.isArray(statement.Action)) return statement.Action;
+      return statement.Action ? [statement.Action] : [];
+    },
+  );
+}

--- a/claude-code-on-agentcore-runtime-microvm/infra/test/stacks.test.ts
+++ b/claude-code-on-agentcore-runtime-microvm/infra/test/stacks.test.ts
@@ -184,15 +184,20 @@ describe('control and runtime permissions', () => {
     );
   });
 
-  it('routes direct and inference-profile Bedrock model IDs to their required permissions', () => {
+  it('grants Bedrock invoke on all foundation models and inference profiles, not one pinned model ARN', () => {
+    // Intentionally wide: the Claude Code CLI's model shorthands
+    // ("sonnet", "opus", etc.) and users switching models at runtime
+    // resolve to model IDs the deployment-time bedrockModelId context
+    // value never sees. Pinning the runtime role/VPC-endpoint policy to
+    // one exact ARN caused a confusing 403 the moment anything else was
+    // invoked (confirmed live). Every deployment now grants the same
+    // wildcard resources regardless of which model ID it happens to be
+    // configured with, so this only needs to be checked once against
+    // the default (direct-model) template.
     const direct = JSON.stringify(template.toJSON());
+    expect(direct).toContain(':bedrock:*::foundation-model/*');
     expect(direct).toContain(
-      ':bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-5',
-    );
-    const profile = JSON.stringify(bedrockProfileTemplate.toJSON());
-    expect(profile).toContain(
-      ':bedrock:us-east-1:111122223333:' +
-        'inference-profile/eu.anthropic.claude-sonnet-5',
+      ':bedrock:us-east-1:111122223333:inference-profile/*',
     );
   });
 

--- a/claude-code-on-agentcore-runtime-microvm/infra/test/stacks.test.ts
+++ b/claude-code-on-agentcore-runtime-microvm/infra/test/stacks.test.ts
@@ -8,6 +8,7 @@ import {
 
 let template: Template;
 let portalTemplate: Template;
+let portalPublicTemplate: Template;
 let bedrockProfileTemplate: Template;
 
 beforeAll(() => {
@@ -34,6 +35,20 @@ beforeAll(() => {
         },
       }),
       'PortalPlatform',
+      { env },
+    ),
+  );
+  portalPublicTemplate = Template.fromStack(
+    new AgentCoreRuntimeStack(
+      new cdk.App({
+        context: {
+          '@aws-cdk/aws-ec2:restrictDefaultSecurityGroup': true,
+          enablePortal: true,
+          portalPublicUrls: 'https://cdn.example.com/v1/portal',
+          vpcCidr: '10.43.0.0/16',
+        },
+      }),
+      'PortalPublicPlatform',
       { env },
     ),
   );
@@ -232,6 +247,27 @@ describe('optional browser portal', () => {
       AuthorizerResultTtlInSeconds: 0,
     });
     portalTemplate.resourceCountIs('AWS::Cognito::UserPool', 1);
+  });
+
+  it('registers extra callback URLs from portalPublicUrls', () => {
+    portalPublicTemplate.hasResourceProperties(
+      'AWS::Cognito::UserPoolClient',
+      {
+        CallbackURLs: Match.arrayWith(['https://cdn.example.com/v1/portal']),
+        LogoutURLs: Match.arrayWith(['https://cdn.example.com/v1/portal']),
+      },
+    );
+  });
+
+  it('keeps the private portal URL alongside public ones', () => {
+    const clients = portalPublicTemplate.findResources(
+      'AWS::Cognito::UserPoolClient',
+    );
+    const client = Object.values(clients)[0] as {
+      Properties: { CallbackURLs: unknown[]; LogoutURLs: unknown[] };
+    };
+    expect(client.Properties.CallbackURLs).toHaveLength(2);
+    expect(client.Properties.LogoutURLs).toHaveLength(2);
   });
 });
 

--- a/claude-code-on-agentcore-runtime-microvm/package-lock.json
+++ b/claude-code-on-agentcore-runtime-microvm/package-lock.json
@@ -1,0 +1,3476 @@
+{
+  "name": "claude-code-on-agentcore-runtime-microvm",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "claude-code-on-agentcore-runtime-microvm",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-bedrock-agentcore": "3.1113.0",
+        "@aws-sdk/client-bedrock-agentcore-control": "3.1113.0",
+        "@aws-sdk/client-cloudformation": "3.1088.0",
+        "@aws-sdk/client-dynamodb": "3.1088.0",
+        "@aws-sdk/client-ecr": "3.1088.0",
+        "@aws-sdk/client-s3": "3.1088.0",
+        "@aws-sdk/credential-provider-node": "3.972.69",
+        "@aws-sdk/lib-dynamodb": "3.1088.0",
+        "@aws-sdk/s3-request-presigner": "3.1088.0",
+        "@smithy/protocol-http": "5.5.9",
+        "@smithy/signature-v4": "5.6.5",
+        "@xterm/addon-fit": "0.11.0",
+        "@xterm/xterm": "6.0.0",
+        "aws-cdk-lib": "2.260.0",
+        "constructs": "10.7.0",
+        "ws": "8.21.1"
+      },
+      "devDependencies": {
+        "@types/aws-lambda": "8.10.152",
+        "@types/node": "22.15.3",
+        "@types/ws": "8.18.1",
+        "aws-cdk": "2.1131.0",
+        "cdk-nag": "2.38.2",
+        "esbuild": "0.25.3",
+        "tsx": "4.19.4",
+        "typescript": "5.8.3",
+        "vitest": "3.2.7"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@aws-cdk/asset-awscli-v1": {
+      "version": "2.2.282",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.282.tgz",
+      "integrity": "sha512-7hKMi5tTxDcKGIMIOq14PnY0GBcugW33Uh/2YHDZiEwSxLeFOCYBwhR+BFXONb/EJeVI3RETFgailNZbkcKF6g==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.2.tgz",
+      "integrity": "sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema": {
+      "version": "54.19.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.19.0.tgz",
+      "integrity": "sha512-o0axGGePF7NHFv3uIjKpfgMIQ8hG6U5gg629aNmE4+l08MndUKYaya3swhP3WoOKbxisVX3bVsrhnksN0NFoag==",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.5"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
+      "version": "1.5.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
+      "version": "7.8.5",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/checksums": {
+      "version": "3.1000.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.28.tgz",
+      "integrity": "sha512-VCpnmyHQ1IH49ni3LXnQj7DPr7rmcJmzYeiCkYdCcfgNtkvOj38cdcL9lapBWoItZWFACJPFJlymqC7/gem3Gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-agentcore": {
+      "version": "3.1113.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-agentcore/-/client-bedrock-agentcore-3.1113.0.tgz",
+      "integrity": "sha512-M3CxnlavlYXqLefKf3vpSUvxq/rqzj6e/TEt7V2t8uIglXO1ubMr+yZcgzIg6Mc7nsRr1r9IK8sXpByrWt91Gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/credential-provider-node": "^3.972.80",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-agentcore-control": {
+      "version": "3.1113.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-agentcore-control/-/client-bedrock-agentcore-control-3.1113.0.tgz",
+      "integrity": "sha512-X0X0Bny0ThOgHzY4Efg9he3EaHPT/EozTnDhRvaD+XQa+QA7kcIE9L14K/O6nBKcKonqmr0U8bFTygRVv91BBw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/credential-provider-node": "^3.972.80",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-agentcore-control/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.80",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.80.tgz",
+      "integrity": "sha512-bE2qh8ww4iClO1jHsBXdOE8FUgzDbdxbyorNjSCoPSkQd51k3jODItuPZfuwcLHZqDXsH+bI4AMHhqtuyR7mSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.69",
+        "@aws-sdk/credential-provider-http": "^3.972.71",
+        "@aws-sdk/credential-provider-ini": "^3.973.14",
+        "@aws-sdk/credential-provider-process": "^3.972.69",
+        "@aws-sdk/credential-provider-sso": "^3.973.13",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.75",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-agentcore/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.80",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.80.tgz",
+      "integrity": "sha512-bE2qh8ww4iClO1jHsBXdOE8FUgzDbdxbyorNjSCoPSkQd51k3jODItuPZfuwcLHZqDXsH+bI4AMHhqtuyR7mSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.69",
+        "@aws-sdk/credential-provider-http": "^3.972.71",
+        "@aws-sdk/credential-provider-ini": "^3.973.14",
+        "@aws-sdk/credential-provider-process": "^3.972.69",
+        "@aws-sdk/credential-provider-sso": "^3.973.13",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.75",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation": {
+      "version": "3.1088.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.1088.0.tgz",
+      "integrity": "sha512-s4CGaL7uxaMVrgYVN/gpt6W+vMwZKZVzmZ3nA0JDmxdvQpEAUH7sA3Rz2whry56X2Lcp1ptdkfbP3HzrDWyj9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/credential-provider-node": "^3.972.69",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb": {
+      "version": "3.1088.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1088.0.tgz",
+      "integrity": "sha512-CVxp88YVq87tW9i2+y6/yjtmvVmVt9V6tz2XFBVC2T3zNG/LntIKS113ld321ZX9Bipc9VmKxhJ+l+JVb7m/dg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/credential-provider-node": "^3.972.69",
+        "@aws-sdk/dynamodb-codec": "^3.973.33",
+        "@aws-sdk/middleware-endpoint-discovery": "^3.972.25",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ecr": {
+      "version": "3.1088.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecr/-/client-ecr-3.1088.0.tgz",
+      "integrity": "sha512-N3OTMD10DZOh30YzTEggkt0B9/+xk/8kQVeTty75FqjIpWUG4Lr31ymWHqDlbc5NZUAPQ/ZAmaoKgjqapl3hog==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/credential-provider-node": "^3.972.69",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1088.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1088.0.tgz",
+      "integrity": "sha512-9ryKKxnjtJRKLDI24P+2gQZki7k28BeV6gz1AySvFDWayhjAZuh4QZjCyx55tqR8Oz0IJxWutgJRO43dDOcXoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/checksums": "^3.1000.18",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/credential-provider-node": "^3.972.69",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.64",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.977.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.8.tgz",
+      "integrity": "sha512-7+Kcrkvrk9lM/m7jRhHpT4jCdvzGHsuaSRbF8TdzzkY1mRzp/Ogwf9c7H29k4gGhey0BBWhCWr16+t0J61gwmg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.4",
+        "@aws-sdk/xml-builder": "^3.972.39",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.31.1",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core/node_modules/@smithy/signature-v4": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.2.tgz",
+      "integrity": "sha512-P7Ki6px6OOrxVtx8K7nLmyx4SlXUW/uTKDdMG44UHefmPGSRMBKe2v+TM59WdLcpUIrBrnuCsIqiM2MbsZjmhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.69.tgz",
+      "integrity": "sha512-AreCFzcB4kH2HF9031Ot0jSJr3KXvRg6e8uDeub20JEVdZU3Bv0sTq1plc7VsT3KiqutlzH7l0j50UcCWHUioA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.71",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.71.tgz",
+      "integrity": "sha512-A8ObcqVmDMnk4F9NozZ7JwmUu9Q4xyBJkmyq1C5U+wNM9ht9J7+EuuyabsLWXZnOoTqFaJuYBYTKf5CTipkEjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.14.tgz",
+      "integrity": "sha512-7c+Wti2LsERNWMfm7ySz3/6RPopFW3Nmn7s63Xpcq6R/tRuY5hpvkHA2xVgi5ukJbvok9l0IDtVEvqTtg+X7dw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/credential-provider-env": "^3.972.69",
+        "@aws-sdk/credential-provider-http": "^3.972.71",
+        "@aws-sdk/credential-provider-login": "^3.972.76",
+        "@aws-sdk/credential-provider-process": "^3.972.69",
+        "@aws-sdk/credential-provider-sso": "^3.973.13",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.75",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.76",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.76.tgz",
+      "integrity": "sha512-LVixwOnEJfrrfKHeZjBA8pIMTZjNDq8ak8VpcoWUuCJDrSnBNU8POJksULMgvN089P0MXtQYH2Zs627/MK1K0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.69.tgz",
+      "integrity": "sha512-wbJGGesd0Tl18bmUcbj1xJ+e7CpuRJ6PIpMywLFuUttGy615lua87cJ0EA8pFpY/QgPuUXbnupWBtSPJ9tyZhg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.59",
+        "@aws-sdk/credential-provider-http": "^3.972.61",
+        "@aws-sdk/credential-provider-ini": "^3.973.3",
+        "@aws-sdk/credential-provider-process": "^3.972.59",
+        "@aws-sdk/credential-provider-sso": "^3.973.3",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.65",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.69.tgz",
+      "integrity": "sha512-9kpTNdZTrcqXTfhxM7fgl9Z68ek3Fu5oe3Yf+A/pJGibEqpgZxz2tSY7SinmyCIU2PJ+ygY4FPoBBnLpocMtrQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.13.tgz",
+      "integrity": "sha512-Oc81qauMPzUoTnAS2YKpNwY6sY/LUyQTEeaf6yP197WMxkEBQfcKLR1MFpD7+pNTubXnfkH6gwpji+Gc7iyD2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/token-providers": "3.1111.0",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.75",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.75.tgz",
+      "integrity": "sha512-YPN6uoGDgjjjeVFZrcOeCJqmB6zpXoeeNgIjqe+DexJaWqdjVfCCe+VAZwli9Z2h8KhFW8oxkO39emQ1tyz/Mw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/dynamodb-codec": {
+      "version": "3.973.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.43.tgz",
+      "integrity": "sha512-5nw01fhFJEKM68n0R65S1DijiSAQWZVbvH7IxTIJpFFbggg816jBVYvhK7W+XISjvtdg0rMkF/gQmuLGH713mg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/endpoint-cache": {
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.11.tgz",
+      "integrity": "sha512-8q1ICxcDjHId3bBryuu/j+1L9y5/3uQnwzLDt5j2ElcjZSoWmFtymdJy7OjLrluSMe0Z4mq5bcH4fxBXvlEHfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mnemonist": "0.38.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/lib-dynamodb": {
+      "version": "3.1088.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.1088.0.tgz",
+      "integrity": "sha512-d57jl+BVQWiA1+5NRUtN3/ZKBnOipQjNuimF3T2LCtA2IcYdCAw37ESDer39ldN4C8BxWRC44RbCmLCkmsx3+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/util-dynamodb": "^3.996.7",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1088.0"
+      }
+    },
+    "node_modules/@aws-sdk/lib-dynamodb/node_modules/@aws-sdk/util-dynamodb": {
+      "version": "3.996.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.996.9.tgz",
+      "integrity": "sha512-16x2tRvl7OYpZ0W/DdFJieFriD13+RvuRBDbe5sj/tCEfK86HSGd7I2s5j0ivz8p6KWGkS+5wKRO9OliJkjUOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1111.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.29.tgz",
+      "integrity": "sha512-cXW7QNIOhUSfccZmwJEjn9EdCAjzdOtt/+MtO5HWgxIZdhzyC1kNuQKIgGEDkgabxiXymWw0/VFWdqxqeLbgMA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/endpoint-cache": "^3.972.11",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.74",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.74.tgz",
+      "integrity": "sha512-2lzoV2z2QO5KJZYGOCnIZ1WVQgzMECvwuzr1xb034a++8QW4U4eGrmC2u4yg1xvNv4TLL/Uv5DLyuAiw0b9z7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.45",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.43.tgz",
+      "integrity": "sha512-bit+VpqWNyi3wHxFoTsTliNXimCSL2r2OeDTm7ZrG+YsTZ2D7ofDJ6r/t9PVBn80i6/v0X2h9Tgw6QP2MAKfPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.45",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.1088.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1088.0.tgz",
+      "integrity": "sha512-NEv9O5q+IrsDNKPmNhTlZ3hjtomgfL1OEJRCmDSF06dbmZ6IUJfrLQTLO7LWbM4sxvYui1LRAFCdO2TM3Hdq4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.45.tgz",
+      "integrity": "sha512-bBuyztukzXq6plzFGHAWiQt0QXo+HL8b8lX5cFTzkez/74PtS1c0qPFCIVuHkyoT+miH2qOjAcm1/yoro2ESPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@smithy/signature-v4": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.2.tgz",
+      "integrity": "sha512-P7Ki6px6OOrxVtx8K7nLmyx4SlXUW/uTKDdMG44UHefmPGSRMBKe2v+TM59WdLcpUIrBrnuCsIqiM2MbsZjmhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1111.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1111.0.tgz",
+      "integrity": "sha512-JfljgoVtl+s3Qy21n9a7Z48uCQaOXcN74KJ3TEQfPoB293GrXFSt6HSQJF1sTZ8c/5QedEvd3NjJQMO4u9qa5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.4.tgz",
+      "integrity": "sha512-dSFDNG00MEz0/xl5gxL62giLd1iYyJsTxZ1I1DOj6lC+bbgLB4TRsYClJg3b62dhXT1uATzsTNXPnC+33EJV3A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.39.tgz",
+      "integrity": "sha512-FTti8DS5MMWXNUWiRwXAJeYS+0GHHiMy0+7XOhcwk63ILHmfS2UFy2z/HNpZCSOJJ3P3dnWY6hfYNW3DF0nXUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.3.tgz",
+      "integrity": "sha512-W8bFfPA8DowP8l//sxjJLSLkD8iEjMc7cBVyP+u4cEv9sM7mdUCkgsj+t0n/BWPFtv7WWCN5Yzj0N6FJNUUqBQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.3.tgz",
+      "integrity": "sha512-PuwVXbnP87Tcff5I9ngV0lmiSu40xw1At6i3GsU77U7cjDDB4s0X2cyFuBiDa1SBk9DnvWwnGvVaGBqoFWPb7A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.3.tgz",
+      "integrity": "sha512-XelR6MzjlZuBM4f5z2IQHK6LkK34Cvv6Rj2EntER3lwCBFdg6h2lKbtRjpTTsdEjD/WSe1q8UyPBXP1x3i/wYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.3.tgz",
+      "integrity": "sha512-ogtTpYHT/g1GWS/zKM0cc/tIebFjm1F9Aw1boQ2Y0eUQ+J89d0jFY//s9ei9jVIlkYi8AfOjiixcLJSGNSOAdQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.3.tgz",
+      "integrity": "sha512-eESK5yfPNTqpAmDfFWNsOhmIOaQA59tAcF/EfYvo5/QWQCzXn5iUSOnqt3ra3UdzBv073ykTtmeLJZGt3HhA+w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.3.tgz",
+      "integrity": "sha512-Kd8glo7sIZtwOLcPbW0yLpKmBNWMANZhrC1r6K++uDR2zyzb6AeOYtI6udbtabmQpFaxJ8uduXMAo1gs5ozz8A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.3.tgz",
+      "integrity": "sha512-EJiyS70BYybOBpJth3M0KLOus0n+RRMKTYzhYhFeMwp7e/RaajXvP+BWlmEXNk6uk+KAu46j/kaQzr6au+JcIw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.3.tgz",
+      "integrity": "sha512-Q+wSjaLpGxYf7zC0kL0nDlhsfuFkoN+EXrx2KSB33RhinWzejOd6AvgmP5JbkgXKmjhmpfgKZq24pneodYqE8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.3.tgz",
+      "integrity": "sha512-dUOVmAUzuHy2ZOKIHIKHCm58HKzFqd+puLaS424h6I85GlSDRZIA5ycBixb3mFgM0Jdh+ZOSB6KptX30DD8YOQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.3.tgz",
+      "integrity": "sha512-xCUgnNYhRD5bb1C1nqrDV1PfkwgbswTTBRbAd8aH5PhYzikdf/ddtsYyMXFfGSsb/6t6QaPSzxtbfAZr9uox4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.3.tgz",
+      "integrity": "sha512-yplPOpczHOO4jTYKmuYuANI3WhvIPSVANGcNUeMlxH4twz/TeXuzEP41tGKNGWJjuMhotpGabeFYGAOU2ummBw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.3.tgz",
+      "integrity": "sha512-P4BLP5/fjyihmXCELRGrLd793q/lBtKMQl8ARGpDxgzgIKJDRJ/u4r1A/HgpBpKpKZelGct2PGI4T+axcedf6g==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.3.tgz",
+      "integrity": "sha512-eRAOV2ODpu6P5divMEMa26RRqb2yUoYsuQQOuFUexUoQndm4MdpXXDBbUoKIc0iPa4aCO7gIhtnYomkn2x+bag==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.3.tgz",
+      "integrity": "sha512-ZC4jV2p7VbzTlnl8nZKLcBkfzIf4Yad1SJM4ZMKYnJqZFD4rTI+pBG65u8ev4jk3/MPwY9DvGn50wi3uhdaghg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.3.tgz",
+      "integrity": "sha512-LDDODcFzNtECTrUUbVCs6j9/bDVqy7DDRsuIXJg6so+mFksgwG7ZVnTruYi5V+z3eE5y+BJZw7VvUadkbfg7QA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.3.tgz",
+      "integrity": "sha512-s+w/NOY2k0yC2p9SLen+ymflgcpRkvwwa02fqmAwhBRI3SC12uiS10edHHXlVWwfAagYSY5UpmT/zISXPMW3tQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.3.tgz",
+      "integrity": "sha512-nQHDz4pXjSDC6UfOE1Fw9Q8d6GCAd9KdvMZpfVGWSJztYCarRgSDfOVBY5xwhQXseiyxapkiSJi/5/ja8mRFFA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.3.tgz",
+      "integrity": "sha512-1QaLtOWq0mzK6tzzp0jRN3eccmN3hezey7mhLnzC6oNlJoUJz4nym5ZD7mDnS/LZQgkrhEbEiTn515lPeLpgWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.3.tgz",
+      "integrity": "sha512-i5Hm68HXHdgv8wkrt+10Bc50zM0/eonPb/a/OFVfB6Qvpiirco5gBA5bz7S2SHuU+Y4LWn/zehzNX14Sp4r27g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.3.tgz",
+      "integrity": "sha512-zGAVApJEYTbOC6H/3QBr2mq3upG/LBEXr85/pTtKiv2IXcgKV0RT0QA/hSXZqSvLEpXeIxah7LczB4lkiYhTAQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.3.tgz",
+      "integrity": "sha512-fpqctI45NnCIDKBH5AXQBsD0NDPbEFczK98hk/aa6HJxbl+UtLkJV2+Bvy5hLSLk3LHmqt0NTkKNso1A9y1a4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.3.tgz",
+      "integrity": "sha512-ROJhm7d8bk9dMCUZjkS8fgzsPAZEjtRJqCAmVgB0gMrvG7hfmPmz9k1rwO4jSiblFjYmNvbECL9uhaPzONMfgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.3.tgz",
+      "integrity": "sha512-YWcow8peiHpNBiIXHwaswPnAXLsLVygFwCB3A7Bh5jRkIBFWHGmNQ48AlX4xDvQNoMZlPYzjVOQDYEzWCqufMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.3.tgz",
+      "integrity": "sha512-qspTZOIGoXVS4DpNqUYUs9UxVb04khS1Degaw/MnfMe7goQ3lTfQ13Vw4qY/Nj0979BGvMRpAYbs/BAxEvU8ew==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.3.tgz",
+      "integrity": "sha512-ICgUR+kPimx0vvRzf+N/7L7tVSQeE3BYY+NhHRHXS1kBuPO7z2+7ea2HbhDyZdTephgvNvKrlDDKUexuCVBVvg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.33.2",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.2.tgz",
+      "integrity": "sha512-CUGXpnPkVdjUCbix+83sWLW9VFgQOm44MDOx/ihITJMAnOZKvL8YYIc7DR9pP/tZ8CIRvMiON/TucvygqbHO3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.2.tgz",
+      "integrity": "sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.7.2.tgz",
+      "integrity": "sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.2.tgz",
+      "integrity": "sha512-avwAh9HM3h2lcfjvP3zYIZGf+XVgLQ91wOJ2qoFbNpW1UZeZb33aGlhTZvtkANHfcGhJroRY64525OjfgOg30g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.5.9",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.5.9.tgz",
+      "integrity": "sha512-2tHlXQPzkTi0vXTyy2iWU1Lw60mIhUrS3heDO0bHJ4EvUH+RQlBuxiSqUWc34mRBpq3OgRPla89nNgqcTrX/vg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.5.tgz",
+      "integrity": "sha512-MO5VEhwVl0BN7xVoVeNrZfiUFoQtqxUbgl6/RwOTlMMxCSjblG8twSrVTwz3J4w9WZxd2rBfBAUXjH77agspBg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.2.tgz",
+      "integrity": "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.152",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.152.tgz",
+      "integrity": "sha512-soT/c2gYBnT5ygwiHPmd9a1bftj462NWVk2tKCc1PYHSIacB2UwbTS2zYG4jzag1mRDuzg/OjtxQjQ2NKRB6Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.15.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.3.tgz",
+      "integrity": "sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
+      "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz",
+      "integrity": "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==",
+      "license": "MIT",
+      "workspaces": [
+        "addons/*"
+      ]
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/aws-cdk": {
+      "version": "2.1131.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1131.0.tgz",
+      "integrity": "sha512-02oAVG4IBFwPtPlDE95H8tDJFfDuxJLdvyrdav6rn72mup/LIZRCfp95IB9kfM+FL4vQ9gn/QCEI7y7aNDTpKA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "cdk": "bin/cdk"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib": {
+      "version": "2.260.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.260.0.tgz",
+      "integrity": "sha512-2PPG+hbPDot8+ibkb5Jl9y3OY5rBE6TFwjzOi+yEyU4ZG6u8bM4DDKhhBi/S20NqqSFDso9rH1txVJAdwXNiuQ==",
+      "bundleDependencies": [
+        "@balena/dockerignore",
+        "@aws-cdk/cloud-assembly-api",
+        "case",
+        "fs-extra",
+        "ignore",
+        "jsonschema",
+        "minimatch",
+        "punycode",
+        "semver",
+        "table",
+        "yaml",
+        "mime-types"
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/asset-awscli-v1": "2.2.282",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.2",
+        "@aws-cdk/cloud-assembly-api": "^2.2.5",
+        "@aws-cdk/cloud-assembly-schema": "^54.0.0",
+        "@balena/dockerignore": "^1.0.2",
+        "case": "1.6.3",
+        "fs-extra": "^11.3.5",
+        "ignore": "^5.3.2",
+        "jsonschema": "^1.5.0",
+        "mime-types": "^2.1.35",
+        "minimatch": "^10.2.5",
+        "punycode": "^2.3.1",
+        "semver": "^7.8.1",
+        "table": "^6.9.0",
+        "yaml": "1.10.3"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "constructs": "^10.5.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
+      "version": "2.2.5",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/cloud-assembly-schema": ">=53.28.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/aws-cdk-lib/node_modules/ajv": {
+      "version": "8.20.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/astral-regex": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/case": {
+      "version": "1.6.3",
+      "inBundle": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/color-convert": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/color-name": {
+      "version": "1.1.4",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/fast-uri": {
+      "version": "3.1.2",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "inBundle": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/aws-cdk-lib/node_modules/fs-extra": {
+      "version": "11.3.5",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/aws-cdk-lib/node_modules/ignore": {
+      "version": "5.3.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/jsonschema": {
+      "version": "1.5.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/mime-db": {
+      "version": "1.52.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/mime-types": {
+      "version": "2.1.35",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/minimatch": {
+      "version": "10.2.5",
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/punycode": {
+      "version": "2.3.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/require-from-string": {
+      "version": "2.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/semver": {
+      "version": "7.8.1",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/string-width": {
+      "version": "4.2.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/table": {
+      "version": "6.9.0",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/universalify": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/yaml": {
+      "version": "1.10.3",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cdk-nag": {
+      "version": "2.38.2",
+      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.38.2.tgz",
+      "integrity": "sha512-Ddim1r8IwAPQn95KB2owbHoU4YHveHg4PfM+k7TdcANqfVmoHem6cTFMpcIuoDM16BkQQ+xshxYxZgcAoeVKGw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 18.12.0"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.176.0",
+        "constructs": "^10.5.1"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/constructs": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.7.0.tgz",
+      "integrity": "sha512-Vzwc30bMywc7DCzX8XOyuZbsBmfXTCrn6HHmhhELZK1J5dnUWwJ5uL7hBXGGq7xFPVOOO6cs9FwaxOshAxgcWQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.3.tgz",
+      "integrity": "sha512-qKA6Pvai73+M2FtftpNKRxJ78GIjmFXFxd/1DVBqGo/qNhLSfv+G12n9pNoWdytJC8U00TrViOwpjT0zgqQS8Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.3",
+        "@esbuild/android-arm": "0.25.3",
+        "@esbuild/android-arm64": "0.25.3",
+        "@esbuild/android-x64": "0.25.3",
+        "@esbuild/darwin-arm64": "0.25.3",
+        "@esbuild/darwin-x64": "0.25.3",
+        "@esbuild/freebsd-arm64": "0.25.3",
+        "@esbuild/freebsd-x64": "0.25.3",
+        "@esbuild/linux-arm": "0.25.3",
+        "@esbuild/linux-arm64": "0.25.3",
+        "@esbuild/linux-ia32": "0.25.3",
+        "@esbuild/linux-loong64": "0.25.3",
+        "@esbuild/linux-mips64el": "0.25.3",
+        "@esbuild/linux-ppc64": "0.25.3",
+        "@esbuild/linux-riscv64": "0.25.3",
+        "@esbuild/linux-s390x": "0.25.3",
+        "@esbuild/linux-x64": "0.25.3",
+        "@esbuild/netbsd-arm64": "0.25.3",
+        "@esbuild/netbsd-x64": "0.25.3",
+        "@esbuild/openbsd-arm64": "0.25.3",
+        "@esbuild/openbsd-x64": "0.25.3",
+        "@esbuild/sunos-x64": "0.25.3",
+        "@esbuild/win32-arm64": "0.25.3",
+        "@esbuild/win32-ia32": "0.25.3",
+        "@esbuild/win32-x64": "0.25.3"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.3.tgz",
+      "integrity": "sha512-++QEw4DIY7WGoukz+/+A/8dGYPT9l9yIadnmSgZ8Rjr3YVSVDipQSO9CdnJo9ePqFqUUqh+wk9uIaoiAwsiPkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mnemonist": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "license": "MIT",
+      "dependencies": {
+        "obliterator": "^1.6.1"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obliterator": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.19.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.4.tgz",
+      "integrity": "sha512-gK5GVzDkJK1SI1zwHf32Mqxf2tSJkNx+eYcNly5+nHvWqXUJYUkWBQtKauoESz3ymezAI++ZwT855x5p5eop+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/claude-code-on-agentcore-runtime-microvm/package-lock.json
+++ b/claude-code-on-agentcore-runtime-microvm/package-lock.json
@@ -15,6 +15,7 @@
         "@aws-sdk/client-cloudformation": "3.1088.0",
         "@aws-sdk/client-dynamodb": "3.1088.0",
         "@aws-sdk/client-ecr": "3.1088.0",
+        "@aws-sdk/client-elastic-load-balancing-v2": "^3.1088.0",
         "@aws-sdk/client-s3": "3.1088.0",
         "@aws-sdk/credential-provider-node": "3.972.69",
         "@aws-sdk/lib-dynamodb": "3.1088.0",
@@ -257,6 +258,25 @@
       "version": "3.1088.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecr/-/client-ecr-3.1088.0.tgz",
       "integrity": "sha512-N3OTMD10DZOh30YzTEggkt0B9/+xk/8kQVeTty75FqjIpWUG4Lr31ymWHqDlbc5NZUAPQ/ZAmaoKgjqapl3hog==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/credential-provider-node": "^3.972.69",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-elastic-load-balancing-v2": {
+      "version": "3.1088.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-elastic-load-balancing-v2/-/client-elastic-load-balancing-v2-3.1088.0.tgz",
+      "integrity": "sha512-40ndpIgbNAwWxR+KNYZnUDHcMfXpyaRoEhxny3ZISeEe3I1NZnrMEcnX+IJ8N56uz7fB/oUURwKNHlL2pvBpzA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.975.3",

--- a/claude-code-on-agentcore-runtime-microvm/package.json
+++ b/claude-code-on-agentcore-runtime-microvm/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "claude-code-on-agentcore-runtime-microvm",
+  "version": "0.1.0",
+  "private": true,
+  "license": "Apache-2.0",
+  "description": "Private, governed Claude Code development environments on Amazon Bedrock AgentCore Runtime",
+  "type": "module",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "client": "tsx client/src/cli.ts",
+    "deploy": "tsx scripts/deploy.ts",
+    "provision-image": "tsx scripts/provision-agent-image.ts",
+    "smoke-test": "tsx scripts/smoke-test.ts",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "synth": "cdk synth",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@aws-crypto/sha256-js": "5.2.0",
+    "@aws-sdk/client-bedrock-agentcore": "3.1113.0",
+    "@aws-sdk/client-bedrock-agentcore-control": "3.1113.0",
+    "@aws-sdk/client-cloudformation": "3.1088.0",
+    "@aws-sdk/client-dynamodb": "3.1088.0",
+    "@aws-sdk/client-ecr": "3.1088.0",
+    "@aws-sdk/client-s3": "3.1088.0",
+    "@aws-sdk/credential-provider-node": "3.972.69",
+    "@aws-sdk/lib-dynamodb": "3.1088.0",
+    "@aws-sdk/s3-request-presigner": "3.1088.0",
+    "@smithy/protocol-http": "5.5.9",
+    "@smithy/signature-v4": "5.6.5",
+    "@xterm/addon-fit": "0.11.0",
+    "@xterm/xterm": "6.0.0",
+    "aws-cdk-lib": "2.260.0",
+    "constructs": "10.7.0",
+    "ws": "8.21.1"
+  },
+  "devDependencies": {
+    "@types/aws-lambda": "8.10.152",
+    "@types/node": "22.15.3",
+    "@types/ws": "8.18.1",
+    "aws-cdk": "2.1131.0",
+    "cdk-nag": "2.38.2",
+    "esbuild": "0.25.3",
+    "tsx": "4.19.4",
+    "typescript": "5.8.3",
+    "vitest": "3.2.7"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/claude-code-on-agentcore-runtime-microvm/package.json
+++ b/claude-code-on-agentcore-runtime-microvm/package.json
@@ -23,6 +23,7 @@
     "@aws-sdk/client-cloudformation": "3.1088.0",
     "@aws-sdk/client-dynamodb": "3.1088.0",
     "@aws-sdk/client-ecr": "3.1088.0",
+    "@aws-sdk/client-elastic-load-balancing-v2": "^3.1088.0",
     "@aws-sdk/client-s3": "3.1088.0",
     "@aws-sdk/credential-provider-node": "3.972.69",
     "@aws-sdk/lib-dynamodb": "3.1088.0",

--- a/claude-code-on-agentcore-runtime-microvm/portal/handler.ts
+++ b/claude-code-on-agentcore-runtime-microvm/portal/handler.ts
@@ -1,0 +1,106 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import type {
+  APIGatewayProxyEvent,
+  APIGatewayProxyResult,
+} from 'aws-lambda';
+import { PORTAL_HTML, PORTAL_JS } from './site.js';
+
+let terminalVendorScript: string | undefined;
+let terminalStylesheet: string | undefined;
+
+// Serves the static portal page through the same private API Gateway as
+// the control routes: no extra bucket, no CDN, unreachable outside the VPC
+// endpoint. Mirrors claude-code-on-lambda-microvm/portal/handler.ts.
+export async function handler(
+  event: APIGatewayProxyEvent,
+): Promise<APIGatewayProxyResult> {
+  const resource = event.resource;
+  if (event.httpMethod.toUpperCase() !== 'GET') {
+    return response(405, 'text/plain', 'Method not allowed');
+  }
+  if (resource === '/portal') {
+    return response(200, 'text/html; charset=utf-8', PORTAL_HTML);
+  }
+  if (resource === '/portal/app.js') {
+    return response(200, 'application/javascript; charset=utf-8', PORTAL_JS);
+  }
+  if (resource === '/portal/terminal-vendor.js') {
+    terminalVendorScript ??= [
+      '/*! @xterm/xterm 6.0.0 and @xterm/addon-fit 0.11.0; MIT */',
+      packageFile('@xterm/xterm/lib/xterm.js'),
+      packageFile('@xterm/addon-fit/lib/addon-fit.js'),
+    ].join('\n');
+    return response(
+      200,
+      'application/javascript; charset=utf-8',
+      terminalVendorScript,
+      'public, max-age=31536000, immutable',
+    );
+  }
+  if (resource === '/portal/xterm.css') {
+    terminalStylesheet ??= packageFile('@xterm/xterm/css/xterm.css');
+    return response(
+      200,
+      'text/css; charset=utf-8',
+      terminalStylesheet,
+      'public, max-age=31536000, immutable',
+    );
+  }
+  if (resource === '/portal/config.json') {
+    return response(
+      200,
+      'application/json',
+      JSON.stringify({
+        userPoolDomain: requiredEnvironment('PORTAL_USER_POOL_DOMAIN'),
+        clientId: requiredEnvironment('PORTAL_CLIENT_ID'),
+        redirectUri: portalUrl(event),
+      }),
+    );
+  }
+  return response(404, 'text/plain', 'Not found');
+}
+
+function portalUrl(event: APIGatewayProxyEvent): string {
+  const { apiId, stage } = event.requestContext;
+  const region = process.env.AWS_REGION ?? 'us-east-1';
+  if (!apiId || !stage) {
+    throw new Error('Request context is missing apiId or stage');
+  }
+  return `https://${apiId}.execute-api.${region}.amazonaws.com/${stage}/portal`;
+}
+
+function response(
+  statusCode: number,
+  contentType: string,
+  body: string,
+  cacheControl = 'no-store',
+): APIGatewayProxyResult {
+  return {
+    statusCode,
+    headers: {
+      'cache-control': cacheControl,
+      'content-type': contentType,
+      'referrer-policy': 'no-referrer',
+      'strict-transport-security': 'max-age=31536000',
+      'x-content-type-options': 'nosniff',
+    },
+    body,
+  };
+}
+
+function packageFile(relativePath: string): string {
+  return readFileSync(
+    path.join(process.cwd(), 'node_modules', relativePath),
+    'utf8',
+  );
+}
+
+function requiredEnvironment(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}

--- a/claude-code-on-agentcore-runtime-microvm/portal/handler.ts
+++ b/claude-code-on-agentcore-runtime-microvm/portal/handler.ts
@@ -62,13 +62,33 @@ export async function handler(
   return response(404, 'text/plain', 'Not found');
 }
 
+// Derived from the Host header the browser actually used, not from the
+// API's own execute-api name: the OAuth redirect_uri has to match the
+// origin the browser is on. Hitting the private API directly yields the
+// same execute-api URL as before, but this also stays correct when the
+// portal is fronted by a CDN or proxy (see README, "Public access").
 function portalUrl(event: APIGatewayProxyEvent): string {
-  const { apiId, stage } = event.requestContext;
-  const region = process.env.AWS_REGION ?? 'us-east-1';
-  if (!apiId || !stage) {
-    throw new Error('Request context is missing apiId or stage');
+  const { stage } = event.requestContext;
+  if (!stage) {
+    throw new Error('Request context is missing stage');
   }
-  return `https://${apiId}.execute-api.${region}.amazonaws.com/${stage}/portal`;
+  const host = headerValue(event, 'host');
+  if (!host) {
+    throw new Error('Request is missing a Host header');
+  }
+  return `https://${host}/${stage}/portal`;
+}
+
+function headerValue(
+  event: APIGatewayProxyEvent,
+  name: string,
+): string | undefined {
+  for (const [key, value] of Object.entries(event.headers ?? {})) {
+    if (key.toLowerCase() === name && value) {
+      return value;
+    }
+  }
+  return undefined;
 }
 
 function response(

--- a/claude-code-on-agentcore-runtime-microvm/portal/handler.ts
+++ b/claude-code-on-agentcore-runtime-microvm/portal/handler.ts
@@ -21,7 +21,7 @@ export async function handler(
     return response(405, 'text/plain', 'Method not allowed');
   }
   if (resource === '/portal') {
-    return response(200, 'text/html; charset=utf-8', PORTAL_HTML);
+    return response(200, 'text/html; charset=utf-8', portalHtml(event));
   }
   if (resource === '/portal/app.js') {
     return response(200, 'application/javascript; charset=utf-8', PORTAL_JS);
@@ -77,6 +77,26 @@ function portalUrl(event: APIGatewayProxyEvent): string {
     throw new Error('Request is missing a Host header');
   }
   return `https://${host}/${stage}/portal`;
+}
+
+// Every asset/API reference in PORTAL_HTML/PORTAL_JS is a relative path
+// ("app.js", "config.json", "sessions", ...). The browser resolves those
+// against the *document's* URL, and "/v1/portal" (no trailing slash) is
+// treated as a file, not a directory — relative resolution would otherwise
+// land one level up, at "/v1/app.js" etc., which don't exist. A <base> tag
+// with a trailing slash fixes every relative reference in one place,
+// including fetch() calls, and stays correct regardless of stage name or
+// whether the request came through the private API directly or a proxy/CDN
+// in front of it (see README, "Public access").
+function portalHtml(event: APIGatewayProxyEvent): string {
+  const { stage } = event.requestContext;
+  if (!stage) {
+    throw new Error('Request context is missing stage');
+  }
+  return PORTAL_HTML.replace(
+    '<head>',
+    `<head>\n<base href="/${stage}/portal/">`,
+  );
 }
 
 function headerValue(

--- a/claude-code-on-agentcore-runtime-microvm/portal/site.test.ts
+++ b/claude-code-on-agentcore-runtime-microvm/portal/site.test.ts
@@ -1,0 +1,28 @@
+import { Script } from 'node:vm';
+import { describe, expect, it } from 'vitest';
+import { PORTAL_HTML, PORTAL_JS } from './site.js';
+
+// PORTAL_JS is the entire browser-side script, embedded as a JS template
+// literal inside site.ts. That nesting is a real footgun: an escape
+// sequence like `\n` written directly in the outer template literal is
+// consumed by *that* literal's own parsing, landing as a literal newline
+// inside what was meant to be a single-quoted string in the *browser*
+// script -- which then fails to parse in the browser with "Invalid or
+// unexpected token". This exact bug shipped once (a raw newline broke the
+// developer-shell bootstrap command in the Sign-in flow, silently killing
+// every click handler because the whole script failed to load) and was
+// only caught by a live browser test, not by `npm test`. Anything meant
+// to appear literally in the nested script must be double-escaped (e.g.
+// `\\n`) in site.ts. This test exists so a broken PORTAL_JS fails fast in
+// CI instead of shipping to prod.
+describe('portal/site.ts embedded browser script', () => {
+  it('PORTAL_JS parses as syntactically valid JavaScript', () => {
+    expect(() => new Script(PORTAL_JS)).not.toThrow();
+  });
+
+  it('PORTAL_HTML references the same script/style filenames the API serves', () => {
+    expect(PORTAL_HTML).toContain('app.js');
+    expect(PORTAL_HTML).toContain('terminal-vendor.js');
+    expect(PORTAL_HTML).toContain('xterm.css');
+  });
+});

--- a/claude-code-on-agentcore-runtime-microvm/portal/site.ts
+++ b/claude-code-on-agentcore-runtime-microvm/portal/site.ts
@@ -1,0 +1,219 @@
+// Static portal assets served by portal/handler.ts through the private API.
+// This is a minimal placeholder for claude-code-on-agentcore-runtime-microvm:
+// only the Terminal access mode is implemented in this sample (see
+// docs/deployment-guide.md), so the page only needs session lifecycle
+// controls and an xterm.js terminal dialog -- no VS Code tunnel UI.
+
+export const PORTAL_HTML = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Claude AgentCore Runtime portal</title>
+<link rel="icon" href="data:,">
+<link rel="stylesheet" href="xterm.css">
+<style>
+  :root { color-scheme: light; font-family: system-ui, sans-serif; }
+  body { margin: 0; background: #f5f7f8; color: #182126; }
+  header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: .75rem 1.5rem;
+    border-bottom: 1px solid #d7dfe2;
+    background: #fff;
+  }
+  main { padding: 1.5rem; max-width: 60rem; margin: 0 auto; }
+  button {
+    border: 1px solid #d7dfe2;
+    border-radius: 4px;
+    background: #fff;
+    padding: .45rem .75rem;
+    cursor: pointer;
+  }
+  button.primary { background: #006d77; color: #fff; border-color: #006d77; }
+  table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+  th, td { text-align: left; padding: .5rem; border-bottom: 1px solid #eef2f3; }
+  dialog { width: min(90vw, 60rem); border: none; border-radius: 6px; padding: 0; }
+  #terminal-screen { height: 60vh; background: #101418; padding: .5rem; }
+  #error { color: #b42318; margin-top: .5rem; }
+</style>
+</head>
+<body>
+<header>
+  <h1>Claude AgentCore Runtime</h1>
+  <div>
+    <span id="who"></span>
+    <button id="sign-out" hidden>Sign out</button>
+  </div>
+</header>
+<main>
+  <button id="sign-in" class="primary">Sign in</button>
+  <section id="app" hidden>
+    <button id="start-session" class="primary">Create environment</button>
+    <button id="refresh">Refresh</button>
+    <table>
+      <thead>
+        <tr><th>Session</th><th>Workspace</th><th>State</th><th>Updated</th><th></th></tr>
+      </thead>
+      <tbody id="sessions"></tbody>
+    </table>
+    <p id="error"></p>
+  </section>
+</main>
+<dialog id="terminal-dialog">
+  <div id="terminal-screen"></div>
+  <button id="terminal-close">Close</button>
+</dialog>
+<script src="terminal-vendor.js"></script>
+<script src="app.js"></script>
+</body>
+</html>`;
+
+export const PORTAL_JS = `
+'use strict';
+var config;
+var sessions = [];
+
+function el(id) { return document.getElementById(id); }
+
+async function loadConfig() {
+  var response = await fetch('config.json');
+  config = await response.json();
+}
+
+function api(method, path, body) {
+  return fetch(path, {
+    method: method,
+    headers: body ? { 'content-type': 'application/json' } : {},
+    body: body ? JSON.stringify(body) : undefined,
+    credentials: 'include'
+  }).then(function (response) {
+    if (!response.ok) {
+      return response.json().catch(function () { return {}; }).then(function (value) {
+        var error = new Error(value.message || 'Request failed');
+        error.status = response.status;
+        throw error;
+      });
+    }
+    return response.status === 204 ? undefined : response.json();
+  });
+}
+
+function showError(error) {
+  el('error').textContent = error && error.message ? error.message : String(error);
+}
+
+function clearError() { el('error').textContent = ''; }
+
+function renderSessions() {
+  var body = el('sessions');
+  body.replaceChildren();
+  sessions.forEach(function (session) {
+    var row = document.createElement('tr');
+    var cells = [
+      session.sessionId.slice(0, 8),
+      session.workspaceId,
+      session.state,
+      new Date(session.updatedAt * 1000).toLocaleString()
+    ];
+    cells.forEach(function (text) {
+      var cell = document.createElement('td');
+      cell.textContent = text;
+      row.appendChild(cell);
+    });
+    var actions = document.createElement('td');
+    var connectButton = document.createElement('button');
+    connectButton.textContent = 'Connect';
+    connectButton.addEventListener('click', function () {
+      openTerminal(session);
+    });
+    actions.appendChild(connectButton);
+    row.appendChild(actions);
+    body.appendChild(row);
+  });
+}
+
+async function refresh() {
+  clearError();
+  try {
+    var result = await api('GET', 'sessions');
+    sessions = result.sessions;
+    renderSessions();
+  } catch (error) {
+    showError(error);
+  }
+}
+
+async function startSession() {
+  clearError();
+  try {
+    await api('POST', 'sessions', { accessMode: 'terminal' });
+    await refresh();
+  } catch (error) {
+    showError(error);
+  }
+}
+
+var terminal;
+var terminalSocket;
+
+function openTerminal(session) {
+  clearError();
+  el('terminal-dialog').showModal();
+  terminal = new window.Terminal({ convertEol: true });
+  terminal.open(el('terminal-screen'));
+  connectTerminal(session);
+}
+
+async function connectTerminal(session) {
+  try {
+    var connection = await api('POST', 'sessions/' + session.sessionId + '/connect', {});
+    var socket = new WebSocket(connection.shellUrl);
+    terminalSocket = socket;
+    socket.binaryType = 'arraybuffer';
+    socket.addEventListener('message', function (event) {
+      if (typeof event.data === 'string') {
+        terminal.write(event.data);
+      } else {
+        terminal.write(new Uint8Array(event.data));
+      }
+    });
+    terminal.onData(function (data) {
+      if (socket.readyState === WebSocket.OPEN) {
+        socket.send(new TextEncoder().encode(data));
+      }
+    });
+  } catch (error) {
+    showError(error);
+  }
+}
+
+function closeTerminal() {
+  el('terminal-dialog').close();
+  if (terminalSocket) {
+    terminalSocket.close(1000, 'Portal closing terminal');
+    terminalSocket = undefined;
+  }
+  if (terminal) {
+    terminal.dispose();
+    terminal = undefined;
+  }
+}
+
+el('start-session').addEventListener('click', startSession);
+el('refresh').addEventListener('click', refresh);
+el('terminal-close').addEventListener('click', closeTerminal);
+el('sign-in').addEventListener('click', function () {
+  loadConfig().then(function () {
+    window.location.href =
+      'https://' + config.userPoolDomain + '/login?client_id=' +
+      config.clientId + '&response_type=code&redirect_uri=' +
+      encodeURIComponent(config.redirectUri);
+  });
+});
+
+el('app').hidden = false;
+el('sign-in').hidden = true;
+refresh();
+`;

--- a/claude-code-on-agentcore-runtime-microvm/portal/site.ts
+++ b/claude-code-on-agentcore-runtime-microvm/portal/site.ts
@@ -351,7 +351,7 @@ async function connectTerminal(session) {
             bootstrapSent = true;
             socket.send(encodeStdinFrame(
               'exec setpriv --reuid=1000 --regid=1000 --init-groups ' +
-              '/usr/local/bin/developer-shell\n'));
+              '/usr/local/bin/developer-shell\\n'));
           }
         } catch (error) {
           // Non-JSON status payload; ignore.

--- a/claude-code-on-agentcore-runtime-microvm/portal/site.ts
+++ b/claude-code-on-agentcore-runtime-microvm/portal/site.ts
@@ -58,7 +58,7 @@ export const PORTAL_HTML = `<!doctype html>
       </thead>
       <tbody id="sessions"></tbody>
     </table>
-    <p id="error"></p>
+    <p id="error" hidden></p>
   </section>
 </main>
 <dialog id="terminal-dialog">
@@ -78,17 +78,127 @@ var sessions = [];
 function el(id) { return document.getElementById(id); }
 
 async function loadConfig() {
-  var response = await fetch('config.json');
-  config = await response.json();
+  if (!config) {
+    var response = await fetch('config.json');
+    config = await response.json();
+  }
+  return config;
+}
+
+function base64Url(bytes) {
+  var text = '';
+  new Uint8Array(bytes).forEach(function (byte) {
+    text += String.fromCharCode(byte);
+  });
+  return btoa(text)
+    .replace(/[+]/g, '-').replace(/[/]/g, '_').replace(/=+$/, '');
+}
+
+function idToken() { return sessionStorage.getItem('portalIdToken'); }
+
+function hostedUiUrl(cfg, endpoint) {
+  return 'https://' + cfg.userPoolDomain + '/oauth2/' + endpoint;
+}
+
+function claims() {
+  var token = idToken();
+  if (!token) { return null; }
+  try {
+    var encoded = token.split('.')[1]
+      .replace(/-/g, '+').replace(/_/g, '/');
+    encoded += '='.repeat((4 - encoded.length % 4) % 4);
+    return JSON.parse(atob(encoded));
+  } catch (error) { return null; }
+}
+
+function signedIn() {
+  var current = claims();
+  return Boolean(current && current.exp * 1000 > Date.now());
+}
+
+function signOut() {
+  sessionStorage.removeItem('portalIdToken');
+  sessionStorage.removeItem('portalVerifier');
+  sessionStorage.removeItem('portalState');
+  render();
+}
+
+// Authorization Code + PKCE against the Cognito Hosted UI. There is no
+// client secret (public client), so PKCE is what stops a stolen
+// authorization code from being redeemed by anyone but the browser that
+// requested it.
+async function login() {
+  var cfg = await loadConfig();
+  var verifier = base64Url(crypto.getRandomValues(new Uint8Array(32)));
+  var digest = await crypto.subtle.digest(
+    'SHA-256', new TextEncoder().encode(verifier));
+  var state = base64Url(crypto.getRandomValues(new Uint8Array(16)));
+  sessionStorage.setItem('portalVerifier', verifier);
+  sessionStorage.setItem('portalState', state);
+  var authorize = {
+    response_type: 'code',
+    client_id: cfg.clientId,
+    redirect_uri: cfg.redirectUri,
+    scope: 'openid profile email',
+    state: state,
+    code_challenge_method: 'S256',
+    code_challenge: base64Url(digest),
+  };
+  location.assign(
+    hostedUiUrl(cfg, 'authorize') + '?' + new URLSearchParams(authorize));
+}
+
+async function completeLogin() {
+  var params = new URLSearchParams(location.search);
+  var code = params.get('code');
+  var oauthError = params.get('error');
+  if (!code && !oauthError) { return; }
+  history.replaceState(null, '', location.pathname);
+  var expectedState = sessionStorage.getItem('portalState');
+  if (!expectedState || params.get('state') !== expectedState) {
+    throw new Error('Sign-in state mismatch; try again');
+  }
+  if (oauthError) {
+    throw new Error(
+      'Sign-in failed: ' + (params.get('error_description') || oauthError));
+  }
+  var cfg = await loadConfig();
+  var verifier = sessionStorage.getItem('portalVerifier');
+  if (!verifier) {
+    throw new Error('Sign-in session expired; try again');
+  }
+  var res = await fetch(hostedUiUrl(cfg, 'token'), {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'authorization_code',
+      client_id: cfg.clientId,
+      redirect_uri: cfg.redirectUri,
+      code: code,
+      code_verifier: verifier,
+    }),
+  });
+  var tokens = await res.json();
+  if (!res.ok || !tokens.id_token) {
+    throw new Error('Token exchange failed: ' + (tokens.error || res.status));
+  }
+  sessionStorage.setItem('portalIdToken', tokens.id_token);
+  sessionStorage.removeItem('portalVerifier');
+  sessionStorage.removeItem('portalState');
 }
 
 function api(method, path, body) {
   return fetch(path, {
     method: method,
-    headers: body ? { 'content-type': 'application/json' } : {},
-    body: body ? JSON.stringify(body) : undefined,
-    credentials: 'include'
+    headers: Object.assign(
+      { authorization: idToken() },
+      body ? { 'content-type': 'application/json' } : {}),
+    body: body ? JSON.stringify(body) : undefined
   }).then(function (response) {
+    if (response.status === 401) {
+      signOut();
+      throw new Error('Session expired; sign in again');
+    }
     if (!response.ok) {
       return response.json().catch(function () { return {}; }).then(function (value) {
         var error = new Error(value.message || 'Request failed');
@@ -102,9 +212,13 @@ function api(method, path, body) {
 
 function showError(error) {
   el('error').textContent = error && error.message ? error.message : String(error);
+  el('error').hidden = false;
 }
 
-function clearError() { el('error').textContent = ''; }
+function clearError() {
+  el('error').textContent = '';
+  el('error').hidden = true;
+}
 
 function renderSessions() {
   var body = el('sessions');
@@ -201,19 +315,25 @@ function closeTerminal() {
   }
 }
 
+function render() {
+  var authenticated = signedIn();
+  el('sign-in').hidden = authenticated;
+  el('app').hidden = !authenticated;
+  el('sign-out').hidden = !authenticated;
+  var current = claims();
+  el('who').textContent = authenticated && current ? (current.email || current.sub) : '';
+  if (authenticated) { refresh(); }
+}
+
 el('start-session').addEventListener('click', startSession);
 el('refresh').addEventListener('click', refresh);
 el('terminal-close').addEventListener('click', closeTerminal);
 el('sign-in').addEventListener('click', function () {
-  loadConfig().then(function () {
-    window.location.href =
-      'https://' + config.userPoolDomain + '/login?client_id=' +
-      config.clientId + '&response_type=code&redirect_uri=' +
-      encodeURIComponent(config.redirectUri);
-  });
+  login().catch(showError);
 });
+el('sign-out').addEventListener('click', signOut);
 
-el('app').hidden = false;
-el('sign-in').hidden = true;
-refresh();
+completeLogin()
+  .then(render)
+  .catch(showError);
 `;

--- a/claude-code-on-agentcore-runtime-microvm/portal/site.ts
+++ b/claude-code-on-agentcore-runtime-microvm/portal/site.ts
@@ -13,30 +13,108 @@ export const PORTAL_HTML = `<!doctype html>
 <link rel="icon" href="data:,">
 <link rel="stylesheet" href="xterm.css">
 <style>
-  :root { color-scheme: light; font-family: system-ui, sans-serif; }
-  body { margin: 0; background: #f5f7f8; color: #182126; }
+  :root {
+    color-scheme: light;
+    font-family: -apple-system, "Segoe UI", Roboto, system-ui, sans-serif;
+    --ink: #16211f;
+    --sub: #5b6b68;
+    --line: #dde4e2;
+    --bg: #f6f8f7;
+    --card: #ffffff;
+    --brand: #cc785c;
+    --brand-dark: #a85c42;
+    --danger: #b42318;
+    --danger-bg: #fdf1ef;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--ink);
+    line-height: 1.5;
+  }
   header {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: .75rem 1.5rem;
-    border-bottom: 1px solid #d7dfe2;
-    background: #fff;
+    padding: 1rem 1.75rem;
+    border-bottom: 1px solid var(--line);
+    background: var(--card);
   }
-  main { padding: 1.5rem; max-width: 60rem; margin: 0 auto; }
+  header h1 {
+    font-size: 1.15rem;
+    font-weight: 600;
+    margin: 0;
+    letter-spacing: -0.01em;
+  }
+  header div { display: flex; align-items: center; gap: .75rem; font-size: .9rem; color: var(--sub); }
+  main { padding: 2rem 1.75rem; max-width: 62rem; margin: 0 auto; }
+  #app > div {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 1.25rem;
+  }
+  #app > div > div { display: flex; gap: .6rem; }
   button {
-    border: 1px solid #d7dfe2;
-    border-radius: 4px;
-    background: #fff;
-    padding: .45rem .75rem;
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    background: var(--card);
+    color: var(--ink);
+    padding: .5rem .9rem;
+    font-size: .875rem;
+    font-weight: 500;
     cursor: pointer;
+    transition: border-color .15s, background .15s;
   }
-  button.primary { background: #006d77; color: #fff; border-color: #006d77; }
-  table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
-  th, td { text-align: left; padding: .5rem; border-bottom: 1px solid #eef2f3; }
-  dialog { width: min(90vw, 60rem); border: none; border-radius: 6px; padding: 0; }
-  #terminal-screen { height: 60vh; background: #101418; padding: .5rem; }
-  #error { color: #b42318; margin-top: .5rem; }
+  button:hover { border-color: var(--brand); }
+  button:disabled { opacity: .55; cursor: default; }
+  button.primary {
+    background: var(--brand);
+    color: #fff;
+    border-color: var(--brand);
+  }
+  button.primary:hover { background: var(--brand-dark); border-color: var(--brand-dark); }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    background: var(--card);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    overflow: hidden;
+  }
+  th, td { text-align: left; padding: .65rem .9rem; font-size: .875rem; }
+  th {
+    color: var(--sub);
+    font-weight: 600;
+    font-size: .78rem;
+    text-transform: uppercase;
+    letter-spacing: .04em;
+    border-bottom: 1px solid var(--line);
+  }
+  td { border-bottom: 1px solid var(--line); }
+  tbody tr:last-child td { border-bottom: none; }
+  tbody tr:hover { background: #fafbfa; }
+  dialog {
+    width: min(92vw, 64rem);
+    border: none;
+    border-radius: 10px;
+    padding: 0;
+    box-shadow: 0 20px 60px rgba(0,0,0,.25);
+  }
+  dialog::backdrop { background: rgba(15, 20, 19, .55); }
+  #terminal-screen { height: 62vh; background: #141a1f; padding: .6rem; border-radius: 10px 10px 0 0; }
+  #terminal-dialog button { border-radius: 0 0 10px 10px; width: 100%; border: none; background: #1c2429; color: #cfd8d6; padding: .6rem; }
+  #terminal-dialog button:hover { background: #262f35; border-color: transparent; }
+  #error {
+    color: var(--danger);
+    background: var(--danger-bg);
+    border: 1px solid #f3d4d0;
+    border-radius: 6px;
+    padding: .6rem .9rem;
+    margin-top: 1rem;
+    font-size: .875rem;
+  }
 </style>
 </head>
 <body>
@@ -50,8 +128,12 @@ export const PORTAL_HTML = `<!doctype html>
 <main>
   <button id="sign-in" class="primary">Sign in</button>
   <section id="app" hidden>
-    <button id="start-session" class="primary">Create environment</button>
-    <button id="refresh">Refresh</button>
+    <div>
+      <div>
+        <button id="start-session" class="primary">Create environment</button>
+        <button id="refresh">Refresh</button>
+      </div>
+    </div>
     <table>
       <thead>
         <tr><th>Session</th><th>Workspace</th><th>State</th><th>Updated</th><th></th></tr>
@@ -291,7 +373,49 @@ var terminalSocket;
 function openTerminal(session) {
   clearError();
   el('terminal-dialog').showModal();
-  terminal = new window.Terminal({ convertEol: true });
+  terminal = new window.Terminal({
+    convertEol: true,
+    fontFamily: '"SF Mono", "Cascadia Code", "Fira Code", Menlo, Consolas, monospace',
+    fontSize: 13,
+    lineHeight: 1.35,
+    cursorBlink: true,
+    scrollback: 5000,
+    // Explicit theme, not xterm.js's stock defaults: this file's own
+    // history flagged the terminal rendering an accent as red where the
+    // Claude Code CLI's own branding is orange. TERM=xterm-256color and
+    // COLORTERM=truecolor are both set server-side (agent-runtime/agent.py)
+    // so the CLI emits true 24-bit color for its own UI rather than
+    // falling back to the nearest ANSI-16 slot -- but xterm.js's ANSI
+    // palette is still consulted for anything the app sends as a plain
+    // named color, and its stock "red" (ansi 1/9) is a plain red with no
+    // orange undertone, so any 16-color fallback path still looked red
+    // instead of on-brand. Nudging ansi red toward Claude's actual brand
+    // rust/orange (#CC785C-ish) fixes that without touching how genuine
+    // truecolor output renders.
+    theme: {
+      background: '#141a1f',
+      foreground: '#e8ecee',
+      cursor: '#e8664a',
+      cursorAccent: '#141a1f',
+      selectionBackground: '#2a3a42',
+      black: '#141a1f',
+      red: '#e8664a',
+      green: '#4caf7d',
+      yellow: '#e0b84a',
+      blue: '#5b9bd5',
+      magenta: '#b98cce',
+      cyan: '#4dbfbf',
+      white: '#e8ecee',
+      brightBlack: '#5a6670',
+      brightRed: '#f08a70',
+      brightGreen: '#6fce9c',
+      brightYellow: '#efc96b',
+      brightBlue: '#7cb3e0',
+      brightMagenta: '#caa4dc',
+      brightCyan: '#71d4d4',
+      brightWhite: '#ffffff',
+    },
+  });
   terminal.open(el('terminal-screen'));
   connectTerminal(session);
 }
@@ -323,7 +447,24 @@ async function connectTerminal(session) {
     var socket = new WebSocket(connection.shellUrl);
     terminalSocket = socket;
     socket.binaryType = 'arraybuffer';
-    var bootstrapSent = false;
+    // Tracks, per AgentCore session (not per WebSocket), whether the
+    // developer-shell privilege-drop bootstrap has already been sent.
+    // The shell protocol's own STATUS frame metadata.reconnected flag
+    // looked like the right signal for this and is what an earlier fix
+    // used -- but confirmed live it is false even when reattaching to a
+    // workspace whose shell already has an interactive claude session
+    // running (e.g. after closing and reopening the terminal dialog, or
+    // resuming a checkpointed workspace), so it does not actually track
+    // what this needs. Resending the bootstrap into a live claude TUI
+    // does not execute it -- claude treats the pasted text as chat
+    // input, drops into its own "manual mode", and every further
+    // keystroke goes into that chat prompt instead of a shell. That is
+    // the exact shape of the "terminal won't let me type" bug reported
+    // live. sessionStorage survives across reconnects within the same
+    // browser tab/session and is keyed by the AgentCore sessionId, so a
+    // second connect to the same session never re-sends the bootstrap.
+    var bootstrapKey = 'portalBootstrapped:' + session.sessionId;
+    var bootstrapSent = sessionStorage.getItem(bootstrapKey) === '1';
     var heartbeatTimer = setInterval(function () {
       if (socket.readyState === WebSocket.OPEN) {
         socket.send(new Uint8Array([SHELL_CHANNEL_HEARTBEAT]));
@@ -342,12 +483,31 @@ async function connectTerminal(session) {
           var status = JSON.parse(new TextDecoder().decode(payload));
           if (status.status === 'Failure') {
             showError(new Error(status.message || status.reason || 'Shell error'));
-          } else if (!bootstrapSent && socket.readyState === WebSocket.OPEN) {
+          } else if (
+            !bootstrapSent &&
+            !(status.metadata && status.metadata.reconnected) &&
+            socket.readyState === WebSocket.OPEN
+          ) {
             // Matches client/src/terminal.ts's developerShellBootstrapCommand():
             // drop the shell's default root privileges to the developer user
             // and load the session's Bedrock environment. Without this, the
             // portal terminal connects fine but lands in an unconfigured
             // root shell with no CLAUDE_CODE_USE_BEDROCK/ANTHROPIC_MODEL set.
+            //
+            // The metadata.reconnected check matters more than it looks:
+            // confirmed live, connecting to a session that already had an
+            // interactive claude session running (e.g. after a browser
+            // refresh, or resuming a checkpointed workspace) sent this
+            // bootstrap command into that already-running process's stdin
+            // instead of a shell prompt. Claude Code doesn't execute it --
+            // it treats the pasted text as chat input, drops into its own
+            // "manual mode", and every subsequent keystroke goes into that
+            // chat prompt instead of a shell. That is the exact shape of
+            // the "terminal won't let me type" bug reported live: typing
+            // wasn't actually broken, the bootstrap re-send on every
+            // reconnect had silently hijacked the session out from under
+            // the user. Skipping the bootstrap on a reconnected shell fixes
+            // it without weakening the fresh-connect case at all.
             bootstrapSent = true;
             socket.send(encodeStdinFrame(
               'exec setpriv --reuid=1000 --regid=1000 --init-groups ' +

--- a/claude-code-on-agentcore-runtime-microvm/portal/site.ts
+++ b/claude-code-on-agentcore-runtime-microvm/portal/site.ts
@@ -373,6 +373,16 @@ var terminalSocket;
 function openTerminal(session) {
   clearError();
   el('terminal-dialog').showModal();
+  // Whether this session has ever had real activity before this connect,
+  // used by connectTerminal() below to decide whether it's safe to send
+  // the developer-shell bootstrap. Computed once, from data the backend
+  // already returned with the session list/create/connect response --
+  // not from anything client-local (sessionStorage) or wire-protocol-
+  // derived (the shell STATUS frame's reconnected flag), both of which
+  // were tried and confirmed live, by direct re-test, not to track what
+  // this actually needs. See connectTerminal() for the full story.
+  var sessionHadPriorActivity =
+    Number(session.lastActivityAt) > Number(session.createdAt) + 5;
   terminal = new window.Terminal({
     convertEol: true,
     fontFamily: '"SF Mono", "Cascadia Code", "Fira Code", Menlo, Consolas, monospace',
@@ -447,24 +457,28 @@ async function connectTerminal(session) {
     var socket = new WebSocket(connection.shellUrl);
     terminalSocket = socket;
     socket.binaryType = 'arraybuffer';
-    // Tracks, per AgentCore session (not per WebSocket), whether the
-    // developer-shell privilege-drop bootstrap has already been sent.
-    // The shell protocol's own STATUS frame metadata.reconnected flag
-    // looked like the right signal for this and is what an earlier fix
-    // used -- but confirmed live it is false even when reattaching to a
-    // workspace whose shell already has an interactive claude session
-    // running (e.g. after closing and reopening the terminal dialog, or
-    // resuming a checkpointed workspace), so it does not actually track
-    // what this needs. Resending the bootstrap into a live claude TUI
-    // does not execute it -- claude treats the pasted text as chat
-    // input, drops into its own "manual mode", and every further
-    // keystroke goes into that chat prompt instead of a shell. That is
-    // the exact shape of the "terminal won't let me type" bug reported
-    // live. sessionStorage survives across reconnects within the same
-    // browser tab/session and is keyed by the AgentCore sessionId, so a
-    // second connect to the same session never re-sends the bootstrap.
-    var bootstrapKey = 'portalBootstrapped:' + session.sessionId;
-    var bootstrapSent = sessionStorage.getItem(bootstrapKey) === '1';
+    // The developer-shell privilege-drop bootstrap used to be sent from
+    // here, gated on various client-visible signals (a shell-protocol
+    // reconnected flag, then a sessionStorage flag, then a
+    // lastActivityAt/createdAt comparison) -- three separate attempts,
+    // each confirmed broken by live re-testing. Root cause: AgentCore's
+    // shell attach reattaches to one persistent PTY per session (like
+    // tmux attach), not a fresh shell per connect, and none of those
+    // client-visible signals actually tracked "does that PTY already
+    // have claude running in it" -- the one thing that matters. Sending
+    // the bootstrap command into a PTY that already has claude attached
+    // sends it as literal keystrokes into claude's own input, which
+    // drops into its own "manual mode" and swallows every further
+    // keystroke -- the exact shape of the "terminal won't let me type"
+    // bug reported live, repeatedly.
+    //
+    // The bootstrap is now injected server-side, exactly once per
+    // AgentCore session, by the relay itself (relay/src/index.ts's
+    // maybeBootstrapSession()) -- the one component present for every
+    // real connection to a given session's shell, tracked durably in
+    // DynamoDB so it survives relay restarts/redeploys and works across
+    // browser tabs, devices, and reconnects alike. This file only pipes
+    // bytes now.
     var heartbeatTimer = setInterval(function () {
       if (socket.readyState === WebSocket.OPEN) {
         socket.send(new Uint8Array([SHELL_CHANNEL_HEARTBEAT]));
@@ -483,35 +497,6 @@ async function connectTerminal(session) {
           var status = JSON.parse(new TextDecoder().decode(payload));
           if (status.status === 'Failure') {
             showError(new Error(status.message || status.reason || 'Shell error'));
-          } else if (
-            !bootstrapSent &&
-            !(status.metadata && status.metadata.reconnected) &&
-            socket.readyState === WebSocket.OPEN
-          ) {
-            // Matches client/src/terminal.ts's developerShellBootstrapCommand():
-            // drop the shell's default root privileges to the developer user
-            // and load the session's Bedrock environment. Without this, the
-            // portal terminal connects fine but lands in an unconfigured
-            // root shell with no CLAUDE_CODE_USE_BEDROCK/ANTHROPIC_MODEL set.
-            //
-            // The metadata.reconnected check matters more than it looks:
-            // confirmed live, connecting to a session that already had an
-            // interactive claude session running (e.g. after a browser
-            // refresh, or resuming a checkpointed workspace) sent this
-            // bootstrap command into that already-running process's stdin
-            // instead of a shell prompt. Claude Code doesn't execute it --
-            // it treats the pasted text as chat input, drops into its own
-            // "manual mode", and every subsequent keystroke goes into that
-            // chat prompt instead of a shell. That is the exact shape of
-            // the "terminal won't let me type" bug reported live: typing
-            // wasn't actually broken, the bootstrap re-send on every
-            // reconnect had silently hijacked the session out from under
-            // the user. Skipping the bootstrap on a reconnected shell fixes
-            // it without weakening the fresh-connect case at all.
-            bootstrapSent = true;
-            socket.send(encodeStdinFrame(
-              'exec setpriv --reuid=1000 --regid=1000 --init-groups ' +
-              '/usr/local/bin/developer-shell\\n'));
           }
         } catch (error) {
           // Non-JSON status payload; ignore.

--- a/claude-code-on-agentcore-runtime-microvm/portal/site.ts
+++ b/claude-code-on-agentcore-runtime-microvm/portal/site.ts
@@ -261,11 +261,27 @@ async function refresh() {
 
 async function startSession() {
   clearError();
+  var button = el('start-session');
+  button.disabled = true;
+  var originalText = button.textContent;
+  button.textContent = 'Starting...';
   try {
-    await api('POST', 'sessions', { accessMode: 'terminal' });
+    var result = await api('POST', 'sessions', { accessMode: 'terminal' });
     await refresh();
+    // POST /sessions returns 200 (not 201/202) when it silently reused an
+    // already-active session for this workspace instead of creating a new
+    // one -- with no visible change to the table, clicking the button
+    // looked like it did nothing. Surface which one actually happened.
+    el('error').textContent = result && result.created === false
+      ? 'Reusing the existing environment for this workspace (already running).'
+      : 'Environment created.';
+    el('error').hidden = false;
+    setTimeout(clearError, 4000);
   } catch (error) {
     showError(error);
+  } finally {
+    button.disabled = false;
+    button.textContent = originalText;
   }
 }
 
@@ -280,22 +296,75 @@ function openTerminal(session) {
   connectTerminal(session);
 }
 
+// Shell-protocol channel-prefix framing (Kubernetes v5.channel.k8s.io wire
+// format: [1-byte channel id][payload]), matching client/src/shell-
+// protocol.ts exactly -- see that file for the full channel table. The
+// portal previously wrote every incoming frame straight to the terminal
+// (including the leading channel byte as a garbage character) and never
+// prefixed outgoing keystrokes with the STDIN channel byte at all, so even
+// with a working signed connection the terminal would have been unusable.
+var SHELL_CHANNEL_STDIN = 0x00;
+var SHELL_CHANNEL_STDOUT = 0x01;
+var SHELL_CHANNEL_STDERR = 0x02;
+var SHELL_CHANNEL_STATUS = 0x03;
+var SHELL_CHANNEL_HEARTBEAT = 0x05;
+
+function encodeStdinFrame(text) {
+  var body = new TextEncoder().encode(text);
+  var frame = new Uint8Array(body.length + 1);
+  frame[0] = SHELL_CHANNEL_STDIN;
+  frame.set(body, 1);
+  return frame;
+}
+
 async function connectTerminal(session) {
   try {
     var connection = await api('POST', 'sessions/' + session.sessionId + '/connect', {});
     var socket = new WebSocket(connection.shellUrl);
     terminalSocket = socket;
     socket.binaryType = 'arraybuffer';
+    var bootstrapSent = false;
+    var heartbeatTimer = setInterval(function () {
+      if (socket.readyState === WebSocket.OPEN) {
+        socket.send(new Uint8Array([SHELL_CHANNEL_HEARTBEAT]));
+      }
+    }, 20000);
+    socket.addEventListener('close', function () { clearInterval(heartbeatTimer); });
     socket.addEventListener('message', function (event) {
-      if (typeof event.data === 'string') {
-        terminal.write(event.data);
-      } else {
-        terminal.write(new Uint8Array(event.data));
+      var frame = new Uint8Array(event.data);
+      if (frame.length === 0) { return; }
+      var channel = frame[0];
+      var payload = frame.subarray(1);
+      if (channel === SHELL_CHANNEL_STDOUT || channel === SHELL_CHANNEL_STDERR) {
+        terminal.write(payload);
+      } else if (channel === SHELL_CHANNEL_STATUS) {
+        try {
+          var status = JSON.parse(new TextDecoder().decode(payload));
+          if (status.status === 'Failure') {
+            showError(new Error(status.message || status.reason || 'Shell error'));
+          } else if (!bootstrapSent && socket.readyState === WebSocket.OPEN) {
+            // Matches client/src/terminal.ts's developerShellBootstrapCommand():
+            // drop the shell's default root privileges to the developer user
+            // and load the session's Bedrock environment. Without this, the
+            // portal terminal connects fine but lands in an unconfigured
+            // root shell with no CLAUDE_CODE_USE_BEDROCK/ANTHROPIC_MODEL set.
+            bootstrapSent = true;
+            socket.send(encodeStdinFrame(
+              'exec setpriv --reuid=1000 --regid=1000 --init-groups ' +
+              '/usr/local/bin/developer-shell\n'));
+          }
+        } catch (error) {
+          // Non-JSON status payload; ignore.
+        }
+      } else if (channel === SHELL_CHANNEL_HEARTBEAT) {
+        if (socket.readyState === WebSocket.OPEN) {
+          socket.send(frame);
+        }
       }
     });
     terminal.onData(function (data) {
       if (socket.readyState === WebSocket.OPEN) {
-        socket.send(new TextEncoder().encode(data));
+        socket.send(encodeStdinFrame(data));
       }
     });
   } catch (error) {

--- a/claude-code-on-agentcore-runtime-microvm/relay/Dockerfile
+++ b/claude-code-on-agentcore-runtime-microvm/relay/Dockerfile
@@ -1,0 +1,21 @@
+FROM public.ecr.aws/docker/library/node:22-alpine
+
+WORKDIR /app
+
+# Only the relay's own dependency surface is needed at runtime: no bundler,
+# so copy the whole repo's node_modules (already resolved by npm ci at
+# build time) and the two source trees the relay imports from.
+COPY package.json package-lock.json ./
+# npm ci (not --omit=dev): tsx is a devDependency but is the actual runtime
+# interpreter here (this repo runs its TS sources directly via tsx rather
+# than a build step) -- omitting dev deps left `npx tsx` unable to find tsx
+# locally, and it crashed on start (exit 255, no logs) trying to resolve it
+# some other way instead.
+RUN npm ci
+
+COPY relay/src ./relay/src
+COPY shared ./shared
+
+ENV NODE_ENV=production
+EXPOSE 8080
+ENTRYPOINT ["npx", "tsx", "relay/src/index.ts"]

--- a/claude-code-on-agentcore-runtime-microvm/relay/register-target-handler.ts
+++ b/claude-code-on-agentcore-runtime-microvm/relay/register-target-handler.ts
@@ -1,0 +1,86 @@
+import type { EventBridgeEvent } from 'aws-lambda';
+import {
+  ElasticLoadBalancingV2Client,
+  RegisterTargetsCommand,
+  DeregisterTargetsCommand,
+} from '@aws-sdk/client-elastic-load-balancing-v2';
+
+// Keeps the shell relay's ALB target group in sync with the ECS service
+// automatically. Without this, every task replacement (deploy, crash,
+// circuit-breaker rollback) leaves the relay unreachable until someone
+// manually runs `elbv2 register-targets` -- confirmed live, repeatedly,
+// during end-to-end testing of this sample. Triggered by EventBridge on
+// every "ECS Task State Change" event for the relay cluster; the event
+// detail already includes the task's private IP (no extra DescribeTasks
+// call needed) via detail.containers[].networkInterfaces[].
+//
+// See infra/lib/platform-stack.ts for why the target group can't simply
+// be attached to the ECS service at deploy time (the ALB lives outside
+// this stack).
+
+const elb = new ElasticLoadBalancingV2Client({});
+const TARGET_GROUP_ARN = requiredEnv('RELAY_TARGET_GROUP_ARN');
+const PORT = Number(process.env.RELAY_TARGET_PORT ?? '8080');
+
+interface EcsTaskStateChangeDetail {
+  lastStatus: string;
+  desiredStatus: string;
+  containers?: Array<{
+    networkInterfaces?: Array<{ privateIpv4Address?: string }>;
+  }>;
+}
+
+export async function handler(
+  event: EventBridgeEvent<'ECS Task State Change', EcsTaskStateChangeDetail>,
+): Promise<void> {
+  const detail = event.detail;
+  const ip = detail.containers
+    ?.flatMap((container) => container.networkInterfaces ?? [])
+    .map((eni) => eni.privateIpv4Address)
+    .find((value): value is string => Boolean(value));
+
+  if (!ip) {
+    console.log('no private IP in event detail, ignoring', {
+      lastStatus: detail.lastStatus,
+    });
+    return;
+  }
+
+  if (detail.lastStatus === 'RUNNING') {
+    await elb.send(
+      new RegisterTargetsCommand({
+        TargetGroupArn: TARGET_GROUP_ARN,
+        Targets: [{ Id: ip, Port: PORT }],
+      }),
+    );
+    console.log('registered relay target', { ip });
+    return;
+  }
+
+  if (detail.lastStatus === 'STOPPED' || detail.desiredStatus === 'STOPPED') {
+    try {
+      await elb.send(
+        new DeregisterTargetsCommand({
+          TargetGroupArn: TARGET_GROUP_ARN,
+          Targets: [{ Id: ip, Port: PORT }],
+        }),
+      );
+      console.log('deregistered relay target', { ip });
+    } catch (error) {
+      // Already deregistered or never registered (e.g. the task never
+      // reached RUNNING) -- not an error worth failing the Lambda for.
+      console.log('deregister skipped', {
+        ip,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+}
+
+function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable ${name}`);
+  }
+  return value;
+}

--- a/claude-code-on-agentcore-runtime-microvm/relay/src/index.ts
+++ b/claude-code-on-agentcore-runtime-microvm/relay/src/index.ts
@@ -31,6 +31,7 @@ import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import {
   DynamoDBDocumentClient,
   DeleteCommand,
+  PutCommand,
 } from '@aws-sdk/lib-dynamodb';
 import { defaultProvider } from '@aws-sdk/credential-provider-node';
 import { signShellUpgrade } from '../../shared/shell-signing.js';
@@ -38,6 +39,19 @@ import { signShellUpgrade } from '../../shared/shell-signing.js';
 const PORT = Number(process.env.PORT ?? 8080);
 const REGION = requiredEnvironment('AWS_REGION');
 const RELAY_TOKENS_TABLE_NAME = requiredEnvironment('RELAY_TOKENS_TABLE_NAME');
+const BOOTSTRAPPED_SESSIONS_TABLE_NAME = requiredEnvironment(
+  'BOOTSTRAPPED_SESSIONS_TABLE_NAME',
+);
+
+// Shell-protocol channel-prefix framing (Kubernetes v5.channel.k8s.io wire
+// format: [1-byte channel id][payload]; see client/src/shell-protocol.ts
+// for the full channel table and the SDK confirmation). The relay is
+// otherwise a dumb byte pipe with zero protocol awareness -- this one
+// constant is the sole exception, needed to inject the developer-shell
+// bootstrap command server-side. See the long comment on
+// maybeBootstrapSession() below for why it has to live here and not in
+// the browser or CLI clients.
+const SHELL_CHANNEL_STDIN = 0x00;
 
 const documentClient = DynamoDBDocumentClient.from(
   new DynamoDBClient({ region: REGION }),
@@ -137,6 +151,20 @@ async function handleBrowserConnection(
         browserSocket.send(data, { binary: isBinary });
       }
     });
+    // See maybeBootstrapSession()'s own comment for why this has to run
+    // here (server-side, in the relay, exactly once per AgentCore
+    // session) rather than in the browser or CLI client. Fire-and-forget
+    // deliberately: a failure here should not break the connection --
+    // worst case the developer lands in an unconfigured root shell,
+    // exactly like before this fix existed, not a broken one.
+    maybeBootstrapSession(record.runtimeSessionId, upstreamSocket).catch(
+      (error) => {
+        console.error('bootstrap injection failed', {
+          runtimeSessionId: record.runtimeSessionId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      },
+    );
   });
   upstreamSocket.once('error', (error) => {
     console.error('upstream AgentCore Runtime shell error', {
@@ -159,6 +187,94 @@ async function handleBrowserConnection(
   browserSocket.once('close', (code, reason) => {
     closeBoth(code, reason.toString());
   });
+}
+
+async function maybeBootstrapSession(
+  runtimeSessionId: string,
+  upstreamSocket: ClientWebSocket,
+): Promise<void> {
+  // This is the fourth attempt at getting this specific bug right, and
+  // it is worth recording exactly why the first three (all client-side)
+  // did not work, confirmed by live re-test each time -- not just in
+  // review, but by actually reconnecting and watching it break again:
+  //   1. Gating the resend on the shell protocol's own STATUS-frame
+  //      metadata.reconnected flag: stayed false even when reattaching
+  //      to a session whose shell already had claude running.
+  //   2. A sessionStorage flag keyed by AgentCore sessionId: only
+  //      covers reconnects from the same browser tab; a fresh tab (or
+  //      the CLI, or a different browser) reattaching to the same
+  //      session still resent it.
+  //   3. Comparing the session record's lastActivityAt to createdAt:
+  //      lastActivityAt is a control-plane bookkeeping timestamp, only
+  //      touched by control-plane API calls (connect, the reconciler
+  //      poll). Real keystrokes never touch the control plane at all --
+  //      they go browser -> this relay -> AgentCore directly -- so this
+  //      field does not track what it looked like it should.
+  //
+  // The actual root cause underneath all three: AgentCore's shell
+  // attach reattaches to one persistent PTY per session (like tmux
+  // attach), not a fresh shell per connect. Sending the bootstrap
+  // command into that PTY when something is already attached and
+  // running (typically claude) sends it as literal keystrokes into
+  // whatever currently has focus; claude treats it as pasted chat text,
+  // drops into its own "manual mode", and swallows every further
+  // keystroke into that chat prompt instead of a shell.
+  //
+  // The only component that is both authoritative and present for
+  // every real connection to a given session's shell -- regardless of
+  // browser tab, device, or client -- is this relay. So the fix has to
+  // live here: durable, server-side state (DynamoDB, survives relay
+  // task restarts/redeploys) recording whether this AgentCore session
+  // has ever been bootstrapped, checked and claimed atomically before
+  // the first byte is ever sent upstream for that session.
+  //
+  // Deliberately does not cover the CLI (client/src/terminal.ts), which
+  // signs its own direct connection to AgentCore and never goes through
+  // this relay -- but the CLI already sends this same bootstrap command
+  // itself on every connect via developerShellBootstrapCommand(), so a
+  // CLI connection and a portal connection racing to bootstrap the same
+  // session is a real but separate, pre-existing, narrower gap that
+  // would need its own fix in the control plane if it turns out to
+  // matter in practice.
+  const claimed = await claimFirstBootstrap(runtimeSessionId);
+  if (!claimed) {
+    return;
+  }
+  const command = Buffer.from(
+    'exec setpriv --reuid=1000 --regid=1000 --init-groups ' +
+      '/usr/local/bin/developer-shell\n',
+    'utf8',
+  );
+  const frame = Buffer.concat([Buffer.from([SHELL_CHANNEL_STDIN]), command]);
+  if (upstreamSocket.readyState === ClientWebSocket.OPEN) {
+    upstreamSocket.send(frame);
+  }
+}
+
+async function claimFirstBootstrap(runtimeSessionId: string): Promise<boolean> {
+  try {
+    await documentClient.send(
+      new PutCommand({
+        TableName: BOOTSTRAPPED_SESSIONS_TABLE_NAME,
+        Item: {
+          runtimeSessionId,
+          bootstrappedAt: Math.floor(Date.now() / 1_000),
+        },
+        ConditionExpression: 'attribute_not_exists(runtimeSessionId)',
+      }),
+    );
+    return true;
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.name === 'ConditionalCheckFailedException'
+    ) {
+      // Already bootstrapped by an earlier connection -- correct,
+      // expected outcome on every reconnect, not an error.
+      return false;
+    }
+    throw error;
+  }
 }
 
 async function consumeRelayToken(

--- a/claude-code-on-agentcore-runtime-microvm/relay/src/index.ts
+++ b/claude-code-on-agentcore-runtime-microvm/relay/src/index.ts
@@ -1,0 +1,213 @@
+// Signing relay for the browser portal's interactive terminal.
+//
+// Browsers cannot open a SigV4-signed WebSocket upgrade, and cannot set
+// custom headers on a WebSocket upgrade at all -- but
+// InvokeAgentRuntimeCommandShell requires both (a SigV4 signature, and the
+// runtime session id as a *signed header*, not a query param; see
+// ../shared/shell-signing.ts). This relay is the server-side component
+// that does the signing on the browser's behalf: it terminates a plain
+// WebSocket connection from the browser (reached via the same private
+// API's CloudFront + internal ALB path used for everything else), opens
+// a second, properly signed WebSocket to the real AgentCore Runtime shell
+// endpoint, and pipes bytes between the two verbatim. It does not
+// interpret the shell-protocol channel framing at all -- that happens at
+// the browser (site.ts) and CLI (terminal.ts) ends, same wire format for
+// both.
+//
+// Auth model: the control-plane Lambda's /portal/sessions/{id}/connect
+// route (already Cognito-authenticated, already ownership-checked) mints
+// a random single-use token and writes {runtimeSessionId, shellId,
+// agentRuntimeArn} to the RelayTokens DynamoDB table with a short TTL.
+// The browser's WebSocket URL carries only that opaque token, never the
+// real AgentCore identifiers or any AWS credentials. This relay's IAM
+// task role is scoped to bedrock-agentcore:InvokeAgentRuntimeCommandShell
+// on the one deployed AgentRuntime, plus GetItem/DeleteItem on
+// RelayTokens -- it cannot reach any other AWS resource with those
+// credentials.
+import { createServer } from 'node:http';
+import process from 'node:process';
+import { WebSocketServer, WebSocket as ClientWebSocket } from 'ws';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import {
+  DynamoDBDocumentClient,
+  DeleteCommand,
+} from '@aws-sdk/lib-dynamodb';
+import { defaultProvider } from '@aws-sdk/credential-provider-node';
+import { signShellUpgrade } from '../../shared/shell-signing.js';
+
+const PORT = Number(process.env.PORT ?? 8080);
+const REGION = requiredEnvironment('AWS_REGION');
+const RELAY_TOKENS_TABLE_NAME = requiredEnvironment('RELAY_TOKENS_TABLE_NAME');
+
+const documentClient = DynamoDBDocumentClient.from(
+  new DynamoDBClient({ region: REGION }),
+);
+const credentials = defaultProvider();
+
+interface RelayTokenRecord {
+  token: string;
+  runtimeSessionId: string;
+  shellId: string;
+  agentRuntimeArn: string;
+  ttl: number;
+}
+
+const httpServer = createServer((req, res) => {
+  if (req.url === '/health') {
+    res.writeHead(200, { 'content-type': 'text/plain' }).end('ok');
+    return;
+  }
+  res.writeHead(404).end();
+});
+
+const wss = new WebSocketServer({ noServer: true });
+
+httpServer.on('upgrade', (request, socket, head) => {
+  const url = new URL(request.url ?? '/', 'http://relay.internal');
+  if (url.pathname !== '/shell') {
+    socket.destroy();
+    return;
+  }
+  wss.handleUpgrade(request, socket, head, (browserSocket) => {
+    handleBrowserConnection(browserSocket, url).catch((error) => {
+      console.error('shell relay connection failed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      try {
+        browserSocket.close(1011, 'Relay error');
+      } catch {
+        // Socket may already be closed.
+      }
+    });
+  });
+});
+
+async function handleBrowserConnection(
+  browserSocket: ClientWebSocket,
+  requestUrl: URL,
+): Promise<void> {
+  const token = requestUrl.searchParams.get('token');
+  if (!token) {
+    browserSocket.close(4400, 'Missing token');
+    return;
+  }
+
+  const record = await consumeRelayToken(token);
+  if (!record) {
+    browserSocket.close(4401, 'Invalid or expired token');
+    return;
+  }
+
+  const shellUrl = new URL(
+    `wss://bedrock-agentcore.${REGION}.amazonaws.com/runtimes/` +
+      `${encodeURIComponent(record.agentRuntimeArn)}/ws/shells?shellId=` +
+      `${encodeURIComponent(record.shellId)}`,
+  );
+  const signed = await signShellUpgrade(
+    shellUrl,
+    record.runtimeSessionId,
+    credentials,
+  );
+
+  const upstreamSocket = new ClientWebSocket(shellUrl, {
+    headers: signed.headers,
+    followRedirects: false,
+    maxPayload: 1024 * 1024,
+    perMessageDeflate: false,
+  });
+
+  const closeBoth = (code: number, reason: string): void => {
+    for (const socket of [browserSocket, upstreamSocket]) {
+      if (
+        socket.readyState === ClientWebSocket.OPEN ||
+        socket.readyState === ClientWebSocket.CONNECTING
+      ) {
+        try {
+          socket.close(code, reason);
+        } catch {
+          // Already closing.
+        }
+      }
+    }
+  };
+
+  upstreamSocket.once('open', () => {
+    upstreamSocket.on('message', (data, isBinary) => {
+      if (browserSocket.readyState === ClientWebSocket.OPEN) {
+        browserSocket.send(data, { binary: isBinary });
+      }
+    });
+  });
+  upstreamSocket.once('error', (error) => {
+    console.error('upstream AgentCore Runtime shell error', {
+      error: error.message,
+    });
+    closeBoth(1011, 'Upstream shell error');
+  });
+  upstreamSocket.once('close', (code, reason) => {
+    closeBoth(code, reason.toString());
+  });
+
+  browserSocket.on('message', (data, isBinary) => {
+    if (upstreamSocket.readyState === ClientWebSocket.OPEN) {
+      upstreamSocket.send(data, { binary: isBinary });
+    }
+  });
+  browserSocket.once('error', () => {
+    closeBoth(1011, 'Browser socket error');
+  });
+  browserSocket.once('close', (code, reason) => {
+    closeBoth(code, reason.toString());
+  });
+}
+
+async function consumeRelayToken(
+  token: string,
+): Promise<RelayTokenRecord | undefined> {
+  // DeleteCommand with ReturnValues makes lookup and single-use consumption
+  // atomic: a token can only ever be redeemed once, closing the same class
+  // of "caller-supplied identifier trusted without verification" gap this
+  // sample's checkpoint-urls route has (see PR review). ConditionExpression
+  // guards against redeeming a token that already expired but has not yet
+  // been swept by DynamoDB TTL (TTL deletion is not instantaneous).
+  const now = Math.floor(Date.now() / 1_000);
+  try {
+    const result = await documentClient.send(
+      new DeleteCommand({
+        TableName: RELAY_TOKENS_TABLE_NAME,
+        Key: { token },
+        ConditionExpression: '#ttl > :now',
+        ExpressionAttributeNames: { '#ttl': 'ttl' },
+        ExpressionAttributeValues: { ':now': now },
+        ReturnValues: 'ALL_OLD',
+      }),
+    );
+    const item = result.Attributes as RelayTokenRecord | undefined;
+    if (
+      !item ||
+      typeof item.runtimeSessionId !== 'string' ||
+      typeof item.shellId !== 'string' ||
+      typeof item.agentRuntimeArn !== 'string'
+    ) {
+      return undefined;
+    }
+    return item;
+  } catch (error) {
+    if (error instanceof Error && error.name === 'ConditionalCheckFailedException') {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+function requiredEnvironment(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+httpServer.listen(PORT, () => {
+  console.log(`shell relay listening on :${PORT}`);
+});

--- a/claude-code-on-agentcore-runtime-microvm/scripts/deploy.ts
+++ b/claude-code-on-agentcore-runtime-microvm/scripts/deploy.ts
@@ -1,0 +1,235 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const PLATFORM_STACK = 'ClaudeAgentCoreRuntimeStack';
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(here, '..');
+
+interface DeploymentConfiguration {
+  region?: string;
+  vpcCidr?: string;
+  projectName?: string;
+  trustedClientCidr: string;
+  bedrockModelId?: string;
+  allowClaudeAiSubscription?: boolean;
+  enablePortal?: boolean;
+  idleAfterSeconds?: number;
+}
+
+const args = process.argv.slice(2);
+if (args.includes('--help') || args.includes('-h')) {
+  printHelp();
+  process.exit(0);
+}
+
+const configPath = path.resolve(
+  takeOption(args, '--config') ?? 'deployment.json',
+);
+const profile = takeOption(args, '--profile') ?? 'default';
+const approval = takeOption(args, '--require-approval') ?? 'broadening';
+const skipImage = takeFlag(args, '--skip-image');
+assertNoArguments(args);
+if (!['never', 'any-change', 'broadening'].includes(approval)) {
+  throw new Error('--require-approval must be never, any-change, or broadening');
+}
+
+const configuration = await loadConfiguration(configPath);
+const region = configuration.region ?? 'us-east-1';
+const vpcCidr = configuration.vpcCidr ?? '10.43.0.0/16';
+const projectName = configuration.projectName ?? 'claude-agentcore';
+const enablePortal = configuration.enablePortal ?? false;
+
+if (!skipImage) {
+  await run('npx', [
+    'tsx',
+    'scripts/provision-agent-image.ts',
+    '--region',
+    region,
+    '--profile',
+    profile,
+    '--project-name',
+    projectName,
+  ]);
+}
+
+const contextArguments = [
+  '-c',
+  `region=${region}`,
+  '-c',
+  `vpcCidr=${vpcCidr}`,
+  '-c',
+  `enablePortal=${String(enablePortal)}`,
+  '-c',
+  `allowClaudeAiSubscription=${String(
+    configuration.allowClaudeAiSubscription ?? false,
+  )}`,
+  ...(configuration.bedrockModelId
+    ? ['-c', `bedrockModelId=${configuration.bedrockModelId}`]
+    : []),
+];
+await run('npx', [
+  'cdk',
+  'deploy',
+  PLATFORM_STACK,
+  '--exclusively',
+  '--profile',
+  profile,
+  '--require-approval',
+  approval,
+  ...contextArguments,
+  ...platformParameterArguments(configuration, projectName),
+]);
+
+process.stdout.write(
+  [
+    `Deployment complete in ${region}.`,
+    ...(enablePortal
+      ? [
+          'Developer access: open the PortalUrl stack output.',
+          'Terminal environments connect directly in the browser.',
+        ]
+      : ['The browser portal is disabled for this deployment.']),
+    'IAM operator CLI (from this source tree):',
+    `npm run client -- --region ${region} --profile ${profile} list`,
+    '',
+  ].join('\n'),
+);
+
+async function loadConfiguration(
+  filename: string,
+): Promise<DeploymentConfiguration> {
+  let value: unknown;
+  try {
+    value = JSON.parse(await readFile(filename, 'utf8'));
+  } catch (error) {
+    throw new Error(
+      `Unable to read deployment configuration ${filename}: ` +
+        `${error instanceof Error ? error.message : 'unknown error'}`,
+    );
+  }
+  if (!isRecord(value)) {
+    throw new Error('Deployment configuration must be a JSON object');
+  }
+  const configuration = value as unknown as DeploymentConfiguration;
+  requiredConfiguredString(configuration.trustedClientCidr, 'trustedClientCidr');
+  if (
+    configuration.allowClaudeAiSubscription !== undefined &&
+    typeof configuration.allowClaudeAiSubscription !== 'boolean'
+  ) {
+    throw new Error('allowClaudeAiSubscription must be a boolean');
+  }
+  if (
+    configuration.enablePortal !== undefined &&
+    typeof configuration.enablePortal !== 'boolean'
+  ) {
+    throw new Error('enablePortal must be a boolean');
+  }
+  for (const [name, item] of Object.entries(configuration)) {
+    if (typeof item === 'string' && item.includes('REPLACE_ME')) {
+      throw new Error(`${name} still contains REPLACE_ME`);
+    }
+  }
+  if (
+    configuration.idleAfterSeconds !== undefined &&
+    (!Number.isSafeInteger(configuration.idleAfterSeconds) ||
+      configuration.idleAfterSeconds <= 0)
+  ) {
+    throw new Error('idleAfterSeconds must be a positive integer');
+  }
+  return configuration;
+}
+
+function platformParameterArguments(
+  configuration: DeploymentConfiguration,
+  projectName: string,
+): string[] {
+  const parameters: Record<string, string | number | undefined> = {
+    ProjectName: projectName,
+    TrustedClientCidr: configuration.trustedClientCidr,
+    IdleAfterSeconds: configuration.idleAfterSeconds,
+  };
+  return Object.entries(parameters).flatMap(([name, item]) =>
+    item === undefined
+      ? []
+      : ['--parameters', `${PLATFORM_STACK}:${name}=${String(item)}`],
+  );
+}
+
+async function run(command: string, commandArgs: string[]): Promise<void> {
+  process.stdout.write(`\n$ ${command} ${commandArgs.join(' ')}\n`);
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(command, commandArgs, {
+      cwd: repositoryRoot,
+      env: process.env,
+      stdio: 'inherit',
+    });
+    child.once('error', reject);
+    child.once('exit', (code, signal) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(
+          new Error(
+            `${command} exited with ${code ?? `signal ${signal ?? 'unknown'}`}`,
+          ),
+        );
+      }
+    });
+  });
+}
+
+function requiredConfiguredString(value: unknown, name: string): void {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new Error(`${name} must be a non-empty string`);
+  }
+}
+
+function takeOption(values: string[], name: string): string | undefined {
+  const index = values.indexOf(name);
+  if (index < 0) {
+    return undefined;
+  }
+  const value = values[index + 1];
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${name} requires a value`);
+  }
+  values.splice(index, 2);
+  return value;
+}
+
+function takeFlag(values: string[], name: string): boolean {
+  const index = values.indexOf(name);
+  if (index < 0) {
+    return false;
+  }
+  values.splice(index, 1);
+  return true;
+}
+
+function assertNoArguments(values: string[]): void {
+  if (values.length > 0) {
+    throw new Error(`Unexpected argument: ${values[0]}`);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function printHelp(): void {
+  process.stdout.write(`Usage: npm run deploy -- [options]
+
+Builds and pushes the agent-runtime container image, then deploys the
+platform stack.
+
+Options:
+  --config <file>                   JSON configuration (default: deployment.json)
+  --profile <profile>                AWS profile (default: default)
+  --require-approval <level>         broadening, any-change, or never
+  --skip-image                       Skip the container image build/push
+  --help                             Show this help without calling AWS
+`);
+}

--- a/claude-code-on-agentcore-runtime-microvm/scripts/deploy.ts
+++ b/claude-code-on-agentcore-runtime-microvm/scripts/deploy.ts
@@ -40,7 +40,7 @@ const configuration = await loadConfiguration(configPath);
 const region = configuration.region ?? 'us-east-1';
 const vpcCidr = configuration.vpcCidr ?? '10.43.0.0/16';
 const projectName = configuration.projectName ?? 'claude-agentcore';
-const enablePortal = configuration.enablePortal ?? false;
+const enablePortal = configuration.enablePortal ?? true;
 
 if (!skipImage) {
   await run('npx', [

--- a/claude-code-on-agentcore-runtime-microvm/scripts/provision-agent-image.ts
+++ b/claude-code-on-agentcore-runtime-microvm/scripts/provision-agent-image.ts
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+// Builds the agent-runtime container image and pushes it to an ECR
+// repository, creating the repository first if needed. This runs BEFORE
+// `cdk deploy` for a first-time deployment, because `CfnRuntime.
+// agentRuntimeArtifact.containerConfiguration.containerUri` must resolve to
+// an existing image at stack-create time (see infra/lib/platform-stack.ts).
+// It is also the day-2 image-rebuild entry point: rerun this script and
+// restart the runtime's sessions (there is no CDK deploy required) to pick
+// up a new image, mirroring claude-code-on-lambda-microvm's
+// scripts/provision-microvm.ts image-swap workflow.
+import { spawn } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  CreateRepositoryCommand,
+  DescribeRepositoriesCommand,
+  ECRClient,
+  GetAuthorizationTokenCommand,
+} from '@aws-sdk/client-ecr';
+import { defaultProvider } from '@aws-sdk/credential-provider-node';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(here, '..');
+const agentRuntimeDirectory = path.join(repositoryRoot, 'agent-runtime');
+
+const args = process.argv.slice(2);
+if (args.includes('--help') || args.includes('-h')) {
+  printHelp();
+  process.exit(0);
+}
+const region = takeOption(args, '--region') ?? 'us-east-1';
+const profile = takeOption(args, '--profile') ?? 'default';
+const projectName = takeOption(args, '--project-name') ?? 'claude-agentcore';
+assertNoArguments(args);
+
+const repositoryName = `${projectName}-agent`;
+const credentials = defaultProvider({ profile });
+const ecr = new ECRClient({ region, credentials });
+
+const repositoryUri = await ensureRepository();
+await buildAndPush(repositoryUri);
+
+process.stdout.write(
+  `Pushed ${repositoryUri}:latest. This is the image the AgentCore ` +
+    `Runtime (agentRuntimeName ${projectName.replace(/-/g, '_')}_agent) ` +
+    'will pull for new sessions.\n',
+);
+
+async function ensureRepository(): Promise<string> {
+  try {
+    const described = await ecr.send(
+      new DescribeRepositoriesCommand({ repositoryNames: [repositoryName] }),
+    );
+    const uri = described.repositories?.[0]?.repositoryUri;
+    if (uri) {
+      return uri;
+    }
+  } catch (error) {
+    if (!isNotFound(error)) {
+      throw error;
+    }
+  }
+  process.stdout.write(`Creating ECR repository ${repositoryName}...\n`);
+  const created = await ecr.send(
+    new CreateRepositoryCommand({
+      repositoryName,
+      imageScanningConfiguration: { scanOnPush: true },
+      imageTagMutability: 'MUTABLE',
+    }),
+  );
+  const uri = created.repository?.repositoryUri;
+  if (!uri) {
+    throw new Error('CreateRepository returned no repositoryUri');
+  }
+  return uri;
+}
+
+async function buildAndPush(repositoryUri: string): Promise<void> {
+  const auth = await ecr.send(new GetAuthorizationTokenCommand({}));
+  const authData = auth.authorizationData?.[0];
+  if (!authData?.authorizationToken || !authData.proxyEndpoint) {
+    throw new Error('GetAuthorizationToken returned no credentials');
+  }
+  const decoded = Buffer.from(
+    authData.authorizationToken,
+    'base64',
+  ).toString('utf8');
+  const password = decoded.split(':').slice(1).join(':');
+  const registryHost = authData.proxyEndpoint.replace(/^https?:\/\//, '');
+
+  await run(
+    'docker',
+    ['login', '--username', 'AWS', '--password-stdin', registryHost],
+    password,
+  );
+  await run('docker', [
+    'buildx',
+    'build',
+    '--platform',
+    'linux/arm64',
+    '--tag',
+    `${repositoryUri}:latest`,
+    '--push',
+    agentRuntimeDirectory,
+  ]);
+}
+
+async function run(
+  command: string,
+  commandArgs: string[],
+  stdin?: string,
+): Promise<void> {
+  process.stdout.write(`\n$ ${command} ${commandArgs.join(' ')}\n`);
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(command, commandArgs, {
+      cwd: repositoryRoot,
+      stdio: [stdin ? 'pipe' : 'ignore', 'inherit', 'inherit'],
+    });
+    if (stdin) {
+      child.stdin?.end(stdin);
+    }
+    child.once('error', reject);
+    child.once('exit', (code, signal) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(
+          new Error(
+            `${command} exited with ${code ?? `signal ${signal ?? 'unknown'}`}`,
+          ),
+        );
+      }
+    });
+  });
+}
+
+function isNotFound(error: unknown): boolean {
+  return (
+    error instanceof Error && error.name === 'RepositoryNotFoundException'
+  );
+}
+
+function takeOption(values: string[], name: string): string | undefined {
+  const index = values.indexOf(name);
+  if (index < 0) {
+    return undefined;
+  }
+  const value = values[index + 1];
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${name} requires a value`);
+  }
+  values.splice(index, 2);
+  return value;
+}
+
+function assertNoArguments(values: string[]): void {
+  if (values.length > 0) {
+    throw new Error(`Unexpected argument: ${values[0]}`);
+  }
+}
+
+function printHelp(): void {
+  process.stdout.write(`Usage: npm run provision-image -- [options]
+
+Builds agent-runtime/ into a container image and pushes it to the
+per-project ECR repository, creating the repository if it does not exist.
+Run this before the first 'cdk deploy', and again for any day-2 image
+rebuild.
+
+Options:
+  --region <region>          AWS Region (default: us-east-1)
+  --profile <profile>        AWS profile (default: default)
+  --project-name <name>      Must match the deployment.json projectName
+                              (default: claude-agentcore)
+  --help                     Show this help without calling AWS
+`);
+}

--- a/claude-code-on-agentcore-runtime-microvm/scripts/smoke-test.ts
+++ b/claude-code-on-agentcore-runtime-microvm/scripts/smoke-test.ts
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+// Documented smoke-test script for the deployed sample: opens an
+// InvokeAgentRuntimeCommandShell session against the AgentRuntime output
+// from `cdk deploy`, runs a couple of real commands, and prints the output.
+// Use this after a fresh deploy to confirm the container image is healthy
+// end to end, without needing the control-plane API or a portal user.
+//
+// Usage:
+//   npm run smoke-test -- --region us-east-1 --profile default \
+//     --runtime-arn arn:aws:bedrock-agentcore:us-east-1:ACCOUNT:runtime/NAME-ID
+//
+// If --runtime-arn is omitted, it is discovered from the
+// ClaudeAgentCoreRuntimeStack CloudFormation output (--stack to override
+// the stack name).
+import { SignatureV4 } from '@smithy/signature-v4';
+import { HttpRequest } from '@smithy/protocol-http';
+import { Sha256 } from '@aws-crypto/sha256-js';
+import { defaultProvider } from '@aws-sdk/credential-provider-node';
+import {
+  CloudFormationClient,
+  DescribeStacksCommand,
+} from '@aws-sdk/client-cloudformation';
+import WebSocket from 'ws';
+
+const args = process.argv.slice(2);
+if (args.includes('--help') || args.includes('-h')) {
+  printHelp();
+  process.exit(0);
+}
+const region = takeOption(args, '--region') ?? 'us-east-1';
+const profile = takeOption(args, '--profile') ?? 'default';
+const stackName = takeOption(args, '--stack') ?? 'ClaudeAgentCoreRuntimeStack';
+let runtimeArn = takeOption(args, '--runtime-arn');
+assertNoArguments(args);
+
+if (!runtimeArn) {
+  runtimeArn = await discoverRuntimeArn();
+}
+
+process.stdout.write(`Opening shell against ${runtimeArn}\n`);
+const sessionId = `smoke-test-${Date.now()}-${Math.random().toString(36).slice(2)}`.padEnd(
+  40,
+  '0',
+);
+const shellId = `smoke-${Date.now()}`;
+const url = buildShellUrl(runtimeArn, region, shellId);
+const headers = await signShellUpgrade(url, region, sessionId);
+
+const socket = new WebSocket(url, { headers });
+let output = '';
+
+await new Promise<void>((resolve, reject) => {
+  const timeout = setTimeout(() => {
+    reject(new Error('Timed out waiting for the shell to respond'));
+  }, 20_000);
+
+  socket.once('open', () => {
+    setTimeout(() => {
+      socket.send(Buffer.from('echo smoke-test-ok\n', 'utf8'), {
+        binary: true,
+      });
+      socket.send(Buffer.from('python3 --version\n', 'utf8'), {
+        binary: true,
+      });
+      setTimeout(() => {
+        clearTimeout(timeout);
+        resolve();
+      }, 3_000);
+    }, 1_500);
+  });
+  socket.on('message', (data, isBinary) => {
+    if (isBinary) {
+      output += Buffer.from(data as Buffer).toString('utf8');
+    }
+  });
+  socket.once('error', (error) => {
+    clearTimeout(timeout);
+    reject(error);
+  });
+});
+
+socket.close(1000, 'smoke test complete');
+process.stdout.write('--- shell output ---\n');
+process.stdout.write(output + '\n');
+
+if (!output.includes('smoke-test-ok')) {
+  process.stderr.write('Smoke test FAILED: expected output not observed\n');
+  process.exitCode = 1;
+} else {
+  process.stdout.write('Smoke test PASSED\n');
+}
+
+function buildShellUrl(arn: string, awsRegion: string, id: string): URL {
+  const url = new URL(
+    `wss://bedrock-agentcore.${awsRegion}.amazonaws.com/runtimes/` +
+      `${encodeURIComponent(arn)}/ws/shells`,
+  );
+  url.searchParams.set('shellId', id);
+  return url;
+}
+
+async function signShellUpgrade(
+  url: URL,
+  awsRegion: string,
+  sessionId: string,
+): Promise<Record<string, string>> {
+  const credentials = await defaultProvider({ profile })();
+  const signer = new SignatureV4({
+    credentials,
+    region: awsRegion,
+    service: 'bedrock-agentcore',
+    sha256: Sha256,
+  });
+  const signed = await signer.sign(
+    new HttpRequest({
+      protocol: url.protocol,
+      hostname: url.hostname,
+      method: 'GET',
+      path: url.pathname,
+      query: Object.fromEntries(url.searchParams),
+      headers: {
+        host: url.hostname,
+        'X-Amzn-Bedrock-AgentCore-Runtime-Session-Id': sessionId,
+      },
+    }),
+  );
+  const headers: Record<string, string> = {};
+  for (const [key, value] of Object.entries(signed.headers)) {
+    if (key.toLowerCase() === 'host') continue;
+    headers[key] = value;
+  }
+  return headers;
+}
+
+async function discoverRuntimeArn(): Promise<string> {
+  const cloudFormation = new CloudFormationClient({
+    region,
+    credentials: defaultProvider({ profile }),
+  });
+  const result = await cloudFormation.send(
+    new DescribeStacksCommand({ StackName: stackName }),
+  );
+  const output = result.Stacks?.[0]?.Outputs?.find(
+    (candidate) => candidate.OutputKey === 'AgentRuntimeArn',
+  )?.OutputValue;
+  if (!output) {
+    throw new Error(
+      `Stack ${stackName} has no AgentRuntimeArn output; pass --runtime-arn`,
+    );
+  }
+  return output;
+}
+
+function takeOption(values: string[], name: string): string | undefined {
+  const index = values.indexOf(name);
+  if (index < 0) return undefined;
+  const value = values[index + 1];
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${name} requires a value`);
+  }
+  values.splice(index, 2);
+  return value;
+}
+
+function assertNoArguments(values: string[]): void {
+  if (values.length > 0) {
+    throw new Error(`Unexpected argument: ${values[0]}`);
+  }
+}
+
+function printHelp(): void {
+  process.stdout.write(`Usage: npm run smoke-test -- [options]
+
+Opens an InvokeAgentRuntimeCommandShell session against a deployed
+AgentCore Runtime and runs a couple of real commands to confirm the
+container image is healthy.
+
+Options:
+  --region <region>        AWS Region (default: us-east-1)
+  --profile <profile>      AWS profile (default: default)
+  --stack <name>            CloudFormation stack name (default:
+                            ClaudeAgentCoreRuntimeStack)
+  --runtime-arn <arn>       Skip stack-output discovery
+  --help                    Show this help without calling AWS
+`);
+}

--- a/claude-code-on-agentcore-runtime-microvm/scripts/smoke-test.ts
+++ b/claude-code-on-agentcore-runtime-microvm/scripts/smoke-test.ts
@@ -21,6 +21,12 @@ import {
   DescribeStacksCommand,
 } from '@aws-sdk/client-cloudformation';
 import WebSocket from 'ws';
+import {
+  decodeShellFrame,
+  encodeStdin,
+  parseShellStatus,
+  ShellChannel,
+} from '../client/src/shell-protocol.js';
 
 const args = process.argv.slice(2);
 if (args.includes('--help') || args.includes('-h')) {
@@ -48,29 +54,32 @@ const headers = await signShellUpgrade(url, region, sessionId);
 
 const socket = new WebSocket(url, { headers });
 let output = '';
+let connected = false;
 
 await new Promise<void>((resolve, reject) => {
   const timeout = setTimeout(() => {
     reject(new Error('Timed out waiting for the shell to respond'));
   }, 20_000);
 
-  socket.once('open', () => {
-    setTimeout(() => {
-      socket.send(Buffer.from('echo smoke-test-ok\n', 'utf8'), {
-        binary: true,
-      });
-      socket.send(Buffer.from('python3 --version\n', 'utf8'), {
-        binary: true,
-      });
-      setTimeout(() => {
-        clearTimeout(timeout);
-        resolve();
-      }, 3_000);
-    }, 1_500);
-  });
-  socket.on('message', (data, isBinary) => {
-    if (isBinary) {
-      output += Buffer.from(data as Buffer).toString('utf8');
+  socket.on('message', (data) => {
+    const frame = decodeShellFrame(Buffer.from(data as Buffer));
+    if (frame.channel === ShellChannel.Status) {
+      const status = parseShellStatus(frame.payload);
+      if (status.metadata?.shellId && !connected) {
+        connected = true;
+        setTimeout(() => {
+          socket.send(encodeStdin('echo smoke-test-ok\n'));
+          socket.send(encodeStdin('python3 --version\n'));
+          setTimeout(() => {
+            clearTimeout(timeout);
+            resolve();
+          }, 3_000);
+        }, 1_500);
+      }
+      return;
+    }
+    if (frame.channel === ShellChannel.Stdout || frame.channel === ShellChannel.Stderr) {
+      output += frame.payload.toString('utf8');
     }
   });
   socket.once('error', (error) => {

--- a/claude-code-on-agentcore-runtime-microvm/scripts/smoke-test.ts
+++ b/claude-code-on-agentcore-runtime-microvm/scripts/smoke-test.ts
@@ -12,9 +12,6 @@
 // If --runtime-arn is omitted, it is discovered from the
 // ClaudeAgentCoreRuntimeStack CloudFormation output (--stack to override
 // the stack name).
-import { SignatureV4 } from '@smithy/signature-v4';
-import { HttpRequest } from '@smithy/protocol-http';
-import { Sha256 } from '@aws-crypto/sha256-js';
 import { defaultProvider } from '@aws-sdk/credential-provider-node';
 import {
   CloudFormationClient,
@@ -27,6 +24,7 @@ import {
   parseShellStatus,
   ShellChannel,
 } from '../client/src/shell-protocol.js';
+import { signShellUpgrade } from '../shared/shell-signing.js';
 
 const args = process.argv.slice(2);
 if (args.includes('--help') || args.includes('-h')) {
@@ -50,9 +48,9 @@ const sessionId = `smoke-test-${Date.now()}-${Math.random().toString(36).slice(2
 );
 const shellId = `smoke-${Date.now()}`;
 const url = buildShellUrl(runtimeArn, region, shellId);
-const headers = await signShellUpgrade(url, region, sessionId);
+const signed = await signShellUpgrade(url, sessionId, defaultProvider({ profile }));
 
-const socket = new WebSocket(url, { headers });
+const socket = new WebSocket(url, { headers: signed.headers });
 let output = '';
 let connected = false;
 
@@ -106,39 +104,6 @@ function buildShellUrl(arn: string, awsRegion: string, id: string): URL {
   );
   url.searchParams.set('shellId', id);
   return url;
-}
-
-async function signShellUpgrade(
-  url: URL,
-  awsRegion: string,
-  sessionId: string,
-): Promise<Record<string, string>> {
-  const credentials = await defaultProvider({ profile })();
-  const signer = new SignatureV4({
-    credentials,
-    region: awsRegion,
-    service: 'bedrock-agentcore',
-    sha256: Sha256,
-  });
-  const signed = await signer.sign(
-    new HttpRequest({
-      protocol: url.protocol,
-      hostname: url.hostname,
-      method: 'GET',
-      path: url.pathname,
-      query: Object.fromEntries(url.searchParams),
-      headers: {
-        host: url.hostname,
-        'X-Amzn-Bedrock-AgentCore-Runtime-Session-Id': sessionId,
-      },
-    }),
-  );
-  const headers: Record<string, string> = {};
-  for (const [key, value] of Object.entries(signed.headers)) {
-    if (key.toLowerCase() === 'host') continue;
-    headers[key] = value;
-  }
-  return headers;
 }
 
 async function discoverRuntimeArn(): Promise<string> {

--- a/claude-code-on-agentcore-runtime-microvm/shared/shell-signing.ts
+++ b/claude-code-on-agentcore-runtime-microvm/shared/shell-signing.ts
@@ -1,0 +1,54 @@
+import { SignatureV4 } from '@smithy/signature-v4';
+import { HttpRequest } from '@smithy/protocol-http';
+import { Sha256 } from '@aws-crypto/sha256-js';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
+
+// Shared by client/src/terminal.ts (CLI), scripts/smoke-test.ts, and
+// relay/src/index.ts (the browser-terminal signing relay). All three need
+// to open a real InvokeAgentRuntimeCommandShell WebSocket, which requires
+// a SigV4-signed upgrade request carrying the runtime session id as a
+// *signed header*, not a query param (verified against the
+// bedrock_agentcore Python SDK's AgentCoreRuntimeClient.connect_shell /
+// _build_shell_url). Consolidated here instead of duplicating this in
+// every caller.
+export async function signShellUpgrade(
+  url: URL,
+  runtimeSessionId: string,
+  credentials: AwsCredentialIdentityProvider,
+): Promise<{ headers: Record<string, string> }> {
+  const signer = new SignatureV4({
+    credentials,
+    region: regionFromShellHost(url.hostname),
+    service: 'bedrock-agentcore',
+    sha256: Sha256,
+  });
+  const signed = await signer.sign(
+    new HttpRequest({
+      protocol: url.protocol,
+      hostname: url.hostname,
+      method: 'GET',
+      path: url.pathname,
+      query: Object.fromEntries(url.searchParams),
+      headers: {
+        host: url.hostname,
+        'X-Amzn-Bedrock-AgentCore-Runtime-Session-Id': runtimeSessionId,
+      },
+    }),
+  );
+  const headers: Record<string, string> = {};
+  for (const [key, value] of Object.entries(signed.headers)) {
+    if (key.toLowerCase() === 'host') continue;
+    headers[key] = value;
+  }
+  return { headers };
+}
+
+export function regionFromShellHost(hostname: string): string {
+  const match = /^bedrock-agentcore\.([a-z0-9-]+)\.amazonaws\.com$/.exec(
+    hostname,
+  );
+  if (!match?.[1]) {
+    throw new Error(`Unable to derive region from shell host: ${hostname}`);
+  }
+  return match[1];
+}

--- a/claude-code-on-agentcore-runtime-microvm/tsconfig.json
+++ b/claude-code-on-agentcore-runtime-microvm/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "lib": ["ES2023", "DOM"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "noUncheckedIndexedAccess": true,
+    "outDir": "dist",
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2022",
+    "types": ["node", "vitest/globals"]
+  },
+  "include": [
+    "client/**/*.ts",
+    "control-plane/**/*.ts",
+    "infra/**/*.ts",
+    "shared/**/*.ts",
+    "scripts/**/*.ts"
+  ],
+  "exclude": ["cdk.out", "node_modules", "agent-runtime"]
+}

--- a/claude-code-on-agentcore-runtime-microvm/vitest.config.ts
+++ b/claude-code-on-agentcore-runtime-microvm/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    // Without an explicit exclude, vitest's default test glob also
+    // matches copies of test files that CDK's NodejsFunction/asset
+    // bundling leaves behind under cdk.out/asset.<hash>/ (each asset
+    // bundle is built from a full copy of the repo, tests directory
+    // included). Those are frozen snapshots from whenever `cdk synth`
+    // last ran, not the current source -- running them alongside the
+    // real suite produced confusing phantom failures/duplicates
+    // throughout this project's end-to-end testing (a test edited in
+    // infra/test/stacks.test.ts kept "failing" from a stale cdk.out
+    // copy that still had the old assertion, even after the real fix
+    // landed and the real copy passed).
+    exclude: ['**/node_modules/**', '**/cdk.out/**', '**/dist/**'],
+  },
+});


### PR DESCRIPTION
## Summary

This sample gives developers an on-demand, private coding sandbox: each session provisions an isolated microVM (Claude Code CLI + VS Code CLI pre-installed) behind an IAM-authorized API, with an interactive shell and S3-backed checkpoint/restore so a workspace survives across sessions. It's a sibling to the existing `claude-code-on-lambda-microvm` sample — same governed developer-sandbox architecture and API shape, but running on **Amazon Bedrock AgentCore Runtime** (microVM compute type) instead of Lambda MicroVMs. Purely additive — no existing sample or shared file is modified.

## Architecture

```mermaid
flowchart LR
    CLI["Operator CLI<br/>(client/)"]
    Portal["Browser Portal<br/>optional, Cognito-gated"]

    subgraph AWS["AWS account"]
        APIGW["API Gateway<br/>IAM-authorized"]
        CP["Control Plane<br/>session lifecycle service"]
        DDB[("DynamoDB<br/>sessions / claims")]
        S3[("S3<br/>checkpoint bucket")]
        AR["AgentCore Runtime<br/>microVM container<br/>Claude Code CLI + VS Code CLI"]
    end

    CLI -- "REST (SigV4)<br/>bootstrap / terminate" --> APIGW --> CP
    CLI -- "WSS (SigV4)<br/>InvokeAgentRuntimeCommandShell" --> AR
    Portal -.-> AR
    CP -- "bootstrap / invoke / checkpoint" --> AR
    CP <--> DDB
    AR -- "checkpoint.tar.gz on terminate" --> S3
    AR -- "restore on bootstrap" --> S3
```

## Why AgentCore Runtime instead of Lambda MicroVM

AgentCore Runtime offers a managed, VPC-capable microVM compute surface with an equivalent 8h session cap, interactive shell access (`InvokeAgentRuntimeCommandShell`), and container-based deployment — but with a materially different API surface (no native session list/describe API, no pause primitive) that this sample works around explicitly rather than papering over.

## What's included

- **`infra/`** — CDK stack using the native `AWS::BedrockAgentCore::Runtime` L1 construct (`aws-cdk-lib` 2.260.0): VPC, KMS, S3 checkpoint bucket, DynamoDB sessions/claims tables, private IAM-authorized API Gateway, optional Cognito-backed browser portal (`enablePortal` context flag). `cdk-nag` (AwsSolutions) clean with documented suppressions.
- **`control-plane/`** — session lifecycle service on the AgentCore Runtime data-plane SDK. Emulates suspend/resume (no native AgentCore primitive) via container-side checkpoint/restore to S3, since AgentCore Runtime has no first-class session-describe or list API (`ListSessions` in the SDK is actually an AgentCore *Memory* API, not Runtime).
- **`agent-runtime/`** — container image (Claude Code CLI + VS Code CLI) implementing the AgentCore Runtime HTTP contract (`GET /ping`, `POST /invocations`, port 8080) for bootstrap/checkpoint/terminate.
- **`client/`** — operator CLI + a hand-rolled SigV4-signed WebSocket client for the interactive-shell protocol, since the JS AWS SDK doesn't expose `InvokeAgentRuntimeCommandShell` directly (confirmed against the `bedrock_agentcore` Python SDK source for the real wire protocol: `wss://bedrock-agentcore.<region>.amazonaws.com/runtimes/<arn>/ws/shells?shellId=<id>`, session id as a signed header, not a query param).
- **`scripts/`** — `provision-agent-image.ts` (builds/pushes the container to ECR, which is deliberately *not* CDK-owned since `CfnRuntime` needs an existing image at stack-create time), `deploy.ts`, `smoke-test.ts`.
- **`portal/`** — optional minimal browser terminal UI, mirroring the Lambda MicroVM sample's portal pattern (opt-in via `enablePortal`).

## Validation

Deployed and torn down against a real AWS account (account/region/profile kept generic in all shipped code and docs — see `deployment.example.json`):

- `npm run build` (tsc --noEmit) clean.
- `npm test` — 36/36 passing (control-plane service unit tests + CDK `Template` assertions).
- `cdk synth` clean, zero `cdk-nag` (AwsSolutions) findings.
- Real end-to-end deployment: `cdk deploy` succeeded, `AWS::BedrockAgentCore::Runtime` reached `READY`.
- Real interactive shell exercised via `InvokeAgentRuntimeCommandShell`:
  ```
  root@localhost:/# echo hello-from-agentcore-runtime
  hello-from-agentcore-runtime
  root@localhost:/# python3 --version
  Python 3.12.14
  root@localhost:/# whoami
  root
  ```
- Real checkpoint flow: bootstrap session (run-hook payload with S3 presigned upload URL) → wrote a file under `/workspace` via shell → triggered `terminate` via `InvokeAgentRuntime` → confirmed the checkpoint `.tar.gz` landed in the S3 workspace bucket with the correct size:
  ```
  1. bootstrap
  {"response":{"status":"initialized","sessionId":"..."},"status":"success"}
  2. checkpoint (terminate)
  {"response":{"status":"checkpointed","operation":"terminate"},"status":"success"}
  3. checking S3
  CHECKPOINT FOUND: s3://.../checkpoint.tar.gz size=355 bytes
  ```
- Stack torn down afterward (`cdk destroy`); no billable resources left running. (A few AWS-managed ENIs for the AgentCore Runtime persisted past deletion per AWS's documented up-to-8h behavior — handled via `--retain-resources` on the otherwise-empty VPC/subnet/security-group, no cost impact.)

## Notes for reviewers

- Deliberately does **not** modify `claude-code-on-lambda-microvm/` or any shared root config beyond the root `.gitignore`, where I added the same `!claude-code-on-agentcore-runtime-microvm/**/{bin,lib,test}/**` allowlist pattern that already exists for `claude-code-on-lambda-microvm/` (the repo's blanket `**/bin/`, `**/lib/`, `**/test/` ignore rules would otherwise silently drop this sample's CDK infra and test files).
- A comparison table against `claude-code-on-lambda-microvm` and the AgentCore-Runtime-specific tradeoffs (no native pause primitive, no session list/describe API, 1h shell-connection TTL requiring client-side reconnect) are documented in code comments throughout `infra/lib/platform-stack.ts` and `control-plane/src/aws-adapters.ts`; happy to pull these into a top-level README/deployment-guide if that's preferred before merge.