### PR TITLE
fix(skills): correct IAM-auth worker example in CPOA migration skill

### DIFF
--- a/.claude/skills/claude-platform-on-aws/references/code-patterns.md
+++ b/.claude/skills/claude-platform-on-aws/references/code-patterns.md
@@ -194,19 +194,24 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
-### After (CPOA — Worker with IAM Auth)
+### After (CPOA — Worker with IAM Auth via Short-Term Token)
+
+A natively SigV4-signing worker client is not a documented pattern. To authenticate a worker with IAM credentials, generate a short-term token from the AWS credential chain and pass it as the auth token (requires the `AnthropicSelfHostedEnvironmentAccess` IAM policy).
 
 ```python
 import asyncio
 import os
 from anthropic import AsyncAnthropic
 from anthropic.lib.environments import EnvironmentWorker
+from token_generator_for_aws_external_anthropic import TokenGenerator
 
 async def main() -> None:
-    # On CPOA: no environment key needed — authenticate via IAM
-    # Requires AnthropicSelfHostedEnvironmentAccess IAM policy
+    # On CPOA: no Claude Console environment key — derive a short-term token
+    # from IAM credentials. Tokens default to 12h and do not auto-refresh:
+    # long-running workers must regenerate and reconnect before expiry.
+    token = TokenGenerator(region=os.environ["AWS_REGION"]).get_token()
     environment_id = os.environ["ANTHROPIC_ENVIRONMENT_ID"]
-    async with AsyncAnthropic() as client:  # SigV4 via AWS credential chain
+    async with AsyncAnthropic(auth_token=token) as client:
         await EnvironmentWorker(
             client,
             environment_id=environment_id,


### PR DESCRIPTION
## Summary

Follow-up to #231, resolving the last open review thread there.

The "Worker with IAM Auth" example in `code-patterns.md` used the base `AsyncAnthropic()` client with a `# SigV4 via AWS credential chain` comment. The base client targets `api.anthropic.com` and cannot SigV4-sign, so the example could not work as written — the same defect fixed in the inference examples during review of #231.

## Change

Replaced the block with a documented pattern: derive a short-term token from IAM credentials via `TokenGenerator` and pass it as the worker's `auth_token` (mirroring the API-key worker block). Added notes that a natively SigV4-signing worker client is not a documented pattern, and that tokens default to 12h with no auto-refresh.

Docs-only change; single file.