### PR TITLE
chore: add empty Mergify config to stop default queue prompts

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,4 @@
+# Intentionally empty: keeps the still-installed Mergify app from posting its
+# default merge-queue prompt on every PR. Automated merging is not used here.
+# Remove this file once the Mergify app is uninstalled from the repo.
+pull_request_rules: []


### PR DESCRIPTION
With no config the still-installed Mergify app falls back to posting a
'Queue this pull request' comment on every open PR. An empty rule set
silences it until the app is uninstalled.
