### PR TITLE
docs(claude-apps-gateway): scope the per-user attribution claim (#279)

### DIFF
--- a/claude-apps-gateway/README.md
+++ b/claude-apps-gateway/README.md
@@ -281,6 +281,26 @@ See [`docs/deployment.md`](docs/deployment.md#telemetry) for deployment details.
 - The gateway itself does not log or store prompt/completion content
 - Configuring `telemetry.forward_to` automatically pushes OTEL environment variables to all connected clients
 
+**Where that attribution reaches — and where it stops.** Per-user attribution is a property
+of the *gateway's* records, not of the AWS audit trail. Three sources carry the developer's
+identity:
+
+| Source | What you get |
+|---|---|
+| Gateway audit log (`/claude-gateway/gateway`) | `inference` / `session.mint` events with user id, email, groups, client IP — including *denied* requests |
+| OTLP metrics | token counts, model, latency, tagged `user.id` / `user.email` / groups |
+| Admin API (opt-in, §5) | period-to-date spend per user via `/v1/organizations/spend_limits/effective` |
+
+> [!IMPORTANT]
+> **CloudTrail and Bedrock invocation logging see only the ECS task role**, not the
+> developer. That is inherent to the design: developers hold no AWS credentials, so the
+> gateway signs every Bedrock call with the one task role. If your controls require
+> per-individual attribution in the *native AWS* trail, read
+> [`docs/gotchas.md` §21](docs/gotchas.md#21-per-user-attribution-stops-at-the-gateway--cloudtrail-sees-only-the-task-role)
+> before you commit to this architecture — it covers the team-level workaround using tagged
+> Bedrock application inference profiles, and why per-user session names would require a
+> change in the gateway binary itself.
+
 ---
 
 ### 4. Routing: inference with failover

--- a/claude-apps-gateway/docs/gotchas.md
+++ b/claude-apps-gateway/docs/gotchas.md
@@ -483,3 +483,75 @@ claude gateway --config /tmp/probe.yaml
 
 `chatTabEnabled` and `chatAdvancedFileAnalysisEnabled` are the current examples: both need
 **≥ 2.1.227**. See [`upstream-watch.md`](upstream-watch.md) for the version-gate checklist.
+
+---
+
+## 21. Per-user attribution stops at the gateway — CloudTrail sees only the task role
+
+**Symptom:** the gateway gives you clean per-developer usage and spend numbers, but
+CloudTrail and Bedrock invocation logging attribute *every*
+`InvokeModelWithResponseStream` call to the same principal — the ECS task role. There is
+no per-user breakdown in the native AWS audit trail.
+
+**Why:** this is by design, and it's the point of the architecture. Developers hold no
+AWS credentials; the gateway holds the one upstream credential and calls Bedrock on their
+behalf. The upstream is configured with `auth: {}` (the AWS default credential chain), which
+on Fargate resolves to the single task role in `cdk/lib/claude-gateway-stack.ts`. Centralising
+the credential is exactly what makes offboarding an IdP operation — and it is also what
+collapses 200 developers into one IAM principal at the AWS API boundary.
+
+The gateway signs the SigV4 request itself, inside the `claude` binary. Its Bedrock `auth:`
+block accepts only static credentials — `aws_access_key_id`, `aws_secret_access_key`,
+`aws_session_token`, `aws_bearer_token` — with no role ARN, no `RoleSessionName`, and no
+mapping from an OIDC claim. So there is no config in this example that would stamp the
+developer's identity onto the AWS call, and no sidecar workaround either: the gateway sends
+no user-identity header upstream, so a re-signing proxy would have nothing to attribute
+against.
+
+**Where per-user attribution actually lives.** All three of these are per-developer today:
+
+| Source | What you get | Where |
+|---|---|---|
+| Gateway audit log | `inference` and `session.mint` events with user id, email, groups, client IP | task stderr → CloudWatch `/claude-gateway/gateway` |
+| OTLP metrics | token counts, model, latency, tagged `user.id` / `user.email` / groups | your collector (CloudWatch by default) |
+| Admin API | period-to-date spend per user, when the `admin:` block is enabled | `GET /v1/organizations/spend_limits/effective` |
+
+Treat the gateway audit log as the system of record for user-level attribution. It is the
+only one that records *denied* requests as well as served ones.
+
+**Partial fix if you need attribution in the native AWS trail.** Bedrock **application
+inference profiles** are taggable, and CloudTrail records the profile ARN on the call — so
+one profile per team, referenced from group-scoped `models:` entries, gives you team-level
+breakdowns in CloudTrail and Cost Explorer:
+
+```yaml
+managed:
+  policies:
+    - match: { groups: [team-platform] }
+      cli:
+        availableModels: [claude-sonnet-5-platform]
+models:
+  - id: claude-sonnet-5-platform
+    label: Claude Sonnet 5
+    upstream_model:
+      # application inference profile tagged team=platform
+      bedrock: arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123
+```
+
+**This needs a third ARN family in the task role.** The shipped policy grants
+`inference-profile/global.anthropic.*` and `foundation-model/anthropic.*` (see §9);
+`application-inference-profile/*` is a *separate* resource type and is not covered by either,
+so without adding it you get the same opaque 403 as §9. Add it alongside the other two in
+`cdk/lib/claude-gateway-stack.ts`:
+
+```
+arn:aws:bedrock:<region>:<acct>:application-inference-profile/*
+```
+
+This is **team-level, not per-individual**. A compliance requirement written per person
+(NERC CIP and similar) is not satisfied by it. Per-user `AssumeRole` with a
+`RoleSessionName` derived from the OIDC subject would have to come from the gateway binary
+itself — tracked upstream as
+[anthropics/claude-code](https://github.com/anthropics/claude-code/issues) and discussed in
+[aws-samples/anthropic-on-aws#279](https://github.com/aws-samples/anthropic-on-aws/issues/279).
+Don't plan a deployment around it landing.


### PR DESCRIPTION
## Why

Raised by #279. The README advertises "per-user cost attribution" without ever saying where that attribution stops. It stops at the gateway: developers hold no AWS credentials, so every Bedrock call is signed with the one ECS task role, and CloudTrail / Bedrock invocation logging attribute all users to that single principal.

An evaluator with a per-individual audit requirement (the reporter's case is NERC CIP) had no way to learn this from the docs before committing to the architecture. That omission is the defect — the behaviour itself is correct and intentional.

## What changed

Docs only, two files, no behaviour change.

**`README.md` §3** — a table of the three sources that genuinely carry per-user identity (gateway audit log, OTLP metrics, admin API), plus an `IMPORTANT` callout that the native AWS trail is task-role granularity only, linking to the detail.

**`docs/gotchas.md` §21** — the full field note:
- Why it's inherent: the `claude` binary signs SigV4 itself, and its Bedrock `auth:` block accepts only static credentials (`aws_access_key_id`, `aws_secret_access_key`, `aws_session_token`, `aws_bearer_token`) — no role ARN, no `RoleSessionName`, no OIDC claim mapping. Verified against the pinned 2.1.229 binary and the published config reference.
- Why there's no sidecar workaround either: the gateway emits no user-identity header upstream, so a re-signing proxy would have nothing to attribute against.
- Which source to treat as the system of record — the gateway audit log, since it's the only one that records *denied* requests as well as served ones.
- The team-level workaround: tagged Bedrock application inference profiles referenced from group-scoped `models:` entries, giving CloudTrail and Cost Explorer breakdowns by team.

## Reviewer note

The application-inference-profile snippet needs a **third ARN family** in the task role. The shipped policy grants `inference-profile/global.anthropic.*` and `foundation-model/anthropic.*`; `application-inference-profile/*` is a separate resource type covered by neither, so the workaround would 403 exactly as gotchas §9 describes. §21 spells out the extra grant rather than leaving readers to hit it.

The workaround is explicitly labelled **team-level, not per-individual** — it does not satisfy a requirement written per person. Per-user session names would need a change in the gateway binary; the reporter has been redirected to [anthropics/claude-code](https://github.com/anthropics/claude-code/issues) and told not to plan a deployment around it landing.

## Scope

Deliberately not fixing #262 here (`deploy.sh` fails after partial resource creation, and `cdk/README.md` currently claims otherwise). That one needs a code change, not a doc change, so it wants its own PR.

## Verification

Markdown only — no `setup.sh`, stack, or config changes, so per `CLAUDE.md` the CDK/shell test suites are unaffected. Anchor link derivation checked against the existing `#20-...` and `#13-...` cross-references in the repo. Framing preserved throughout: a worked example, not a supported production artifact.