### PR TITLE
chore: turn off Mergify queue-control and status comments

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,6 +1,7 @@
-# Intentionally minimal: keeps the still-installed Mergify app quiet. Automated
-# merging is not used here (aws-samples policy). Remove this file once the
-# Mergify app is uninstalled from the repo.
+# Mergify is installed on this repo but not used for merging (aws-samples
+# policy: a human reviews and merges every PR). This config keeps the app
+# quiet: no rules, no queue-control checkbox, no status or merge-protection
+# comments.
 pull_request_rules: []
 merge_queue:
   queue_controls_comment: false

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,4 +1,9 @@
-# Intentionally empty: keeps the still-installed Mergify app from posting its
-# default merge-queue prompt on every PR. Automated merging is not used here.
-# Remove this file once the Mergify app is uninstalled from the repo.
+# Intentionally minimal: keeps the still-installed Mergify app quiet. Automated
+# merging is not used here (aws-samples policy). Remove this file once the
+# Mergify app is uninstalled from the repo.
 pull_request_rules: []
+merge_queue:
+  queue_controls_comment: false
+  status_comments: none
+merge_protections_settings:
+  post_comment: false


### PR DESCRIPTION
An empty rule set was not enough: Mergify's 'Queue this pull request'
checkbox comment is controlled separately by
merge_queue.queue_controls_comment (default true) and is posted on every
PR regardless of rules. Disable it, queue status comments, and merge
protection comments.
