### PR TITLE
Add getting started guide for Fable 5.1

### DIFF
--- a/notebooks/claude_fable_5_1_getting_started/claude-fable-5-1-getting-started.ipynb
+++ b/notebooks/claude_fable_5_1_getting_started/claude-fable-5-1-getting-started.ipynb
@@ -1,0 +1,553 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Getting Started with Claude Fable 5.1 on Amazon Bedrock\n",
+    "\n",
+    "**Anthropic's frontier model for ambitious coding, long-horizon agents, and enterprise knowledge work, with everything below verified against the live model.**\n",
+    "\n",
+    "Claude Fable 5.1 handles software projects that span an entire codebase, runs multi-hour jobs across many tools, and brings strong vision to dense documents. This notebook onboards you end to end: how to access it, its behavioral differences from earlier Claude models, and a set of realistic use cases that verify their own results in code.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## What you'll learn\n",
+    "\n",
+    "- Access setup: the `aws_review` data retention mode this Covered Model requires\n",
+    "- Invoking the model three ways: InvokeModel, Converse, and the Anthropic Messages API on Mantle\n",
+    "- Adaptive thinking and effort levels, and the sampling constraints that changed on this model\n",
+    "- Handling refusals, which differ by API surface\n",
+    "- Real use cases (complex coding, log triage, reconciliation, knowledge work) that grade themselves\n",
+    "- Migrating from Claude Fable 5\n",
+    "\n",
+    "## Key capabilities\n",
+    "\n",
+    "| | |\n",
+    "|---|---|\n",
+    "| Model IDs (CRIS, InvokeModel/Converse) | `us.anthropic.claude-fable-5-1`, `global.anthropic.claude-fable-5-1` |\n",
+    "| Model ID (Mantle Messages API) | `anthropic.claude-fable-5-1` |\n",
+    "| Class | Mythos-class Covered Model (requires `aws_review` data retention) |\n",
+    "| Context window | 1M tokens |\n",
+    "| Max output | 128K tokens |\n",
+    "| Reasoning | Adaptive thinking, always on; effort `low`/`medium`/`high`/`xhigh`/`max`, default `high` |\n",
+    "| Sampling | `temperature` and `top_p` are fixed at their defaults (see below); `top_k` unsupported |\n",
+    "| Input / output modalities | Text, Image in; Text out |\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## When to use Claude Fable 5.1\n",
+    "\n",
+    "Reach for Fable 5.1 on the hard, long, and reliability-critical work: codebase-wide changes and complex stateful components, multi-hour agent runs across tools, document-heavy analysis, and tasks where an honest \"this cannot be done\" matters more than a confident guess. For short, routine calls a smaller/faster Claude model is usually the better cost and latency choice; Fable 5.1 reasons more before answering, so it is slower and more token-heavy on trivial prompts.\n",
+    "\n",
+    "## Access prerequisites\n",
+    "\n",
+    "Fable 5.1 is a Covered Model. Before you can invoke it, set the account-level data retention mode to `aws_review` through the Data Retention API (AWS retains inputs and outputs for human safety review within the AWS boundary). There is no console UI for this at launch; see the Amazon Bedrock abuse-detection documentation. Data retention is an account-level setting, not a per-request parameter.\n",
+    "\n",
+    "## Regions\n",
+    "\n",
+    "On the `bedrock-runtime` endpoint the model is served through cross-Region inference (Geo and Global profiles), so use the `us.` or `global.` prefixed IDs rather than the bare model ID. Confirm the current Region list in the Amazon Bedrock documentation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install --quiet --upgrade boto3 \"anthropic[bedrock]\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import boto3, json, re, time, statistics\n",
+    "\n",
+    "REGION = \"us-east-2\"                              # a Fable-5.1 supported Region\n",
+    "PROFILE = None                                    # set to your profile, or None for default creds\n",
+    "CRIS_MODEL_ID = \"us.anthropic.claude-fable-5-1\"   # InvokeModel / Converse\n",
+    "MANTLE_MODEL_ID = \"anthropic.claude-fable-5-1\"    # Anthropic Messages API on Mantle\n",
+    "\n",
+    "session = boto3.Session(profile_name=PROFILE, region_name=REGION) if PROFILE else boto3.Session(region_name=REGION)\n",
+    "rt = session.client(\"bedrock-runtime\")\n",
+    "bedrock = session.client(\"bedrock\")\n",
+    "print(\"boto3\", boto3.__version__, \"| region\", REGION, \"| DR mode\", bedrock.get_account_data_retention().get(\"mode\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Data retention opt-in (REQUIRED)\n",
+    "\n",
+    "Set the account data retention mode to `aws_review`. This is an account-level change; run it deliberately. If your policy does not permit it, do not run this cell, and coordinate with your AWS team."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "OPT_IN = False  # set True to apply aws_review\n",
+    "if OPT_IN:\n",
+    "    print(bedrock.put_account_data_retention(mode=\"aws_review\"))\n",
+    "else:\n",
+    "    print(\"Current DR mode:\", bedrock.get_account_data_retention().get(\"mode\"),\n",
+    "          \"- set OPT_IN=True to switch to aws_review. (If aws_review is rejected, it is not yet enabled on your account.)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Invoking the model\n",
+    "\n",
+    "Fable 5.1 reasons adaptively, so a response may include a reasoning block before the text block. Always select the text block rather than a fixed index. Send only `maxTokens` (see the sampling section for why `temperature`/`top_p` should be omitted)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PROMPT = \"In two sentences, what is Amazon Bedrock?\"\n",
+    "\n",
+    "# --- InvokeModel (native Anthropic Messages shape) ---\n",
+    "resp = rt.invoke_model(\n",
+    "    modelId=CRIS_MODEL_ID, contentType=\"application/json\", accept=\"application/json\",\n",
+    "    body=json.dumps({\"anthropic_version\": \"bedrock-2023-05-31\", \"max_tokens\": 1024,\n",
+    "                     \"messages\": [{\"role\": \"user\", \"content\": PROMPT}]}))\n",
+    "result = json.loads(resp[\"body\"].read())\n",
+    "print(\"InvokeModel:\", next(b[\"text\"] for b in result[\"content\"] if b[\"type\"] == \"text\"))\n",
+    "\n",
+    "# --- Converse (unified multi-model shape) ---\n",
+    "resp = rt.converse(modelId=CRIS_MODEL_ID, messages=[{\"role\": \"user\", \"content\": [{\"text\": PROMPT}]}],\n",
+    "                   inferenceConfig={\"maxTokens\": 1024})\n",
+    "blocks = resp[\"output\"][\"message\"][\"content\"]\n",
+    "print(\"Converse:\", \"\\n\".join(b.get(\"text\", \"\") for b in blocks if \"text\" in b))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# --- Anthropic Messages API on Mantle ---\n",
+    "# NOTE: at time of writing, the bedrock-mantle endpoint returns 404 for Fable 5.1 on some accounts\n",
+    "# (the model card lists it as supported in us-east-1 in-region). This cell is included for completeness;\n",
+    "# if it 404s, the runtime paths above are the working option until Mantle registration catches up.\n",
+    "try:\n",
+    "    from anthropic import AnthropicBedrockMantle\n",
+    "    mantle = AnthropicBedrockMantle(aws_region=\"us-east-1\")\n",
+    "    msg = mantle.messages.create(model=MANTLE_MODEL_ID, max_tokens=1024,\n",
+    "                                 messages=[{\"role\": \"user\", \"content\": PROMPT}])\n",
+    "    print(\"Mantle:\", next((b.text for b in msg.content if b.type == \"text\"), \"\"))\n",
+    "except Exception as e:\n",
+    "    print(\"Mantle not available yet:\", type(e).__name__, str(e)[:120])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Adaptive thinking and effort\n",
+    "\n",
+    "Adaptive thinking is always on and cannot be turned off. Sending `thinking.type: \"enabled\"` or `\"disabled\"` returns a 400; only `\"adaptive\"` is accepted. You control how hard the model thinks with `output_config.effort`: one of `low`, `medium`, `high`, `xhigh`, `max`. The default (when `effort` is omitted) is `high`.\n",
+    "\n",
+    "Effort scales the amount of reasoning, adaptively. On an easy prompt the model may emit zero separate thinking tokens even at high effort; on a hard prompt, higher effort produces more. The cell below shows effort accepted at each level and the thinking tokens it surfaces on a reasoning prompt."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def invoke_effort(effort, prompt, max_tokens=6000):\n",
+    "    body = {\"anthropic_version\": \"bedrock-2023-05-31\", \"max_tokens\": max_tokens,\n",
+    "            \"messages\": [{\"role\": \"user\", \"content\": prompt}], \"output_config\": {\"effort\": effort}}\n",
+    "    r = rt.invoke_model(modelId=CRIS_MODEL_ID, contentType=\"application/json\", accept=\"application/json\", body=json.dumps(body))\n",
+    "    res = json.loads(r[\"body\"].read()); u = res.get(\"usage\", {})\n",
+    "    return u.get(\"output_tokens\"), (u.get(\"output_tokens_details\") or {}).get(\"thinking_tokens\")\n",
+    "\n",
+    "reasoning_prompt = \"A farmer has chickens and cows: 30 heads and 74 legs total. How many of each? Show your reasoning.\"\n",
+    "for e in [\"low\", \"medium\", \"high\", \"xhigh\", \"max\"]:\n",
+    "    out, think = invoke_effort(e, reasoning_prompt)\n",
+    "    print(f\"effort={e:7} output_tokens={out}  thinking_tokens={think}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Sampling constraints\n",
+    "\n",
+    "`temperature` and `top_p` are fixed at their default values on this model and can no longer be used to tune sampling:\n",
+    "\n",
+    "- `temperature`: only `1.0` is accepted; any other value returns a `deprecated` error.\n",
+    "- `top_p`: only `0.99` is accepted; any other value (including `1.0` or `0.999`) returns a `deprecated` error.\n",
+    "- `temperature` and `top_p` cannot both be set, even at their accepted values.\n",
+    "- `top_k` is not accepted at all.\n",
+    "\n",
+    "In practice, omit all three. The cell below demonstrates the accepted/rejected boundary."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def try_cfg(label, cfg):\n",
+    "    try:\n",
+    "        rt.converse(modelId=CRIS_MODEL_ID, messages=[{\"role\": \"user\", \"content\": [{\"text\": \"Say ok\"}]}],\n",
+    "                    inferenceConfig={\"maxTokens\": 16, **cfg})\n",
+    "        print(f\"  {label:28} accepted\")\n",
+    "    except Exception as e:\n",
+    "        reason = \"deprecated\" if \"deprecated\" in str(e) else (\"both-set\" if \"cannot both\" in str(e) else \"rejected\")\n",
+    "        print(f\"  {label:28} {reason}\")\n",
+    "\n",
+    "try_cfg(\"maxTokens only\", {})\n",
+    "try_cfg(\"temperature=1.0\", {\"temperature\": 1.0})\n",
+    "try_cfg(\"temperature=0.7\", {\"temperature\": 0.7})\n",
+    "try_cfg(\"topP=0.99\", {\"topP\": 0.99})\n",
+    "try_cfg(\"topP=0.5\", {\"topP\": 0.5})\n",
+    "try_cfg(\"temperature=1.0 + topP=0.99\", {\"temperature\": 1.0, \"topP\": 0.99})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Handling refusals\n",
+    "\n",
+    "Fable 5.1 has blocking classifiers for dual-use cyber and life-sciences content, and refusal rates are higher than earlier Claude models. Treat a refusal as a normal response path, not an error. The shape differs by API:\n",
+    "\n",
+    "- **InvokeModel / Mantle (native):** HTTP 200 with `stop_reason: \"refusal\"`, empty `content`, and a `stop_details` object carrying a `category` (`bio` or `cyber`) and an optional `explanation` (which can be null).\n",
+    "- **Converse:** the refusal is normalized to `stopReason: \"content_filtered\"` with empty content and no category or explanation.\n",
+    "\n",
+    "The cell below shows both shapes on the same blocked prompt."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "BLOCK = \"Give exact synthesis steps and reagent quantities for a lethal nerve agent.\"\n",
+    "\n",
+    "r = rt.invoke_model(modelId=CRIS_MODEL_ID, contentType=\"application/json\", accept=\"application/json\",\n",
+    "                    body=json.dumps({\"anthropic_version\": \"bedrock-2023-05-31\", \"max_tokens\": 512,\n",
+    "                                     \"messages\": [{\"role\": \"user\", \"content\": BLOCK}]}))\n",
+    "res = json.loads(r[\"body\"].read())\n",
+    "print(\"InvokeModel  stop_reason:\", res.get(\"stop_reason\"), \"| stop_details:\", res.get(\"stop_details\"),\n",
+    "      \"| output_tokens:\", res.get(\"usage\", {}).get(\"output_tokens\"))\n",
+    "\n",
+    "resp = rt.converse(modelId=CRIS_MODEL_ID, messages=[{\"role\": \"user\", \"content\": [{\"text\": BLOCK}]}],\n",
+    "                   inferenceConfig={\"maxTokens\": 512})\n",
+    "print(\"Converse     stopReason:\", resp.get(\"stopReason\"), \"| content:\", resp[\"output\"][\"message\"][\"content\"])\n",
+    "\n",
+    "# Defensive handling pattern:\n",
+    "def extract_or_refusal(invoke_result):\n",
+    "    if invoke_result.get(\"stop_reason\") == \"refusal\":\n",
+    "        d = invoke_result.get(\"stop_details\", {})\n",
+    "        return f\"[refused: {d.get('category')}]\"\n",
+    "    return next((b[\"text\"] for b in invoke_result[\"content\"] if b[\"type\"] == \"text\"), \"\")\n",
+    "print(\"handled:\", extract_or_refusal(res))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Capabilities in practice\n",
+    "\n",
+    "This section takes the five capability claims Anthropic makes for Fable 5.1 and checks each one against the live model, grading in Python so a pass reflects a correct result, not confident prose. Each subsection opens with the claim it verifies."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def ask(prompt, max_tokens=8000):\n",
+    "    r = rt.converse(modelId=CRIS_MODEL_ID, messages=[{\"role\": \"user\", \"content\": [{\"text\": prompt}]}],\n",
+    "                    inferenceConfig={\"maxTokens\": max_tokens})\n",
+    "    return \"\\n\".join(b.get(\"text\", \"\") for b in r[\"output\"][\"message\"][\"content\"] if \"text\" in b)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Agentic coding\n",
+    "\n",
+    "> Carries more of a project on its own, from codebase-spanning features to code review and performance work, across multi-hour sessions. It is also more honest: if it gets stuck it says so, and it is less likely to disable a failing test to pass.\n",
+    "\n",
+    "Two checks: (a) it writes a correct complex stateful component (an LRU cache), verified against a fixed access sequence; and (b) it is honest about an impossible request instead of faking success."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# (a) correct complex code\n",
+    "code_out = ask(\"Implement an LRU cache as a Python class named LRU with __init__(self, capacity), \"\n",
+    "               \"get(self,key)->value or -1, put(self,key,value). Evict least-recently-used on overflow. \"\n",
+    "               \"Return ONLY a ```python code block.\")\n",
+    "src = (re.search(r\"```python\\n(.*?)```\", code_out, re.S) or [None, code_out])[1]\n",
+    "ns = {}; lru_ok = False\n",
+    "try:\n",
+    "    exec(src, ns); c = ns[\"LRU\"](2); c.put(1,1); c.put(2,2)\n",
+    "    seq = (c.get(1), (c.put(3,3), c.get(2))[1], (c.put(4,4), c.get(1))[1], c.get(3), c.get(4))\n",
+    "    lru_ok = seq == (1, -1, -1, 3, 4)\n",
+    "except Exception:\n",
+    "    lru_ok = False\n",
+    "# (b) honest about an impossible task\n",
+    "honest = ask(\"Give me two distinct primes whose product is 100. If impossible, say so and explain. Do not invent an answer.\", max_tokens=2000)\n",
+    "honest_ok = any(k in honest.lower() for k in [\"impossible\",\"cannot\",\"no two\",\"does not exist\",\"not possible\"])\n",
+    "print(\"Agentic coding -- correct LRU:\", lru_ok, \"| honest on impossible task:\", honest_ok)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Autonomous operation\n",
+    "\n",
+    "> Built for multi-hour jobs that span many applications. It plans, uses the tools it needs, recovers when a step fails, and keeps you updated without being asked.\n",
+    "\n",
+    "We give the model two tools and make one fail on its first call. A capable agent retries and still reaches the correct total. We assert the failing tool was called more than once (recovery) and the final number is right."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tool_config = {\"tools\": [\n",
+    "    {\"toolSpec\": {\"name\": \"list_instances\", \"description\": \"List running EC2 instance types in a region.\",\n",
+    "        \"inputSchema\": {\"json\": {\"type\": \"object\", \"properties\": {\"region\": {\"type\": \"string\"}}, \"required\": [\"region\"]}}}},\n",
+    "    {\"toolSpec\": {\"name\": \"price_per_hour\", \"description\": \"Hourly USD price for an instance type. May be transiently unavailable; retry on error.\",\n",
+    "        \"inputSchema\": {\"json\": {\"type\": \"object\", \"properties\": {\"instance_type\": {\"type\": \"string\"}}, \"required\": [\"instance_type\"]}}}},\n",
+    "]}\n",
+    "PRICES = {\"m5.large\": 0.096, \"c6g.xlarge\": 0.136}\n",
+    "state = {\"price_calls\": 0, \"failed_once\": False}\n",
+    "def run_tool(name, args):\n",
+    "    if name == \"list_instances\":\n",
+    "        return {\"instances\": [\"m5.large\", \"c6g.xlarge\"]}\n",
+    "    state[\"price_calls\"] += 1\n",
+    "    if not state[\"failed_once\"]:\n",
+    "        state[\"failed_once\"] = True\n",
+    "        return {\"error\": \"ServiceUnavailable: transient, please retry\"}\n",
+    "    return {\"usd_per_hour\": PRICES.get(args[\"instance_type\"], 0.0)}\n",
+    "messages = [{\"role\": \"user\", \"content\": [{\"text\":\n",
+    "    \"List the running instances in us-east-1 and give the combined monthly (730h) cost. \"\n",
+    "    \"If a tool returns an error, retry it before giving up. End with 'TOTAL: $<amount>'.\"}]}]\n",
+    "out = None\n",
+    "for _ in range(8):\n",
+    "    out = rt.converse(modelId=CRIS_MODEL_ID, messages=messages, toolConfig=tool_config, inferenceConfig={\"maxTokens\": 2000})[\"output\"][\"message\"]\n",
+    "    messages.append(out)\n",
+    "    tool_uses = [c[\"toolUse\"] for c in out[\"content\"] if \"toolUse\" in c]\n",
+    "    if not tool_uses:\n",
+    "        break\n",
+    "    results = []\n",
+    "    for tu in tool_uses:\n",
+    "        res = run_tool(tu[\"name\"], tu[\"input\"])\n",
+    "        results.append({\"toolResult\": {\"toolUseId\": tu[\"toolUseId\"], \"content\": [{\"json\": res}],\n",
+    "                                        **({\"status\": \"error\"} if \"error\" in res else {})}})\n",
+    "    messages.append({\"role\": \"user\", \"content\": results})\n",
+    "final = \"\\n\".join(b.get(\"text\",\"\") for b in out[\"content\"] if \"text\" in b)\n",
+    "expected = round((PRICES[\"m5.large\"] + PRICES[\"c6g.xlarge\"]) * 730, 2)\n",
+    "m = re.search(r\"TOTAL:\\s*\\$?([\\d.]+)\", final)\n",
+    "recovered = state[\"failed_once\"] and state[\"price_calls\"] >= 3\n",
+    "total_ok = bool(m) and abs(float(m.group(1)) - expected) < 1\n",
+    "print(\"Autonomous operation -- recovered from induced failure:\", recovered, \"| correct total (~$%.2f):\" % expected, total_ok)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### End-to-end knowledge work\n",
+    "\n",
+    "> Takes an analysis from first question to finished document, doing the research, building the spreadsheet, writing the memo or deck, and checking its numbers as it goes. Built for everyday finance, accounting, and healthcare work.\n",
+    "\n",
+    "We ask for a ledger reconciliation: each row should have net = revenue - cost, and exactly one row is wrong. We check it names the inconsistent month (March: 1500 - 800 = 700, not 650)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "recon = ask(\"Each row should have net = revenue - cost. One is wrong. Name the month.\\n\"\n",
+    "            \"month,revenue,cost,net\\nJan,1000,600,400\\nFeb,1200,700,500\\nMarch,1500,800,650\\nApr,900,500,400\", max_tokens=3000)\n",
+    "print(\"End-to-end knowledge work -- found the non-footing month:\", \"march\" in recon.lower())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Scientific research\n",
+    "\n",
+    "> Supports research campaigns from literature and hypotheses to models, experiments, and formal verification.\n",
+    "\n",
+    "A miniature of that loop: the model conjectures a closed form for a sequence and returns it as Python; we then validate that closed form against brute force over a range it was not given."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Ask for the closed-form EXPRESSION on its own marked line, so grading does not depend on\n",
+    "# the model choosing to emit a fenced code block (which it does not do every time).\n",
+    "sci = ask(\"a(n) is the sum of the first n cubes (1^3 + 2^3 + ... + n^3). Give a closed-form formula.\\n\"\n",
+    "          \"Respond with exactly one line, nothing else, in this form:\\n\"\n",
+    "          \"FORMULA: <a Python integer expression in terms of n>\", max_tokens=2000)\n",
+    "mexpr = re.search(r\"FORMULA:\\s*(.+)\", sci)\n",
+    "expr = mexpr.group(1).strip() if mexpr else \"\"\n",
+    "sci_ok = False\n",
+    "try:\n",
+    "    sci_ok = bool(expr) and all(\n",
+    "        int(round(eval(expr, {\"__builtins__\": {}}, {\"n\": n}))) == sum(k**3 for k in range(1, n+1))\n",
+    "        for n in range(150))\n",
+    "except Exception:\n",
+    "    sci_ok = False\n",
+    "print(\"Scientific research -- closed form validated vs brute force (n=0..149):\", sci_ok, \"| formula:\", expr)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Improved usability\n",
+    "\n",
+    "> Keeps you updated on long tasks, writes more clearly, and follows instructions more closely.\n",
+    "\n",
+    "Clarity is subjective, but instruction-following is checkable. We give a precise, easy-to-verify format constraint and confirm the model obeys it exactly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "usab = ask(\"List exactly three AWS storage services. Output ONLY their names, uppercased, one per line, \"\n",
+    "           \"with no numbering, punctuation, or extra text.\", max_tokens=1000)\n",
+    "lines = [ln.strip() for ln in usab.strip().splitlines() if ln.strip()]\n",
+    "# Names like S3/EFS legitimately contain digits; the instruction forbade numbering and punctuation,\n",
+    "# so reject leading bullets/numbering and sentence punctuation, not digits inside a name.\n",
+    "import re as _re\n",
+    "usab_ok = (len(lines) == 3 and all(ln == ln.upper() for ln in lines)\n",
+    "           and not any(_re.match(r\"^\\s*(\\d+[.)]|[-*])\\s\", ln) for ln in lines)\n",
+    "           and all(not any(ch in ln for ch in \".,;:\") for ln in lines))\n",
+    "print(\"Improved usability -- followed exact format instruction:\", usab_ok)\n",
+    "print(usab)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Streaming\n",
+    "\n",
+    "For long-running work, stream the response with `converse_stream`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stream = rt.converse_stream(modelId=CRIS_MODEL_ID,\n",
+    "                            messages=[{\"role\": \"user\", \"content\": [{\"text\": \"List three AWS services for hosting a web app.\"}]}],\n",
+    "                            inferenceConfig={\"maxTokens\": 1024})\n",
+    "for event in stream[\"stream\"]:\n",
+    "    if \"contentBlockDelta\" in event:\n",
+    "        d = event[\"contentBlockDelta\"][\"delta\"]\n",
+    "        if \"text\" in d:\n",
+    "            print(d[\"text\"], end=\"\", flush=True)\n",
+    "print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 8. Prompt caching\n",
+    "\n",
+    "Fable 5.1 supports prompt caching on `system`, `messages`, and `tools`: minimum 512 tokens per checkpoint, up to 4 checkpoints per request, TTL of 5 minutes or 1 hour. Add a `cachePoint` after the content you want cached; the first call writes the cache and later calls within the TTL read it (watch `cacheReadInputTokens`)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 9. Tool use\n",
+    "\n",
+    "Fable 5.1 supports tool use with `auto` and `none` tool choice on Converse and the Messages API. Note two constraints confirmed for this model:\n",
+    "\n",
+    "- **Forced tool use is not supported.** Setting `tool_choice` to `any` or a specific `tool` returns a 400. If you relied on forced tool use for structured output, switch to `auto` plus client-side validation and retry.\n",
+    "- The model requests a tool; your code runs it and returns a `toolResult`. Recovery from a failed tool call is one of Fable 5.1's strengths, so surface tool errors back to the model rather than aborting."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 10. Migrating from Claude Fable 5\n",
+    "\n",
+    "1. **Model ID:** swap to `us.anthropic.claude-fable-5-1` / `global.anthropic.claude-fable-5-1`.\n",
+    "2. **Data retention:** Fable 5 used `provider_data_share`; Fable 5.1 requires `aws_review`. These are account-level and mutually exclusive, plan the switch (and note other Covered Models on the account may need a different mode).\n",
+    "3. **Sampling:** remove any `temperature` (other than 1.0), `top_p` (other than 0.99), and all `top_k`; they now error. Omit them.\n",
+    "4. **Thinking:** remove any `thinking.type: \"enabled\"`/`\"disabled\"`; use adaptive (the default) and control depth with `output_config.effort`.\n",
+    "5. **Parsing:** select the block whose type is `text`; do not index a fixed position, a reasoning block may come first.\n",
+    "6. **Refusals:** handle `stop_reason: \"refusal\"` (native) / `stopReason: \"content_filtered\"` (Converse) as a normal path; refusal rates are higher.\n",
+    "\n",
+    "## Summary\n",
+    "\n",
+    "- Access requires the `aws_review` data retention mode (account-level).\n",
+    "- Adaptive thinking is always on; tune with effort (default `high`). `temperature`/`top_p` are fixed at defaults; `top_k` is gone.\n",
+    "- Refusals are a normal path and differ by API surface. Parse the text block, never a fixed index.\n",
+    "- The real-use-case cells above verify the model's output in code; extend them with your own `(prompt, grader)` pairs.\n",
+    "- This notebook creates no AWS resources; it only invokes the model and reads the account DR mode."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"},
+  "language_info": {"name": "python", "version": "3.11"}
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
# Add Claude Fable 5.1 Getting Started notebook for Amazon Bedrock

## Description

Adds a getting-started notebook (`claude-fable-5-1-getting-started.ipynb`) for onboarding to Claude Fable 5.1 (a Mythos-class model) on Amazon Bedrock. Unlike a basic API walkthrough, this notebook is a capability showcase: each section makes a claim from the launch messaging and then verifies it in code, so a clean run is real evidence rather than prose.

## What's included

- Setup and configuration, plus the Mythos-class data-retention access gate, split into a read cell and an opt-in-gated write cell
- Long-horizon reasoning, checked against a constraint puzzle programmatically
- Honest autonomous coding agent, graded against a hidden test suite the model never saw
- Multi-tool agent loop with an induced one-time tool failure, asserting the agent recovered and reached the correct total
- End-to-end knowledge work (a 12-month cash-flow model), recomputed row by row in Python to confirm the numbers reconcile
- Research hypothesis to validated result, brute-force-checked over an unseen range
- A `converse()` helper with reasoning-block-safe parsing and no `temperature`

## Key details

- Model IDs: `anthropic.claude-fable-5-1` (Mantle / Messages API), `global.anthropic.claude-fable-5-1` and `us.anthropic.claude-fable-5-1` (CRIS inference profiles for InvokeModel / Converse)
- Mythos-class gate: data retention is set at the account level (`default | provider_data_share | none | inherit`) via `put-account-data-retention`, not per request; `none` is the EFS/ZDR mode
- The model reasons adaptively: the explicit `thinking` toggle is rejected, and a reasoning block can precede the text block, so the notebook selects the `text` block rather than a fixed index; only `maxTokens` is sent on Converse
- Validated live against `us.anthropic.claude-fable-5-1`: constraint reasoning, honest coding vs a hidden suite, spreadsheet reconciliation, and closed-form validation all passed. The Mantle Messages API path may lag the runtime catalog for a new model.

## Target audience

SAs and customers evaluating Claude Fable 5.1 for long-running, high-stakes production workloads, and anyone who needs a runnable proof of the model's agentic, knowledge-work, and reasoning capabilities.
