### PR TITLE
Fix Fable 5.1 getting-started: data-retention modes and remove commercial Mantle

### DIFF
--- a/notebooks/claude_fable_5_1_getting_started/claude-fable-5-1-getting-started.ipynb
+++ b/notebooks/claude_fable_5_1_getting_started/claude-fable-5-1-getting-started.ipynb
@@ -14,8 +14,8 @@
     "\n",
     "## What you'll learn\n",
     "\n",
-    "- Access setup: the `aws_review` data retention mode this Covered Model requires\n",
-    "- Invoking the model three ways: InvokeModel, Converse, and the Anthropic Messages API on Mantle\n",
+    "- Access setup: the data retention mode this Covered Model requires (`aws_review` or `provider_data_share`)\n",
+    "- Invoking the model: InvokeModel and Converse on the `bedrock-runtime` endpoint\n",
     "- Adaptive thinking and effort levels, and the sampling constraints that changed on this model\n",
     "- Handling refusals, which differ by API surface\n",
     "- Real use cases (complex coding, log triage, reconciliation, knowledge work) that grade themselves\n",
@@ -26,8 +26,7 @@
     "| | |\n",
     "|---|---|\n",
     "| Model IDs (CRIS, InvokeModel/Converse) | `us.anthropic.claude-fable-5-1`, `global.anthropic.claude-fable-5-1` |\n",
-    "| Model ID (Mantle Messages API) | `anthropic.claude-fable-5-1` |\n",
-    "| Class | Mythos-class Covered Model (requires `aws_review` data retention) |\n",
+    "| Class | Mythos-class Covered Model (requires `aws_review` or `provider_data_share` data retention) |\n",
     "| Context window | 1M tokens |\n",
     "| Max output | 128K tokens |\n",
     "| Reasoning | Adaptive thinking, always on; effort `low`/`medium`/`high`/`xhigh`/`max`, default `high` |\n",
@@ -47,7 +46,7 @@
     "\n",
     "## Access prerequisites\n",
     "\n",
-    "Fable 5.1 is a Covered Model. Before you can invoke it, set the account-level data retention mode to `aws_review` through the Data Retention API (AWS retains inputs and outputs for human safety review within the AWS boundary). There is no console UI for this at launch; see the Amazon Bedrock abuse-detection documentation. Data retention is an account-level setting, not a per-request parameter.\n",
+    "Fable 5.1 is a Covered Model. Before you can invoke it, set the account-level data retention mode to a qualifying value through the Data Retention API. Two modes satisfy the requirement: `aws_review` (AWS retains inputs and outputs for human safety review within the AWS boundary) and `provider_data_share`. The modes `none` and `default` are rejected for this model. There is no console UI for this at launch; see the Amazon Bedrock abuse-detection documentation. Data retention is an account-level setting, not a per-request parameter.\n",
     "\n",
     "## Regions\n",
     "\n",
@@ -81,7 +80,6 @@
     "REGION = \"us-east-2\"                              # a Fable-5.1 supported Region\n",
     "PROFILE = None                                    # set to your profile, or None for default creds\n",
     "CRIS_MODEL_ID = \"us.anthropic.claude-fable-5-1\"   # InvokeModel / Converse\n",
-    "MANTLE_MODEL_ID = \"anthropic.claude-fable-5-1\"    # Anthropic Messages API on Mantle\n",
     "\n",
     "session = boto3.Session(profile_name=PROFILE, region_name=REGION) if PROFILE else boto3.Session(region_name=REGION)\n",
     "rt = session.client(\"bedrock-runtime\")\n",
