### PR TITLE
chore(deps): refresh claude-multimodal-llm-playground pins

### DIFF
--- a/claude-multimodal-llm-playground/anthropic/playground.py
+++ b/claude-multimodal-llm-playground/anthropic/playground.py
@@ -213,7 +213,7 @@ if submit:
         full_prompt = " ".join(filter(None, [img_input_prompt1, img_input_prompt2]))
         for file in valid_files:
             image = Image.open(file)
-            st.image(image, caption=f"Uploaded Image: {file.name}", use_column_width=True)
+            st.image(image, caption=f"Uploaded Image: {file.name}", width="stretch")
             st.subheader(f"{selected_model_name} response:")
             response = get_claude_response_image(full_prompt, image, file.name, selected_model_id, max_tokens, system_prompt, temperature, tools)
             

--- a/claude-multimodal-llm-playground/anthropic/requirements.txt
+++ b/claude-multimodal-llm-playground/anthropic/requirements.txt
@@ -1,4 +1,4 @@
-pillow==10.3.0
-streamlit==1.37.0
-python-dotenv==1.0.1
-anthropic==0.28.1
+pillow==12.3.0
+streamlit==1.63.0
+python-dotenv==1.2.3
+anthropic==1.3.0

--- a/claude-multimodal-llm-playground/bedrock/playground.py
+++ b/claude-multimodal-llm-playground/bedrock/playground.py
@@ -226,7 +226,7 @@ if submit:
     elif valid_files:
         for file in valid_files:
             image = Image.open(file)
-            st.image(image, caption=f"Uploaded Image: {file.name}", use_column_width=True)
+            st.image(image, caption=f"Uploaded Image: {file.name}", width="stretch")
             st.subheader(f"{selected_model_name} response:")
             
             # Concatenate prompts if both are provided, or use a default prompt

--- a/claude-multimodal-llm-playground/bedrock/requirements.txt
+++ b/claude-multimodal-llm-playground/bedrock/requirements.txt
@@ -1,4 +1,4 @@
-pillow==10.3.0
-streamlit==1.37.0
-boto3==1.34.130
-botocore==1.34.130
+pillow==12.3.0
+streamlit==1.63.0
+boto3==1.43.87
+botocore==1.43.87


### PR DESCRIPTION
Resolved fresh on Python 3.12: pillow 10.3 -> 12.3, streamlit 1.37 -> 1.63,
python-dotenv 1.0 -> 1.2, anthropic 0.28 -> 1.3, boto3/botocore 1.34 -> 1.43.
Clears 39 Dependabot alerts (pillow, streamlit, python-dotenv).

Verified: both playground.py scripts execute end-to-end under
streamlit.testing.v1.AppTest with no exceptions; the only Anthropic API
surface used is client.messages.create with model/max_tokens/messages/
temperature/system/tools, unchanged in SDK 1.x.
