### PR TITLE
docs: state the dependency and Dependabot policy for samples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,14 @@ opensource-codeofconduct@amazon.com with any additional questions or comments.
 ## Security issue notifications
 If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.
 
+### Dependency updates and Dependabot alerts
+Samples here are not maintained after publication (see the
+[Dependencies and security](README.md#dependencies-and-security) note in the
+README). Dependabot security PRs are reviewed and merged by a maintainer;
+automated merging is not used. Alerts that require a major-version upgrade of an
+unmaintained sample are dismissed as tolerable risk rather than fixed. If you
+are updating a sample, refresh its lockfile in the same PR.
+
 
 ## Licensing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,12 +54,12 @@ opensource-codeofconduct@amazon.com with any additional questions or comments.
 If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.
 
 ### Dependency updates and Dependabot alerts
-Samples here are not maintained after publication (see the
-[Dependencies and security](README.md#dependencies-and-security) note in the
-README). Dependabot security PRs are reviewed and merged by a maintainer;
-automated merging is not used. Alerts that require a major-version upgrade of an
-unmaintained sample are dismissed as tolerable risk rather than fixed. If you
-are updating a sample, refresh its lockfile in the same PR.
+Samples are point-in-time examples with dependencies pinned at publication (see
+[Dependencies and security](README.md#dependencies-and-security) in the README).
+Dependabot security PRs are reviewed and merged by a maintainer; automated
+merging is not used. Alerts that require a major-version upgrade of a sample are
+dismissed as tolerable risk rather than fixed. If you are updating a sample,
+refresh its lockfile in the same PR.
 
 
 ## Licensing

--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@
 
 This repo contains a collection of examples and notebooks for using Anthropic on AWS.
 
+## Dependencies and security
+
+The samples in this repo are point-in-time examples. They are not maintained as
+products, and their dependencies are **not** kept current after publication.
+Before deploying any sample, refresh its dependencies (`npm install`,
+`yarn upgrade`, `uv pip install -U -r requirements.txt`, or equivalent) and
+review the result. Dependabot alerts on unmaintained samples are dismissed as
+tolerable risk for this reason; in-range security fixes are still merged as
+Dependabot opens them.
+
 ## Notebooks
 - [Cookbooks](/cookbooks/README.md)
 

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ This repo contains a collection of examples and notebooks for using Anthropic on
 
 ## Dependencies and security
 
-The samples in this repo are point-in-time examples. They are not maintained as
-products, and their dependencies are **not** kept current after publication.
-Before deploying any sample, refresh its dependencies (`npm install`,
+The samples in this repo are point-in-time examples. Their dependencies are
+pinned at publication and are not continuously upgraded the way a product's
+would be. Before deploying any sample, refresh its dependencies (`npm install`,
 `yarn upgrade`, `uv pip install -U -r requirements.txt`, or equivalent) and
-review the result. Dependabot alerts on unmaintained samples are dismissed as
-tolerable risk for this reason; in-range security fixes are still merged as
-Dependabot opens them.
+review the result. In-range security fixes are merged as Dependabot opens them.
+Alerts that would require a major-version upgrade of a sample are dismissed as
+tolerable risk, with this note as the reason.
 
 ## Notebooks
 - [Cookbooks](/cookbooks/README.md)

--- a/scripts/dismiss-dependabot-alerts.sh
+++ b/scripts/dismiss-dependabot-alerts.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Bulk-dismiss open Dependabot alerts as tolerable risk.
+#
+# The samples in this repo are point-in-time examples with dependencies pinned
+# at publication (see README "Dependencies and security"). Alerts that need a
+# major-version upgrade of a sample are dismissed rather than fixed. Run this
+# quarterly after glancing at any critical alerts.
+#
+# Usage:
+#   scripts/dismiss-dependabot-alerts.sh                 # dry run, lists what would be dismissed
+#   scripts/dismiss-dependabot-alerts.sh --apply         # dismiss
+#   EXCLUDE='claude-apps-gateway' scripts/dismiss-dependabot-alerts.sh --apply
+#
+# EXCLUDE is an extended regex matched against the alert's manifest path; alerts
+# whose manifest matches are left open (use it for samples under active
+# development where you want to fix rather than dismiss).
+#
+# Requires: gh (authenticated with security_events scope), jq.
+set -euo pipefail
+
+REPO="${REPO:-aws-samples/anthropic-on-aws}"
+EXCLUDE="${EXCLUDE:-}"
+REASON="${REASON:-tolerable_risk}"
+COMMENT="${COMMENT:-Sample code with dependencies pinned at publication; refresh before deploying. See README: Dependencies and security.}"
+APPLY=0
+[[ "${1:-}" == "--apply" ]] && APPLY=1
+
+alerts=$(gh api --paginate "repos/$REPO/dependabot/alerts?state=open&per_page=100" \
+  | jq -c '.[] | {n: .number, sev: .security_advisory.severity, pkg: .dependency.package.name, path: .dependency.manifest_path}')
+
+if [[ -n "$EXCLUDE" ]]; then
+  alerts=$(printf '%s\n' "$alerts" | jq -c --arg re "$EXCLUDE" 'select(.path | test($re) | not)')
+fi
+
+count=$(printf '%s\n' "$alerts" | grep -c . || true)
+echo "$count open alert(s) selected (repo=$REPO exclude='${EXCLUDE:-none}')"
+printf '%s\n' "$alerts" | jq -r '"  #\(.n)\t\(.sev)\t\(.pkg)\t\(.path)"'
+
+if [[ $APPLY -eq 0 ]]; then
+  echo
+  echo "Dry run. Re-run with --apply to dismiss these as '$REASON'."
+  exit 0
+fi
+
+printf '%s\n' "$alerts" | jq -r '.n' | while read -r n; do
+  gh api -X PATCH "repos/$REPO/dependabot/alerts/$n" \
+    -f state=dismissed -f dismissed_reason="$REASON" -f dismissed_comment="$COMMENT" \
+    --silent && echo "dismissed #$n"
+done


### PR DESCRIPTION
Samples are point-in-time examples and are not kept current after
publication. Say so in the README, tell users to refresh dependencies
before deploying, and document in CONTRIBUTING how Dependabot PRs and
alerts are handled.