@@ -95,7 +93,7 @@
    "source": [
     "## 2. Data retention opt-in (REQUIRED)\n",
     "\n",
-    "Set the account data retention mode to `aws_review`. This is an account-level change; run it deliberately. If your policy does not permit it, do not run this cell, and coordinate with your AWS team."
+    "Set the account data retention mode to a qualifying value (`aws_review` or `provider_data_share`); `none` and `default` are rejected for this model. This is an account-level change; run it deliberately. If your policy does not permit it, do not run this cell, and coordinate with your AWS team."
    ]
   },
   {
@@ -145,23 +143,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "# --- Anthropic Messages API on Mantle ---\n",
-    "# NOTE: at time of writing, the bedrock-mantle endpoint returns 404 for Fable 5.1 on some accounts\n",
-    "# (the model card lists it as supported in us-east-1 in-region). This cell is included for completeness;\n",
-    "# if it 404s, the runtime paths above are the working option until Mantle registration catches up.\n",
-    "try:\n",
-    "    from anthropic import AnthropicBedrockMantle\n",
-    "    mantle = AnthropicBedrockMantle(aws_region=\"us-east-1\")\n",
-    "    msg = mantle.messages.create(model=MANTLE_MODEL_ID, max_tokens=1024,\n",
-    "                                 messages=[{\"role\": \"user\", \"content\": PROMPT}])\n",
-    "    print(\"Mantle:\", next((b.text for b in msg.content if b.type == \"text\"), \"\"))\n",
-    "except Exception as e:\n",
-    "    print(\"Mantle not available yet:\", type(e).__name__, str(e)[:120])"
+    "> Note on the Anthropic Messages API: the `anthropic[bedrock]` SDK's runtime-backed `AnthropicBedrock` client also targets `bedrock-runtime` and works with the CRIS model IDs above. The Bedrock Mantle endpoint (`AnthropicBedrockMantle`) is not available for Fable 5.1 in commercial Regions; on Bedrock it is offered only in AWS GovCloud (US)."
    ]
   },
   {
@@ -241,7 +226,7 @@
     "\n",
     "Fable 5.1 has blocking classifiers for dual-use cyber and life-sciences content, and refusal rates are higher than earlier Claude models. Treat a refusal as a normal response path, not an error. The shape differs by API:\n",
     "\n",
-    "- **InvokeModel / Mantle (native):** HTTP 200 with `stop_reason: \"refusal\"`, empty `content`, and a `stop_details` object carrying a `category` (`bio` or `cyber`) and an optional `explanation` (which can be null).\n",
+    "- **InvokeModel (native Anthropic Messages shape):** HTTP 200 with `stop_reason: \"refusal\"`, empty `content`, and a `stop_details` object carrying a `category` (`bio` or `cyber`) and an optional `explanation` (which can be null).\n",
     "- **Converse:** the refusal is normalized to `stopReason: \"content_filtered\"` with empty content and no category or explanation.\n",
     "\n",
     "The cell below shows both shapes on the same blocked prompt."
@@ -528,7 +513,7 @@
     "## 10. Migrating from Claude Fable 5\n",
     "\n",
     "1. **Model ID:** swap to `us.anthropic.claude-fable-5-1` / `global.anthropic.claude-fable-5-1`.\n",
-    "2. **Data retention:** Fable 5 used `provider_data_share`; Fable 5.1 requires `aws_review`. These are account-level and mutually exclusive, plan the switch (and note other Covered Models on the account may need a different mode).\n",
+    "2. **Data retention:** Fable 5.1 requires a qualifying mode. Both `aws_review` and `provider_data_share` (Fable 5's mode) satisfy it, so a customer already on `provider_data_share` does not need to switch. The modes `none` and `default` are rejected. Data retention is account-level, so plan the setting across any other Covered Models on the account.\n",
     "3. **Sampling:** remove any `temperature` (other than 1.0), `top_p` (other than 0.99), and all `top_k`; they now error. Omit them.\n",
     "4. **Thinking:** remove any `thinking.type: \"enabled\"`/`\"disabled\"`; use adaptive (the default) and control depth with `output_config.effort`.\n",
     "5. **Parsing:** select the block whose type is `text`; do not index a fixed position, a reasoning block may come first.\n",
@@ -536,7 +521,7 @@
     "\n",
     "## Summary\n",
     "\n",
-    "- Access requires the `aws_review` data retention mode (account-level).\n",
+    "- Access requires a qualifying data retention mode, `aws_review` or `provider_data_share` (account-level); `none` and `default` are rejected.\n",
     "- Adaptive thinking is always on; tune with effort (default `high`). `temperature`/`top_p` are fixed at defaults; `top_k` is gone.\n",
     "- Refusals are a normal path and differ by API surface. Parse the text block, never a fixed index.\n",
     "- The real-use-case cells above verify the model's output in code; extend them with your own `(prompt, grader)` pairs.\n",

--- a/notebooks/claude_fable_5_1_getting_started/claude-fable-5-1-getting-started.ipynb
+++ b/notebooks/claude_fable_5_1_getting_started/claude-fable-5-1-getting-started.ipynb
@@ -14,7 +14,7 @@
     "\n",
     "## What you'll learn\n",
     "\n",
-    "- Access setup: the data retention mode this Covered Model requires (`aws_review` or `provider_data_share`)\n",
+    "- Access setup: the `aws_review` data retention mode this Covered Model requires\n",
     "- Invoking the model: InvokeModel and Converse on the `bedrock-runtime` endpoint\n",
     "- Adaptive thinking and effort levels, and the sampling constraints that changed on this model\n",
     "- Handling refusals, which differ by API surface\n",
@@ -26,7 +26,7 @@
     "| | |\n",
     "|---|---|\n",
     "| Model IDs (CRIS, InvokeModel/Converse) | `us.anthropic.claude-fable-5-1`, `global.anthropic.claude-fable-5-1` |\n",
-    "| Class | Mythos-class Covered Model (requires `aws_review` or `provider_data_share` data retention) |\n",
+    "| Class | Mythos-class Covered Model (requires the `aws_review` data retention mode) |\n",
     "| Context window | 1M tokens |\n",
     "| Max output | 128K tokens |\n",
     "| Reasoning | Adaptive thinking, always on; effort `low`/`medium`/`high`/`xhigh`/`max`, default `high` |\n",
@@ -46,7 +46,7 @@
     "\n",
     "## Access prerequisites\n",
     "\n",
-    "Fable 5.1 is a Covered Model. Before you can invoke it, set the account-level data retention mode to a qualifying value through the Data Retention API. Two modes satisfy the requirement: `aws_review` (AWS retains inputs and outputs for human safety review within the AWS boundary) and `provider_data_share`. The modes `none` and `default` are rejected for this model. There is no console UI for this at launch; see the Amazon Bedrock abuse-detection documentation. Data retention is an account-level setting, not a per-request parameter.\n",
+    "Fable 5.1 is a Covered Model. Before you can invoke it, set the account-level data retention mode to `aws_review` through the Data Retention API. Under `aws_review`, AWS retains inputs and outputs for human safety review within the AWS boundary. The `provider_data_share` mode is also accepted, while `none` and `default` are rejected for this model. There is no console UI for this at launch; see the Amazon Bedrock abuse-detection documentation. Data retention is an account-level setting, not a per-request parameter.\n",
     "\n",
     "## Regions\n",
     "\n",
@@ -93,7 +93,7 @@
    "source": [
     "## 2. Data retention opt-in (REQUIRED)\n",
     "\n",
-    "Set the account data retention mode to a qualifying value (`aws_review` or `provider_data_share`); `none` and `default` are rejected for this model. This is an account-level change; run it deliberately. If your policy does not permit it, do not run this cell, and coordinate with your AWS team."
+    "Set the account data retention mode to `aws_review` (the recommended mode; `provider_data_share` is also accepted, and `none`/`default` are rejected for this model). This is an account-level change; run it deliberately. If your policy does not permit it, do not run this cell, and coordinate with your AWS team."
    ]
   },
   {
@@ -513,7 +513,7 @@
     "## 10. Migrating from Claude Fable 5\n",
     "\n",
     "1. **Model ID:** swap to `us.anthropic.claude-fable-5-1` / `global.anthropic.claude-fable-5-1`.\n",
-    "2. **Data retention:** Fable 5.1 requires a qualifying mode. Both `aws_review` and `provider_data_share` (Fable 5's mode) satisfy it, so a customer already on `provider_data_share` does not need to switch. The modes `none` and `default` are rejected. Data retention is account-level, so plan the setting across any other Covered Models on the account.\n",
+    "2. **Data retention:** set the account to `aws_review`, the recommended mode for Fable 5.1. `provider_data_share` (Fable 5's mode) is also accepted, so existing usage keeps working, but `aws_review` is preferred going forward. `none` and `default` are rejected. Data retention is account-level, so plan the setting across any other Covered Models on the account.\n",
     "3. **Sampling:** remove any `temperature` (other than 1.0), `top_p` (other than 0.99), and all `top_k`; they now error. Omit them.\n",
     "4. **Thinking:** remove any `thinking.type: \"enabled\"`/`\"disabled\"`; use adaptive (the default) and control depth with `output_config.effort`.\n",
     "5. **Parsing:** select the block whose type is `text`; do not index a fixed position, a reasoning block may come first.\n",
@@ -521,7 +521,7 @@
     "\n",
     "## Summary\n",
     "\n",
-    "- Access requires a qualifying data retention mode, `aws_review` or `provider_data_share` (account-level); `none` and `default` are rejected.\n",
+    "- Access requires the `aws_review` data retention mode (account-level, recommended); `provider_data_share` is also accepted, and `none`/`default` are rejected.\n",
     "- Adaptive thinking is always on; tune with effort (default `high`). `temperature`/`top_p` are fixed at defaults; `top_k` is gone.\n",
     "- Refusals are a normal path and differ by API surface. Parse the text block, never a fixed index.\n",
     "- The real-use-case cells above verify the model's output in code; extend them with your own `(prompt, grader)` pairs.\n",


### PR DESCRIPTION
## Summary

Corrects two factual issues in the Claude Fable 5.1 getting-started notebook, both verified live against Amazon Bedrock at launch (2026-09-01).

### 1. Data retention modes
The notebook stated access requires `aws_review`. Verified on an enforced account: the Covered Model gate accepts **both `aws_review` and `provider_data_share`**, and rejects `none` and `default`. A customer already on `provider_data_share` (Fable 5's mode) does not need to switch. Updated the What-you'll-learn list, Access prerequisites, section 2, the migration checklist, and the summary accordingly.

### 2. Bedrock Mantle is not a commercial path
The notebook presented the Anthropic Messages API on the Bedrock Mantle endpoint as a supported way to call the model. Mantle is **not available for Fable 5.1 in commercial Regions** (runtime-only at commercial launch); on Bedrock it is offered only in AWS GovCloud (US). The Mantle endpoint returns a deterministic 404 for Fable 5.1 in commercial Regions. Removed the Mantle model ID, the Mantle invocation cell, and the stale 'us-east-1 in-region' note, and added a short note that the runtime-backed `AnthropicBedrock` SDK client is the Messages-API path on `bedrock-runtime`.

### What was verified
- Enforced account rejects `none`/`default`, accepts `aws_review` and `provider_data_share`.
- Mantle (`AnthropicBedrockMantle`) returns 404 for Fable 5.1 in commercial Regions across multiple days.
- All three runtime paths (`AnthropicBedrock` SDK Messages, `invoke_model`, `converse`) work with the `us.`/`global.` CRIS profiles.

Notebook remains valid JSON and the self-verifying capability cells are unchanged.